### PR TITLE
Default to a different MOZ_APP_BASENAME

### DIFF
--- a/.github/workflows/enterprise.yml
+++ b/.github/workflows/enterprise.yml
@@ -193,7 +193,7 @@ jobs:
 
       - name: "test firefox start"
         run: |
-          RUNTIME_VERSION=$(${{ steps.unpack.outputs.runtime_path }} --version | awk '{ print $3 }')
+          RUNTIME_VERSION=$(${{ steps.unpack.outputs.runtime_path }} --version | awk '{ print $4 }')
           sed -e "s/#RUNTIME_VERSION#/${RUNTIME_VERSION}/g" < firefox_start.json.in > firefox_start.json
           mkdir -p ./profiles/
           . venv_tests/bin/activate
@@ -617,7 +617,7 @@ jobs:
 
       - name: "test firefox start"
         run: |
-          RUNTIME_VERSION=$("${{ steps.attach.outputs.runtime_path }}" --version | awk '{ print $3 }')
+          RUNTIME_VERSION=$("${{ steps.attach.outputs.runtime_path }}" --version | awk '{ print $4 }')
           sed -e "s/#RUNTIME_VERSION#/${RUNTIME_VERSION}/g" < firefox_start.json.in > firefox_start.json
           mkdir -p ./profiles/
           . venv_tests/bin/activate

--- a/browser/extensions/moz.build
+++ b/browser/extensions/moz.build
@@ -14,7 +14,7 @@ DIRS += [
     "newtab",
 ]
 
-if CONFIG["MOZ_WIDGET_FELT"]:
+if CONFIG["MOZ_ENTERPRISE"]:
     DIRS += ["felt"]
 
 JAR_MANIFESTS += ["jar.mn"]

--- a/browser/moz.configure
+++ b/browser/moz.configure
@@ -19,21 +19,28 @@ imply_option("MOZ_APP_ID", "{ec8030f7-c20a-464f-9b0e-13a3a9e97384}")
 imply_option("MOZ_DEVTOOLS", "all")
 imply_option("BROWSER_CHROME_URL", "chrome://browser/content/browser.xhtml")
 
+
 option(
-    "--enable-felt",
+    "--enable-enterprise",
     default=False,
-    help="Felt support",
+    help="Build with enterprise support",
 )
 
 
-@depends("--enable-felt")
-def enable_felt(value):
+@depends("--enable-enterprise")
+def enable_enterprise(value):
     if value:
         return True
 
 
