### PR TITLE
Enable transparent use of primary password

### DIFF
--- a/browser/components/BrowserGlue.sys.mjs
+++ b/browser/components/BrowserGlue.sys.mjs
@@ -21,6 +21,7 @@ ChromeUtils.defineESModuleGetters(lazy, {
   BrowserUtils: "resource://gre/modules/BrowserUtils.sys.mjs",
   BrowserUsageTelemetry: "resource:///modules/BrowserUsageTelemetry.sys.mjs",
   BrowserWindowTracker: "resource:///modules/BrowserWindowTracker.sys.mjs",
+  ConsoleClient: "resource://builtin-addons/felt/content/ConsoleClient.sys.mjs",
   ContentBlockingPrefs:
     "moz-src:///browser/components/protections/ContentBlockingPrefs.sys.mjs",
   ContextualIdentityService:
@@ -1064,6 +1065,84 @@ BrowserGlue.prototype = {
         task: async () => {
           await lazy.ContextualIdentityService.load();
           lazy.Discovery.update();
+        },
+      },
+
+      {
+        name: "EnterpriseStorageEncryption.load",
+        condition: Services.prefs.getBoolPref("security.storage.encryption.enabled", false) &&
+                   Services.prefs.getStringPref("browser.policies.access_token", ""),
+        task: async () => {
+          console.debug("EnterpriseStorageEncryption.load: Starting task");
+
+          // Get the primary secret from the console backend
+          // The API returns { data: "secret_value" }
+          let primary_secret;
+          try {
+            const payload = await lazy.ConsoleClient.getPrimarySecret();
+            primary_secret = payload.data;
+            if (!primary_secret) {
+              console.error("EnterpriseStorageEncryption.load: No data field in payload:", payload);
+              return;
+            }
+            console.log("EnterpriseStorageEncryption.load: primary_secret retreived from the console backend");
+          } catch (e) {
+            console.error("EnterpriseStorageEncryption.load: Failed to get primary secret:", e);
+            return;
+          }
+
+          // Load the PK11 token
+          const tokenDB = Cc["@mozilla.org/security/pk11tokendb;1"].getService(
+            Ci.nsIPK11TokenDB
+          );
+
+          let pk11token;
+          try {
+            pk11token = tokenDB.getInternalKeyToken();
+          } catch (e) {
+            console.error("EnterpriseStorageEncryption.load: Error getting PK11 token: " + e);
+            return;
+          }
+
+          // Check if the PK11 token needs initialization
+          if (pk11token.needsUserInit) {
+            try {
+              pk11token.initPassword(primary_secret);
+              console.log("EnterpriseStorageEncryption.load: PK11 token password initialized with primary_secret.");
+            } catch (e) {
+              console.error("EnterpriseStorageEncryption.load: Failed to initialize PK11 token password: " + e);
+              return;
+            }
+          } else if (!pk11token.needsLogin()) {
+            // Token doesn't need login (empty password), set it to primary_secret
+            try {
+              pk11token.changePassword("", primary_secret);
+              console.log("EnterpriseStorageEncryption.load: PK11 token password changed from empty to primary_secret.");
+            } catch (e) {
+              console.error("EnterpriseStorageEncryption.load: Failed to change password from empty to primary_secret: " + e);
+              return;
+            }
+          } else {
+            // Token needs login - verify the password matches primary_secret
+            let isPasswordValid;
+            try {
+              isPasswordValid = pk11token.checkPassword(primary_secret);
+            } catch (e) {
+              console.error("EnterpriseStorageEncryption.load: Error checking password against PK11 token: " + e);
+              return;
+            }
+
+            console.log(`EnterpriseStorageEncryption.load: Password validation result: ${isPasswordValid}`);
+
+            if (!isPasswordValid) {
+              console.error("EnterpriseStorageEncryption.load: Password against the PK11 token is not valid");
+              return;
+            } else {
+              console.log("EnterpriseStorageEncryption.load: Password against the PK11 token is valid");
+            }
+          }
+
+          console.log("EnterpriseStorageEncryption.load: Done");
         },
       },
     ];

--- a/browser/extensions/felt/content/ConsoleClient.sys.mjs
+++ b/browser/extensions/felt/content/ConsoleClient.sys.mjs
@@ -100,6 +100,7 @@ export const ConsoleClient = {
       STARTUP_PREFS: `${this.consoleAddr}/api/browser/hacks/startup`,
       DEFAULT_PREFS: `${this.consoleAddr}/api/browser/hacks/default`,
       REMOTE_POLICIES: `${this.consoleAddr}/api/browser/policies`,
+      KEY: `${this.consoleAddr}/api/browser/key`,
     };
   },
 
