### PR TITLE
Implement external link handling for Felt launcher

### DIFF
--- a/browser/components/BrowserContentHandler.sys.mjs
+++ b/browser/components/BrowserContentHandler.sys.mjs
@@ -1208,6 +1208,11 @@ nsBrowserContentHandler.prototype = {
 };
 var gBrowserContentHandler = new nsBrowserContentHandler();
 
+// Module-level queue for Felt external link handling
+// URLs are stored here when they arrive via command line (before Felt extension loads)
+// FeltProcessParent imports this module and manages forwarding from this queue
+export let gFeltPendingURLs = [];
+
 function handURIToExistingBrowser(
   uri,
   location,
@@ -1587,10 +1592,53 @@ nsDefaultCommandLineHandler.prototype = {
     }
 
     // Make sure that when FeltUI is requested, we do not try to open another
-    // window.
+    // window. Instead, forward any URLs to be opened in the real Firefox.
     if (Services.felt.isFeltUI()) {
       console.debug(`Felt: Found FeltUI in BrowserContentHandler.`);
       cmdLine.preventDefault = true;
+
+      // Consume Felt-specific flags that don't take parameters
+      cmdLine.handleFlag("feltUI", false);
+
+      // The URLs from -url flags have already been collected into urilist by the
+      // normal Firefox command line processing above (via handleFlagWithParam("url", false)).
+      // Now collect any positional URLs (URLs without -url flag).
+      for (let i = 0; i < cmdLine.length; ++i) {
+        var curarg = cmdLine.getArgument(i);
+        if (curarg.match(/^-/)) {
+          // Log unrecognized flags, we don't expect any at this point
+          console.error("Felt: Warning: unrecognized command line flag", curarg);
+        } else {
+          try {
+            let { uri } = resolveURIInternal(cmdLine, curarg);
+            urilist.push(uri);
+          } catch (e) {
+            console.error(`Felt: Error opening URI ${curarg} from the command line:`, e);
+          }
+        }
+      }
+
+      // Forward any URLs from the command line to the real Firefox
+      if (urilist.length > 0) {
+        const urlSpecs = urilist.filter(shouldLoadURI).map(u => u.spec);
+        if (urlSpecs.length) {
+          // Try to import FeltProcessParent and call queueURL()
+          // This will work if the extension has loaded (chrome:// URLs registered)
+          // If not, URLs stay in gFeltPendingURLs for later retrieval
+          try {
+            const { queueURL } = ChromeUtils.importESModule(
+              "chrome://felt/content/FeltProcessParent.sys.mjs"
+            );
+            for (let urlSpec of urlSpecs) {
+              queueURL(urlSpec);
+            }
+          } catch (err) {
+            // Chrome:// URLs not registered yet (early startup)
+            // Add to queue for FeltProcessParent to retrieve later
+            gFeltPendingURLs.push(...urlSpecs);
+          }
+        }
+      }
       return;
     }
 

--- a/browser/components/BrowserContentHandler.sys.mjs
+++ b/browser/components/BrowserContentHandler.sys.mjs
@@ -1607,19 +1607,28 @@ nsDefaultCommandLineHandler.prototype = {
         var curarg = cmdLine.getArgument(i);
         if (curarg.match(/^-/)) {
           // Log unrecognized flags, we don't expect any at this point
-          console.error("Felt: Warning: unrecognized command line flag", curarg);
+          console.error(
+            "Felt: Warning: unrecognized command line flag",
+            curarg
+          );
+          // To emulate the pre-nsICommandLine behavior, we ignore
+          // the argument after an unrecognized flag.
+          ++i;
         } else {
           try {
             let { uri } = resolveURIInternal(cmdLine, curarg);
             urilist.push(uri);
           } catch (e) {
-            console.error(`Felt: Error opening URI ${curarg} from the command line:`, e);
+            console.error(
+              `Felt: Error opening URI ${curarg} from the command line:`,
+              e
+            );
           }
         }
       }
 
       // Forward any URLs from the command line to the real Firefox
-      if (urilist.length > 0) {
+      if (urilist.length) {
         const urlSpecs = urilist.filter(shouldLoadURI).map(u => u.spec);
         if (urlSpecs.length) {
           // Try to import FeltProcessParent and call queueURL()
@@ -1643,22 +1652,19 @@ nsDefaultCommandLineHandler.prototype = {
     }
 
     for (let i = 0; i < cmdLine.length; ++i) {
-      var curarg = cmdLine.getArgument(i);
-      if (curarg.match(/^-/)) {
-        console.error("Warning: unrecognized command line flag", curarg);
+      let arg = cmdLine.getArgument(i);
+      if (arg.match(/^-/)) {
+        console.error("Warning: unrecognized command line flag", arg);
         // To emulate the pre-nsICommandLine behavior, we ignore
         // the argument after an unrecognized flag.
         ++i;
       } else {
         try {
-          let { uri, principal } = resolveURIInternal(cmdLine, curarg);
+          let { uri, principal } = resolveURIInternal(cmdLine, arg);
           urilist.push(uri);
           principalList.push(principal);
         } catch (e) {
-          console.error(
-            `Error opening URI ${curarg} from the command line:`,
-            e
-          );
+          console.error(`Error opening URI ${arg} from the command line:`, e);
         }
       }
     }

--- a/browser/extensions/felt/api.js
+++ b/browser/extensions/felt/api.js
@@ -72,15 +72,18 @@ this.felt = class extends ExtensionAPI {
       // If no window and sessionstore hasn't restored yet, wait for it
       if (!win && !this._sessionStoreRestored) {
         const self = this;
-        await new Promise((resolve) => {
+        await new Promise(resolve => {
           const observer = {
             observe(subject, topic) {
               if (topic === "sessionstore-windows-restored") {
-                Services.obs.removeObserver(observer, "sessionstore-windows-restored");
+                Services.obs.removeObserver(
+                  observer,
+                  "sessionstore-windows-restored"
+                );
                 self._sessionStoreRestored = true;
                 resolve();
               }
-            }
+            },
           };
           Services.obs.addObserver(observer, "sessionstore-windows-restored");
         });

--- a/browser/extensions/felt/api.js
+++ b/browser/extensions/felt/api.js
@@ -8,6 +8,10 @@
 
 const lazy = {};
 
+ChromeUtils.defineESModuleGetters(lazy, {
+  BrowserWindowTracker: "resource:///modules/BrowserWindowTracker.sys.mjs",
+});
+
 this.felt = class extends ExtensionAPI {
   FELT_PROCESS_ACTOR = "FeltProcess";
   FELT_WINDOW_ACTOR = "FeltWindow";
@@ -51,6 +55,55 @@ this.felt = class extends ExtensionAPI {
     });
   }
 
+  urlObserver = {
+    _sessionStoreRestored: false,
+
+    observe(aSubject, aTopic, aData) {
+      if (aTopic === "felt-open-url" && aData) {
+        this._handleFeltExternalUrl(aData);
+      }
+    },
+
+    async _handleFeltExternalUrl(url) {
+      let win = lazy.BrowserWindowTracker.getTopWindow({
+        private: false,
+      });
+
+      // If no window and sessionstore hasn't restored yet, wait for it
+      if (!win && !this._sessionStoreRestored) {
+        const self = this;
+        await new Promise((resolve) => {
+          const observer = {
+            observe(subject, topic) {
+              if (topic === "sessionstore-windows-restored") {
+                Services.obs.removeObserver(observer, "sessionstore-windows-restored");
+                self._sessionStoreRestored = true;
+                resolve();
+              }
+            }
+          };
+          Services.obs.addObserver(observer, "sessionstore-windows-restored");
+        });
+
+        // Try again after startup completes
+        win = lazy.BrowserWindowTracker.getTopWindow({
+          private: false,
+        });
+      }
+
+      if (!win) {
+        console.error("FeltExtension: No browser window available to open URL");
+        return;
+      }
+
+      try {
+        win.openTrustedLinkIn(url, "tab");
+      } catch (err) {
+        console.error("FeltExtension: Failed to open forwarded URL", url, err);
+      }
+    },
+  };
+
   onStartup() {
     if (Services.felt.isFeltUI()) {
       this.registerChrome();
@@ -59,6 +112,15 @@ this.felt = class extends ExtensionAPI {
       Services.ppmm.addMessageListener("FeltParent:FirefoxNormalExit", this);
       Services.ppmm.addMessageListener("FeltParent:FirefoxAbnormalExit", this);
       Services.ppmm.addMessageListener("FeltParent:FirefoxStarting", this);
+    } else if (Services.felt.isFeltBrowser()) {
+      // In the real Firefox, register observer to handle URLs
+      Services.obs.addObserver(this.urlObserver, "felt-open-url");
+      // Notify that extension is ready to receive URLs
+      try {
+        Services.felt.sendExtensionReady();
+      } catch (e) {
+        console.error("FeltExtension: Failed to send extension ready:", e);
+      }
     }
   }
 
@@ -138,12 +200,20 @@ this.felt = class extends ExtensionAPI {
       return;
     }
 
+    if (Services.felt.isFeltBrowser()) {
+      Services.obs.removeObserver(this.urlObserver, "felt-open-url");
+    }
+
     Services.ppmm.removeMessageListener("FeltChild:Loaded", this);
 
-    this.chromeHandle.destruct();
-    this.chromeHandle = null;
+    if (this.chromeHandle) {
+      this.chromeHandle.destruct();
+      this.chromeHandle = null;
+    }
 
-    ChromeUtils.unregisterWindowActor(this.FELT_WINDOW_ACTOR);
-    ChromeUtils.unregisterProcessActor(this.FELT_PROCESS_ACTOR);
+    if (Services.felt.isFeltUI()) {
+      ChromeUtils.unregisterWindowActor(this.FELT_WINDOW_ACTOR);
+      ChromeUtils.unregisterProcessActor(this.FELT_PROCESS_ACTOR);
+    }
   }
 };

--- a/browser/extensions/felt/content/FeltProcessParent.sys.mjs
+++ b/browser/extensions/felt/content/FeltProcessParent.sys.mjs
@@ -14,6 +14,28 @@ ChromeUtils.defineESModuleGetters(lazy, {
 
 console.debug(`FeltExtension: FeltParentProcess.sys.mjs`);
 
+// Import the shared pending URLs queue from BrowserContentHandler
+// This queue is shared between BrowserContentHandler (which fills it early during command-line
+// processing) and FeltProcessParent (which forwards URLs after Firefox is ready)
+const { gFeltPendingURLs } = ChromeUtils.importESModule(
+  "resource:///modules/BrowserContentHandler.sys.mjs"
+);
+
+export function queueURL(url) {
+  // If Firefox AND extension are both ready, forward immediately
+  if (gFeltProcessParentInstance?.firefoxReady &&
+      gFeltProcessParentInstance?.extensionReady) {
+    gFeltProcessParentInstance.sendURLToFirefox(url);
+    // Ensure Felt launcher stays hidden when forwarding to running Firefox
+    Services.felt.makeBackgroundProcess();
+  } else {
+    // Queue at module level until ready
+    gFeltPendingURLs.push(url);
+  }
+}
+
+let gFeltProcessParentInstance = null;
+
 /**
  * Manages the SSO login and launching Firefox
  */
@@ -23,6 +45,14 @@ export class FeltProcessParent extends JSProcessActorParent {
       `FeltExtension: FeltParentProcess.sys.mjs: FeltProcessParent`
     );
     super();
+
+    // Store instance globally
+    gFeltProcessParentInstance = this;
+
+    // Track Firefox ready state (URLs remain in gFeltPendingURLs until ready)
+    this.firefoxReady = false;
+    // Track extension ready state (extension must register its observer)
+    this.extensionReady = false;
 
     this.restartObserver = {
       observe(aSubject, aTopic) {
@@ -45,6 +75,13 @@ export class FeltProcessParent extends JSProcessActorParent {
             }
             break;
           }
+          case "felt-extension-ready": {
+            if (gFeltProcessParentInstance) {
+              gFeltProcessParentInstance.extensionReady = true;
+              gFeltProcessParentInstance.forwardPendingURLs();
+            }
+            break;
+          }
           default:
             console.debug(`FeltExtension: ParentProcess: Unhandled ${aTopic}`);
             break;
@@ -54,6 +91,7 @@ export class FeltProcessParent extends JSProcessActorParent {
 
     Services.cpmm.addMessageListener("FeltParent:RestartFirefox", this);
     Services.obs.addObserver(this.restartObserver, "felt-firefox-restarting");
+    Services.obs.addObserver(this.restartObserver, "felt-extension-ready");
   }
 
   sanitizePrefs(prefs) {
@@ -112,6 +150,8 @@ export class FeltProcessParent extends JSProcessActorParent {
 
   async startFirefox(ssoCollectedCookies = []) {
     this.restartReported = false;
+    this.firefoxReady = false;
+    this.extensionReady = false;
     Services.cpmm.sendAsyncMessage("FeltParent:FirefoxStarting", {});
     this.firefox = this.startFirefoxProcess();
     this.firefox
@@ -141,6 +181,10 @@ export class FeltProcessParent extends JSProcessActorParent {
 
         Services.felt.sendCookies(ssoCollectedCookies);
         Services.felt.sendReady();
+        this.firefoxReady = true;
+
+        // Try to forward pending URLs now (will only forward if extension is also ready)
+        this.forwardPendingURLs();
       })
       .then(() => {
         console.debug(
@@ -261,6 +305,54 @@ export class FeltProcessParent extends JSProcessActorParent {
     }
 
     Services.felt.ipcChannel();
+  }
+
+  /**
+   * Send a URL to Firefox via IPC (Firefox must be ready)
+   */
+  sendURLToFirefox(url) {
+    if (!this.firefoxReady || !Services.felt) {
+      console.error(`FeltExtension: Cannot send URL, Firefox not ready`);
+      return;
+    }
+
+    try {
+      Services.felt.openURL(url);
+    } catch (err) {
+      console.error(`FeltExtension: Failed to forward URL: ${err}`);
+    }
+  }
+
+  /**
+   * Forward all pending URLs to Firefox
+   */
+  forwardPendingURLs() {
+    if (gFeltPendingURLs.length === 0) {
+      return;
+    }
+
+    // Wait for both Firefox (prefs/cookies) AND extension (observer) to be ready
+    if (!this.firefoxReady || !this.extensionReady) {
+      console.debug(`FeltExtension: Not ready to forward URLs (firefoxReady=${this.firefoxReady}, extensionReady=${this.extensionReady})`);
+      return;
+    }
+
+    if (!Services.felt) {
+      console.error(`FeltExtension: Services.felt not available, cannot forward URLs`);
+      return;
+    }
+
+    // Forward all URLs directly via IPC (both Firefox and extension are ready)
+    for (const url of gFeltPendingURLs) {
+      try {
+        Services.felt.openURL(url);
+      } catch (err) {
+        console.error(`FeltExtension: Failed to forward URL ${url}: ${err}`);
+      }
+    }
+
+    // Clear the queue
+    gFeltPendingURLs.length = 0;
   }
 
   receiveMessage(message) {

--- a/browser/extensions/felt/content/FeltProcessParent.sys.mjs
+++ b/browser/extensions/felt/content/FeltProcessParent.sys.mjs
@@ -17,14 +17,14 @@ console.debug(`FeltExtension: FeltParentProcess.sys.mjs`);
 // Import the shared pending URLs queue from BrowserContentHandler
 // This queue is shared between BrowserContentHandler (which fills it early during command-line
 // processing) and FeltProcessParent (which forwards URLs after Firefox is ready)
-const { gFeltPendingURLs } = ChromeUtils.importESModule(
-  "resource:///modules/BrowserContentHandler.sys.mjs"
-);
+import { gFeltPendingURLs } from "resource:///modules/BrowserContentHandler.sys.mjs";
 
 export function queueURL(url) {
   // If Firefox AND extension are both ready, forward immediately
-  if (gFeltProcessParentInstance?.firefoxReady &&
-      gFeltProcessParentInstance?.extensionReady) {
+  if (
+    gFeltProcessParentInstance?.firefoxReady &&
+    gFeltProcessParentInstance?.extensionReady
+  ) {
     gFeltProcessParentInstance.sendURLToFirefox(url);
     // Ensure Felt launcher stays hidden when forwarding to running Firefox
     Services.felt.makeBackgroundProcess();
@@ -309,6 +309,8 @@ export class FeltProcessParent extends JSProcessActorParent {
 
   /**
    * Send a URL to Firefox via IPC (Firefox must be ready)
+   *
+   * @param {string} url
    */
   sendURLToFirefox(url) {
     if (!this.firefoxReady || !Services.felt) {
@@ -333,12 +335,16 @@ export class FeltProcessParent extends JSProcessActorParent {
 
     // Wait for both Firefox (prefs/cookies) AND extension (observer) to be ready
     if (!this.firefoxReady || !this.extensionReady) {
-      console.debug(`FeltExtension: Not ready to forward URLs (firefoxReady=${this.firefoxReady}, extensionReady=${this.extensionReady})`);
+      console.debug(
+        `FeltExtension: Not ready to forward URLs (firefoxReady=${this.firefoxReady}, extensionReady=${this.extensionReady})`
+      );
       return;
     }
 
     if (!Services.felt) {
-      console.error(`FeltExtension: Services.felt not available, cannot forward URLs`);
+      console.error(
+        `FeltExtension: Services.felt not available, cannot forward URLs`
+      );
       return;
     }
 

--- a/browser/extensions/felt/rust/nsIFelt.idl
+++ b/browser/extensions/felt/rust/nsIFelt.idl
@@ -6,7 +6,7 @@
 #include "nsISupports.idl"
 #include "nsICookie.idl"
 
-[scriptable, uuid(53c53451-3b93-440c-b27b-9759ccb29da6)]
+[scriptable, uuid(373195cb-bbb9-4e01-b276-b799a18ca355)]
 interface nsIFelt : nsISupports {
   [must_use]
   ACString oneShotIpcServer();
@@ -43,4 +43,10 @@ interface nsIFelt : nsISupports {
 
   [must_use]
   void sendRestartForced();
+
+  [must_use]
+  void sendExtensionReady();
+
+  [must_use]
+  void openURL(in ACString url);
 };

--- a/browser/extensions/felt/rust/src/lib.rs
+++ b/browser/extensions/felt/rust/src/lib.rs
@@ -117,6 +117,21 @@ pub extern "C" fn firefox_felt_is_startup_complete() -> bool {
     }
 }
 
+#[no_mangle]
+pub extern "C" fn firefox_felt_send_extension_ready() -> () {
+    trace!("firefox_felt_send_extension_ready()");
+    let guard = FELT_CLIENT.lock().expect("Could not get lock");
+    match &*guard {
+        Some(client) => {
+            trace!("firefox_felt_send_extension_ready(): sending message");
+            client.send_extension_ready();
+        }
+        None => {
+            trace!("firefox_felt_send_extension_ready(): missing client");
+        }
+    }
+}
+
 #[unsafe(no_mangle)]
 pub extern "C" fn felt_constructor(
     iid: *const xpcom::nsIID,

--- a/browser/extensions/felt/rust/src/message.rs
+++ b/browser/extensions/felt/rust/src/message.rs
@@ -14,8 +14,10 @@ pub enum FeltMessage {
     StringPreference((String, String)),
     IntPreference((String, i32)),
     StartupReady,
+    ExtensionReady,
+    OpenURL(String),
     RestartForced,
     Restarting,
 }
 
-pub const FELT_IPC_VERSION: u32 = 1;
+pub const FELT_IPC_VERSION: u32 = 2;

--- a/browser/extensions/felt/rust/src/utils.rs
+++ b/browser/extensions/felt/rust/src/utils.rs
@@ -171,6 +171,29 @@ pub fn notify_observers(name: String) {
     });
 }
 
+pub fn open_url_in_firefox(url: String) {
+    trace!("open_url_in_firefox() url: {}", url);
+    do_main_thread("felt_open_url", async move {
+        let obssvc: RefPtr<nsIObserverService> = xpcom::components::Observer::service().unwrap();
+        let topic = CString::new("felt-open-url").unwrap();
+        let url_data = nsstring::nsString::from(&url);
+
+        let rv = unsafe {
+            obssvc.NotifyObservers(
+                std::ptr::null(),
+                topic.as_ptr(),
+                url_data.as_ptr(),
+            )
+        };
+
+        if rv.succeeded() {
+            trace!("open_url_in_firefox() successfully sent observer notification for URL: {}", url);
+        } else {
+            trace!("open_url_in_firefox() NotifyObservers failed: {:?}", rv);
+        }
+    });
+}
+
 pub fn do_main_thread<F>(name: &'static str, future: F)
 where
     F: Future + Send + 'static,


### PR DESCRIPTION
This adds support for opening external links in the Felt launcher, forwarding the URLs over IPC.

* Added openURL() to nsIFelt interface for sending URLs over IPC
* Single shared queue (gFeltPendingURLs) for all pending URLs
* URLs are queued until Firefox extension signals ready, then forwarded
* Observer notification "felt-open-url" receives URLs from IPC