-set_config("MOZ_WIDGET_FELT", enable_felt)
-set_define("MOZ_WIDGET_FELT", enable_felt)
+set_config("MOZ_ENTERPRISE", enable_enterprise)
+set_define("MOZ_ENTERPRISE", enable_enterprise)
+imply_option("--with-app-basename", "Firefox Enterprise", when="--enable-enterprise")
+imply_option("--with-app-name", "firefox", when="--enable-enterprise")
+imply_option(
+    "--with-branding", "browser/branding/enterprise", when="--enable-enterprise"
+)
+
 
 option(
     "--disable-browser-newtab-as-addon",

--- a/build/mozconfig.common.enterprise
+++ b/build/mozconfig.common.enterprise
@@ -1,8 +1,7 @@
-ac_add_options --with-branding=browser/branding/enterprise
 ac_add_options --enable-bootstrap
 ac_add_options --enable-application=browser
 ac_add_options --enable-warnings-as-errors
-ac_add_options --enable-felt
+ac_add_options --enable-enterprise
 
 ac_add_options --enable-strip
 

--- a/netwerk/cookie/CookieService.cpp
+++ b/netwerk/cookie/CookieService.cpp
@@ -776,7 +776,7 @@ CookieService::AddForAddOn(const nsACString& aHost, const nsACString& aPath,
   return NS_OK;
 }
 
-#if defined(MOZ_WIDGET_FELT)
+#if defined(MOZ_ENTERPRISE)
 NS_IMETHODIMP
 CookieService::AddNativeForFelt(
     const nsACString& aHost, const nsACString& aPath, const nsACString& aName,
@@ -803,7 +803,7 @@ CookieService::AddNativeForFelt(
   MOZ_ASSERT_UNREACHABLE("AddNativeForFelt is not expected to be called");
   return NS_ERROR_FAILURE;
 }
-#endif // defined(MOZ_WIDGET_FELT)
+#endif  // defined(MOZ_ENTERPRISE)
 
 NS_IMETHODIMP_(nsresult)
 CookieService::AddNative(nsIURI* aCookieURI, const nsACString& aHost,

--- a/testing/enterprise/firefox_start.json.in
+++ b/testing/enterprise/firefox_start.json.in
@@ -3,6 +3,6 @@
         "version_box": "#RUNTIME_VERSION#"
     },
     "test_about_buildconfig_enterprise_branding": {
-        "branding": "--with-branding=browser/branding/enterprise"
+        "enterprise": "--enable-enterprise"
     }
 }

--- a/testing/enterprise/test_firefox_start.py
+++ b/testing/enterprise/test_firefox_start.py
@@ -14,9 +14,7 @@ from selenium.webdriver.support import expected_conditions as EC
 
 class EnterpriseTests(EnterpriseTestsBase):
     def __init__(self, firefox, geckodriver, profile_root):
-        super(__class__, self).__init__(
-            "firefox_start.json", firefox, geckodriver, profile_root
-        )
+        super().__init__("firefox_start.json", firefox, geckodriver, profile_root)
 
     def setup(self):
         pass
@@ -32,6 +30,7 @@ class EnterpriseTests(EnterpriseTestsBase):
         )
         self._wait.until(lambda d: len(version_box.text) > 0)
         self._logger.info(f"about:support version: {version_box.text}")
+        self._logger.info(f"expected version: {exp['version_box']}")
         assert version_box.text == exp["version_box"], "version text should match"
 
         return True
@@ -45,7 +44,7 @@ class EnterpriseTests(EnterpriseTestsBase):
         self._wait.until(lambda d: len(build_flags_box.text) > 0)
         self._logger.info(f"about:buildconfig buildflags: {build_flags_box.text}")
         assert (
-            exp["branding"] in build_flags_box.text
+            exp["enterprise"] in build_flags_box.text
         ), "enterprise branding build flag should be there"
 
         return True

--- a/toolkit/library/moz.build
+++ b/toolkit/library/moz.build
@@ -139,7 +139,7 @@ DIRS += [
     "buildid_reader",
 ]
 
-if CONFIG["MOZ_WIDGET_FELT"]:
+if CONFIG["MOZ_ENTERPRISE"]:
     DIRS += ["felt"]
 
 TEST_DIRS += ["gtest"]
@@ -380,7 +380,7 @@ if CONFIG["OS_ARCH"] == "WINNT":
             "uiautomationcore",
         ]
 
-    if CONFIG["MOZ_WIDGET_FELT"]:
+    if CONFIG["MOZ_ENTERPRISE"]:
         OS_LIBS += [
             "mincore",
         ]

--- a/toolkit/library/rust/gkrust-features.mozbuild
+++ b/toolkit/library/rust/gkrust-features.mozbuild
@@ -85,7 +85,7 @@ if CONFIG["MOZ_ICU4X"]:
 if CONFIG["USE_LIBZ_RS"]:
     gkrust_features += ["libz-rs-sys"]
 
-if CONFIG["MOZ_WIDGET_FELT"]:
+if CONFIG["MOZ_ENTERPRISE"]:
     gkrust_features += ["felt"]
 
 # This must remain last.

