### PR TITLE
FELT: Block restart and force exit

### DIFF
--- a/toolkit/xre/nsAppRunner.cpp
+++ b/toolkit/xre/nsAppRunner.cpp
@@ -6238,7 +6238,22 @@ int XREMain::XRE_main(int argc, char* argv[], const BootstrapConfig& aConfig) {
   }
 #endif
 
-  mozilla::AppShutdown::MaybeDoRestart();
+#if defined(MOZ_WIDGET_FELT)
+  // Do not restart when running as Felt client (i.e. Enterprise browser)
+  bool skipRestart = false;
+  if (XRE_IsParentProcess()) {
+    Maybe<const char*> felt = geckoargs::sFelt.Get(gArgc, gArgv, CheckArgFlag::None);
+    if (felt.isSome()) {
+      skipRestart = true;
+    }
+  }
+
+  if (!skipRestart) {
+#endif
+    mozilla::AppShutdown::MaybeDoRestart();
+#if defined(MOZ_WIDGET_FELT)
+  }
+#endif
 
   XRE_DeinitCommandLine();
 


### PR DESCRIPTION
Browser is not allowed to restart and this will be controlled by the FELT runtime