@@ -114,9 +115,25 @@ export const ConsoleClient = {
   async fetch(url) {
     console.debug("ConsoleClient: fetch");
 
+    // Get the access token from preferences
+    let accessToken;
+    try {
+      accessToken = Services.prefs.getStringPref("browser.policies.access_token", "");
+    } catch (e) {
+      console.error("ConsoleClient.fetch: Failed to get access_token from prefs", e);
+    }
+
+    const headers = {};
+    if (accessToken) {
+      headers["Authorization"] = `Bearer ${accessToken}`;
+      console.debug("ConsoleClient: fetch with Authorization header");
+    } else {
+      console.warn("ConsoleClient: fetch without access_token");
+    }
+
     let res;
     try {
-      res = await fetch(url);
+      res = await fetch(url, { headers });
     } catch (e) {
       console.error(`ConsoleClient.fetch: Request failed for ${url}`, e);
       throw e;
@@ -142,6 +159,13 @@ export const ConsoleClient = {
       console.error(err, e);
       throw err;
     }
+  },
+
+  // Gets the primary secret from the console backend
+  async getPrimarySecret() {
+    console.debug("ConsoleClient: getPrimarySecret")
+    const payload = await this.fetch(this.ENDPOINTS.KEY);
+    return payload;
   },
 
   // prefs that needs to be read at startup, i.e., written to profile's

--- a/modules/libpref/init/StaticPrefList.yaml
+++ b/modules/libpref/init/StaticPrefList.yaml
@@ -17529,6 +17529,12 @@
   value: true
   mirror: always
 
+# Enable storage encryption functionality.
+- name: security.storage.encryption.enabled
+  type: bool
+  value: false
+  mirror: always
+
 - name: security.tls13.aes_128_gcm_sha256
   type: RelaxedAtomicBool
   value: true

--- a/toolkit/components/passwordmgr/LoginHelper.sys.mjs
+++ b/toolkit/components/passwordmgr/LoginHelper.sys.mjs
@@ -1588,8 +1588,7 @@ export const LoginHelper = {
   },
 
   /**
-   * Shows the Primary Password prompt if enabled, or the
-   * OS auth dialog otherwise.
+   * Shows OS auth dialog if enabled.
    * @param {Element} browser
    *        The <browser> that the prompt should be shown on
    * @param OSReauthEnabled Boolean indicating if OS reauth should be tried
@@ -1641,8 +1640,10 @@ export const LoginHelper = {
         telemetryEvent,
       };
     }
-    // Use the OS auth dialog if there is no primary password
-    if (!token.hasPassword && OSReauthEnabled) {
+
+    // Use only OS auth dialog if primary password is already unlocked
+    // or no PrP is used.
+    if ((!token.hasPassword || token.isLoggedIn()) && OSReauthEnabled) {
       let result;
       try {
         isAuthorized = await this.verifyUserOSAuth(
@@ -1675,9 +1676,8 @@ export const LoginHelper = {
         telemetryEvent,
       };
     }
-    // We'll attempt to re-auth via Primary Password, force a log-out
-    token.checkPassword("");
 
+    // We may need to unlock the internal softoken with the PrP.
     // If a primary password prompt is already open, just exit early and return false.
     // The user can re-trigger it after responding to the already open dialog.
     if (Services.logins.uiBusy) {
@@ -1688,10 +1688,9 @@ export const LoginHelper = {
       };
     }
 
-    // So there's a primary password. But since checkPassword didn't succeed, we're logged out (per nsIPK11Token.idl).
     try {
-      // Relogin and ask for the primary password.
-      token.login(true); // 'true' means always prompt for token password. User will be prompted until
+      // Login and ask for the primary password if the token is locked.
+      token.login();
       // clicking 'Cancel' or entering the correct password.
     } catch (e) {
       // An exception will be thrown if the user cancels the login prompt dialog.


### PR DESCRIPTION
This PR implement transparent use of the primary password mechanism for users.
Upon start, the browser will use the `ConsoleTokenData` to fetch a Primary Password specific to the authenticated user on the console backend. If the primary password is not set, the browser will silently set it to the fetched value, and will request it to the server for each subsequent use. As a consequence, the user is protected without needing to interact.