### PR TITLE
Use the profile service directly to find or create the enterprise profile

### DIFF
--- a/browser/extensions/felt/content/ConsoleClient.sys.mjs
+++ b/browser/extensions/felt/content/ConsoleClient.sys.mjs
@@ -63,6 +63,7 @@ class ConsoleTokenData {
 }
 
 export const ConsoleClient = {
+    ENTERPRISE_PROFILE: "enterprise-profile",
 
     _consoleTokenData: null,
 


### PR DESCRIPTION
This is quicker than re-launching Firefox. Also adds the `--foreground` argument to make sure Firefox tries to come to the foreground.