### PR TITLE
FELT: Close window before starting Firefox

### DIFF
--- a/browser/extensions/felt/api.js
+++ b/browser/extensions/felt/api.js
@@ -54,12 +54,20 @@ this.felt = class extends ExtensionAPI {
       Ci.nsIFelt
     );
 
+    // In tests if we close too early we lose the browser context
+    if (Services.prefs.getBoolPref("browser.felt.is_testing", false)) {
+      this.windowCloseMessage = "FeltParent:FirefoxStarted";
+    } else {
+      this.windowCloseMessage = "FeltParent:FirefoxStarting";
+    }
+
     if (this.feltXPCOM.isFeltUI()) {
       this.registerChrome();
       this.registerActors();
       this.showWindow();
       Services.ppmm.addMessageListener("FeltParent:FirefoxNormalExit", this);
       Services.ppmm.addMessageListener("FeltParent:FirefoxAbnormalExit", this);
+      Services.ppmm.addMessageListener("FeltParent:FirefoxStarting", this);
       Services.ppmm.addMessageListener("FeltParent:FirefoxStarted", this);
     }
   }
@@ -86,7 +94,7 @@ this.felt = class extends ExtensionAPI {
         // TODO: What should we do, restart Firefox?
         break;
 
-      case "FeltParent:FirefoxStarted":
+      case this.windowCloseMessage:
         Services.startup.enterLastWindowClosingSurvivalArea();
         Services.ww.unregisterNotification(this.windowObserver);
         this._win.close();

--- a/browser/extensions/felt/content/FeltProcessParent.sys.mjs
+++ b/browser/extensions/felt/content/FeltProcessParent.sys.mjs
@@ -48,6 +48,7 @@ export class FeltProcessParent extends JSProcessActorParent {
 
   startFirefox() {
     this.restartReported = false;
+    Services.cpmm.sendAsyncMessage("FeltParent:FirefoxStarting", {});
     this.firefox = this.startFirefoxProcess();
     this.firefox
       .then(async () => {


### PR DESCRIPTION
Somehow this makes the dock icon merging working as we would like, i.e., avoiding a duplicated icon because Felt was running while browser launched.