### PR TITLE
Make Felt UI default and enforce enterprise security restrictions

### DIFF
--- a/browser/extensions/felt/rust/felt.h
+++ b/browser/extensions/felt/rust/felt.h
@@ -15,7 +15,7 @@ bool is_felt_ui();
 
 bool is_felt_browser();
 
-void firefox_connect_to_felt(const char* server_name);
+bool firefox_connect_to_felt(const char* server_name);
 
 void firefox_felt_connection_start_thread();
 

--- a/browser/extensions/felt/rust/src/lib.rs
+++ b/browser/extensions/felt/rust/src/lib.rs
@@ -25,6 +25,18 @@ use env_logger;
 static IS_FELT_UI: AtomicBool = AtomicBool::new(false);
 static IS_FELT_BROWSER: AtomicBool = AtomicBool::new(false);
 
+fn normalize_arg(arg: String) -> String {
+    let mut normalized = arg;
+    normalized.retain(|c| c != '-' && c != '/');
+    normalized.to_lowercase()
+}
+
+fn arg_matches(target: &str) -> bool {
+    env::args()
+        .into_iter()
+        .any(|arg| normalize_arg(arg) == target)
+}
+
 #[no_mangle]
 pub extern "C" fn felt_init() {
     trace!("felt_init()");
@@ -35,25 +47,19 @@ pub extern "C" fn felt_init() {
         Err(_) => false,
     };
 
-    let found_felt_ui_arg = env::args()
-        .into_iter()
-        .any(|arg| arg.replace("-", "").replace("/", "").to_lowercase() == "feltui");
+    let felt_ui_requested = arg_matches("feltui") || found_felt_ui_env;
+    let is_felt_browser = arg_matches("felt");
 
-    let is_felt_ui = found_felt_ui_arg || found_felt_ui_env;
+    if is_felt_browser && felt_ui_requested {
+        panic!("Cannot have both -feltUI and -felt args");
+    }
+
+    let is_felt_ui = !is_felt_browser;
     trace!("felt_init(): is_felt_ui={}", is_felt_ui);
     IS_FELT_UI.store(is_felt_ui, Ordering::Relaxed);
 
-    let is_felt_browser = env::args()
-        .into_iter()
-        .any(|arg| arg.replace("-", "").replace("/", "").to_lowercase() == "felt");
-
     trace!("felt_init(): is_felt_browser={}", is_felt_browser);
     IS_FELT_BROWSER.store(is_felt_browser, Ordering::Relaxed);
-
-    assert!(
-        !(is_felt_browser && is_felt_ui),
-        "Cannot have both -feltUI and -felt args"
-    );
 
     trace!("felt_init() done");
 }
@@ -73,7 +79,7 @@ pub extern "C" fn is_felt_browser() -> bool {
 pub static FELT_CLIENT: Mutex<Option<client::FeltClientThread>> = Mutex::new(None);
 
 #[no_mangle]
-pub extern "C" fn firefox_connect_to_felt(server_name: *const c_char) -> () {
+pub extern "C" fn firefox_connect_to_felt(server_name: *const c_char) -> bool {
     let srv_name = unsafe { CStr::from_ptr(server_name) };
     let server_socket = String::from_utf8_lossy(srv_name.to_bytes()).to_string();
     trace!("firefox_connect_to_felt({})", server_socket);
@@ -82,12 +88,14 @@ pub extern "C" fn firefox_connect_to_felt(server_name: *const c_char) -> () {
             let mut state = FELT_CLIENT.lock().expect("Could not lock mutex");
             trace!("firefox_connect_to_felt(): connected, storing client");
             *state = Some(client);
+            trace!("firefox_connect_to_felt() done: success");
+            true
         }
         Err(()) => {
             trace!("firefox_connect_to_felt(): error");
+            false
         }
     }
-    trace!("firefox_connect_to_felt() done");
 }
 
 #[no_mangle]
@@ -111,8 +119,8 @@ pub extern "C" fn firefox_felt_is_startup_complete() -> bool {
     match &*guard {
         Some(client) => client.is_startup_complete(),
         None => {
-            trace!("firefox_felt_is_startup_complete(): missing client");
-            true
+            trace!("firefox_felt_is_startup_complete(): missing client, blocking startup");
+            false
         }
     }
 }


### PR DESCRIPTION
This makes Felt UI the default mode.

Key changes:

   - Felt UI is now the default mode
   - Felt browser mode (-felt) must provide a valid socket for SSO
   - Block headless mode except in automation (MOZ_AUTOMATION env var)
   - Disable safe mode completely in enterprise builds