--- a/toolkit/modules/AppConstants.sys.mjs
+++ b/toolkit/modules/AppConstants.sys.mjs
@@ -57,8 +57,8 @@ export var AppConstants = Object.freeze({
   false,
 #endif
 
-  MOZ_WIDGET_FELT:
-#ifdef MOZ_WIDGET_FELT
+  MOZ_ENTERPRISE:
+#ifdef MOZ_ENTERPRISE
   true,
 #else
   false,

--- a/toolkit/profile/nsToolkitProfileService.cpp
+++ b/toolkit/profile/nsToolkitProfileService.cpp
@@ -41,7 +41,7 @@
 #  include "mozilla/WidgetUtilsGtk.h"
 #endif
 
-#if defined(MOZ_WIDGET_FELT)
+#if defined(MOZ_ENTERPRISE)
 #  include "mozilla/toolkit/library/felt_ffi.h"
 #endif
 
@@ -1560,7 +1560,7 @@ nsresult nsToolkitProfileService::SelectStartupProfile(
     return NS_OK;
   }
 
-#if defined(MOZ_WIDGET_FELT)
+#if defined(MOZ_ENTERPRISE)
   auto forcedProfile = geckoargs::sProfile.IsPresent(gArgc, gArgv);
   if (is_felt_ui() && !forcedProfile) {
     nsCOMPtr<nsIFile> file;

--- a/toolkit/xre/GeckoArgs.h
+++ b/toolkit/xre/GeckoArgs.h
@@ -262,7 +262,7 @@ static CommandLineArg<UniqueFileHandle> sSignalPipe{"-signalPipe",
                                                     "signalpipe"};
 #endif
 
-#if defined(MOZ_WIDGET_FELT)
+#if defined(MOZ_ENTERPRISE)
 static CommandLineArg<const char*> sFelt{"-felt", "felt"};
 static CommandLineArg<bool> sFeltUI{"-feltui", "feltui"};
 #endif

--- a/toolkit/xre/nsAppRunner.cpp
+++ b/toolkit/xre/nsAppRunner.cpp
@@ -46,7 +46,7 @@
 #include "BaseProfiler.h"
 #include "mozJSModuleLoader.h"
 
-#if defined(MOZ_WIDGET_FELT)
+#if defined(MOZ_ENTERPRISE)
 #  include "mozilla/toolkit/library/felt_ffi.h"
 #endif
 
@@ -5473,7 +5473,7 @@ nsresult XREMain::XRE_mainRun() {
   // Ditto with the command line.
   nsCOMPtr<nsICommandLineRunner> cmdLine;
 
-#if defined(MOZ_WIDGET_FELT)
+#if defined(MOZ_ENTERPRISE)
   Maybe<const char*> felt = Nothing();
   if (XRE_IsParentProcess() && is_felt_browser()) {
     // Collect the value as early as possible to ensure it is removed from
@@ -5929,7 +5929,7 @@ nsresult XREMain::XRE_mainRun() {
   }
 #endif
 
-#if defined(MOZ_WIDGET_FELT)
+#if defined(MOZ_ENTERPRISE)
   if (XRE_IsParentProcess() && is_felt_browser()) {
     if (felt.isSome()) {
       firefox_connect_to_felt(*felt);
@@ -5990,7 +5990,7 @@ int XREMain::XRE_main(int argc, char* argv[], const BootstrapConfig& aConfig) {
   NS_SetCurrentThreadName("MainThread");
 #endif
 
-#if defined(MOZ_WIDGET_FELT)
+#if defined(MOZ_ENTERPRISE)
   if (XRE_IsParentProcess()) {
     Maybe<bool> feltUI =
         geckoargs::sFeltUI.Get(gArgc, gArgv, CheckArgFlag::None);
@@ -6274,12 +6274,12 @@ int XREMain::XRE_main(int argc, char* argv[], const BootstrapConfig& aConfig) {
   }
 #endif
 
-#if defined(MOZ_WIDGET_FELT)
+#if defined(MOZ_ENTERPRISE)
   // Do not restart when running as Felt client (i.e. Enterprise browser)
   if (!is_felt_browser()) {
 #endif
     mozilla::AppShutdown::MaybeDoRestart();
-#if defined(MOZ_WIDGET_FELT)
+#if defined(MOZ_ENTERPRISE)
   }
 #endif
 


### PR DESCRIPTION
This moves where the profiles and profiles database are stored giving separation between the enterprise profiles and the normal Firefox profiles.