### PR TITLE
Encrypt SQLite databases from mozStorageService

### DIFF
--- a/browser/components/BrowserComponents.manifest
+++ b/browser/components/BrowserComponents.manifest
@@ -10,6 +10,7 @@
 category app-startup nsBrowserGlue @mozilla.org/browser/browserglue;1 application={ec8030f7-c20a-464f-9b0e-13a3a9e97384} application={aa3c5121-dab2-40e2-81ca-7ea25febc110}
 
 # Browser global components initializing before UI startup
+category browser-before-ui-startup moz-src:///security/keystore/KeyStorage.sys.mjs KeyStorage.init
 category browser-before-ui-startup resource:///modules/sessionstore/SessionStore.sys.mjs SessionStore.init
 category browser-before-ui-startup resource:///modules/BuiltInThemes.sys.mjs BuiltInThemes.maybeInstallActiveBuiltInTheme
 #ifdef MOZ_NORMANDY

--- a/dom/cache/Connection.cpp
+++ b/dom/cache/Connection.cpp
@@ -246,6 +246,13 @@ Connection::CreateTable(const char* aTable, const char* aSchema) {
 }
 
 NS_IMETHODIMP
+Connection::AttachDatabase(const char* aPath, const char* aName,
+                           mozIStorageStatementCallback* aCallback,
+                           mozIStoragePendingStatement** _handle) {
+  return mBase->AttachDatabase(aPath, aName, aCallback, _handle);
+}
+
+NS_IMETHODIMP
 Connection::SetGrowthIncrement(int32_t aIncrement,
                                const nsACString& aDatabase) {
   return mBase->SetGrowthIncrement(aIncrement, aDatabase);

--- a/modules/libpref/init/StaticPrefList.yaml
+++ b/modules/libpref/init/StaticPrefList.yaml
@@ -17637,6 +17637,12 @@
   value: true
   mirror: always
 
+# Enable keystore file for enterprise storage encryption.
+- name: security.storage.keystore.enabled
+  type: bool
+  value: false
+  mirror: always
+
 - name: security.ssl3.ecdhe_ecdsa_aes_128_gcm_sha256
   type: RelaxedAtomicBool
   value: true

--- a/security/keystore/KeyStorage.cpp
+++ b/security/keystore/KeyStorage.cpp
@@ -1,0 +1,109 @@
+/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*-
+ * vim: sw=2 ts=2 et lcs=trail\:.,tab\:>~ :
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "KeyStorage.h"
+
+#include "Persist.h"
+
+#include "nsIInterfaceRequestor.h"
+#include "nsIPK11Token.h"
+#include "nsIPK11TokenDB.h"
+#include "nsLocalFile.h"
+#include "nsNSSHelper.h"
+#include "mozilla/Base64.h"
+#include "pk11sdr.h"
+
+#include <iomanip>
+#include <sstream>
+#include <string>
+
+static std::string ArrayToHexString(const unsigned char* array,
+                                    unsigned int length) {
+  std::ostringstream oss;
+  oss << std::hex << std::setfill('0');
+  // todo: replace string_view with span once we make the jump to C++20
+  for (unsigned int i = 0; i < length; i++) {
+    oss << std::setw(2) << static_cast<int>(array[i]);
+  }
+  return oss.str();
+}
+
+static nsresult WaitForTokenDB() {
+  nsresult rv;
+
+  nsCOMPtr<nsIPK11TokenDB> tokenDB =
+      do_GetService("@mozilla.org/security/pk11tokendb;1", &rv);
+
+  nsIPK11Token* internalToken;
+  tokenDB->GetInternalKeyToken(&internalToken);
+
+  bool logged_in, needs_login;
+  rv = internalToken->NeedsLogin(&needs_login);
+  NS_ENSURE_SUCCESS(rv, rv);
+  while (needs_login && (rv = internalToken->IsLoggedIn(&logged_in)) == NS_OK &&
+         !logged_in);
+  NS_ENSURE_SUCCESS(rv, rv);
+  return NS_OK;
+}
+
+namespace mozilla::storage::key {
+nsresult GetKeyForPath(const char* aPath, nsCString& key) {
+  nsIFile* file = MakeAndAddRef<nsLocalFile>().take();
+  nsresult rv = file->InitWithNativePath(nsCString(aPath));
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  return GetKeyForFile(file, key);
+}
+
+nsresult GetKeyForFile(nsIFile* aFile, nsCString& keyString) {
+  nsAutoCString telemetryFilename;
+  nsresult rv = aFile->GetNativeLeafName(telemetryFilename);
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  rv = WaitForTokenDB();
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  nsCString encodedKey;
+  rv = LoadKeyFromDisk(telemetryFilename, encodedKey, 112);
+
+  if (rv == NS_OK) {
+    nsCString encryptedKey;
+    rv = mozilla::Base64Decode(encodedKey, encryptedKey);
+    NS_ENSURE_SUCCESS(rv, rv);
+
+    SECItem data = {}, result = {};
+    data.data = (unsigned char*)encryptedKey.Data();
+    data.len = encryptedKey.Length();
+    data.type = siBuffer;
+
+    PK11SDR_Decrypt(&data, &result, nullptr);
+
+    keyString.AssignASCII(ArrayToHexString(result.data, result.len));
+  } else {
+    unsigned char key[32];
+    PK11_GenerateRandom(key, 32);
+
+    keyString.AssignASCII(ArrayToHexString(key, 32));
+
+    SECItem data = {}, result = {}, keyid = {siBuffer, nullptr, 0};
+    data.data = key;
+    data.len = 32;
+    data.type = siBuffer;
+
+    PK11SDR_Encrypt(&keyid, &data, &result, nullptr);
+
+    nsCString encodedKey;
+    rv =
+        mozilla::Base64Encode((const char*)result.data, result.len, encodedKey);
+    NS_ENSURE_SUCCESS(rv, rv);
+
+    rv = StoreKeyToDisk(telemetryFilename, encodedKey);
+    NS_ENSURE_SUCCESS(rv, rv);
+  }
+
+  return NS_OK;
+}
+}  // namespace mozilla::storage::key

--- a/security/keystore/KeyStorage.h
+++ b/security/keystore/KeyStorage.h
@@ -1,0 +1,13 @@
+/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*-
+ * vim: sw=2 ts=2 et lcs=trail\:.,tab\:>~ :
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "nsIFile.h"
+#include "nsStringFwd.h"
+
+namespace mozilla::storage::key {
+nsresult GetKeyForPath(const char* aPath, nsCString& key);
+nsresult GetKeyForFile(nsIFile* aFile, nsCString& key);
+}  // namespace mozilla::storage::key

--- a/security/keystore/KeyStorage.sys.mjs
+++ b/security/keystore/KeyStorage.sys.mjs
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export var KeyStorage = {
+  init() {
+    // Load the PK11 token
+    const tokenDB = Cc["@mozilla.org/security/pk11tokendb;1"].getService(
+      Ci.nsIPK11TokenDB
+    );
+
+    let pk11token;
+    try {
+      pk11token = tokenDB.getInternalKeyToken();
+    } catch (e) {
+      console.error("KeyStorage.init: Error getting PK11 token: " + e);
+      return;
+    }
+
+    try {
+      pk11token.login(true);
+    } catch (e) {
+      console.error(
+        "KeyStorage.init: Error getting logging in PK11 token: " + e
+      );
+    }
+  },
+};

--- a/security/keystore/Persist.cpp
+++ b/security/keystore/Persist.cpp
@@ -1,0 +1,133 @@
+/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*-
+ * vim: sw=2 ts=2 et lcs=trail\:.,tab\:>~ :
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "Persist.h"
+
+#include "nsAppDirectoryServiceDefs.h"
+#include "nsCOMPtr.h"
+#include "nsIToolkitProfileService.h"
+#include "nsIFile.h"
+#include "nsIProperties.h"
+#include "NSSErrorsService.h"
+#include "nsServiceManagerUtils.h"
+#include "prio.h"
+#include "prerror.h"
+
+#define KEYSTORE_MAGIC "# mozilla secure key storage\n"
+
+nsresult GetCurrentProfilePath(nsAString& path) {
+  nsCOMPtr<nsIProperties> dirSvc =
+      do_GetService(NS_DIRECTORY_SERVICE_CONTRACTID);
+  if (dirSvc) {
+    nsCOMPtr<nsIFile> profD;
+    nsresult rv = dirSvc->Get(NS_APP_USER_PROFILE_50_DIR, NS_GET_IID(nsIFile),
+                              getter_AddRefs(profD));  // "ProfD"
+    NS_ENSURE_SUCCESS(rv, rv);
+    if (profD) {
+      return profD->GetPath(path);
+    }
+  }
+  return NS_ERROR_FAILURE;
+}
+
+nsresult GetOrCreateKeyFilePath(nsAString& path) {
+  nsresult rv = GetCurrentProfilePath(path);
+  NS_ENSURE_SUCCESS(rv, rv);
+  path.Append(NS_LITERAL_STRING_FROM_CSTRING("/bikeshed"));
+
+  PR_MakeDir(NS_ConvertUTF16toUTF8(path).get(), 0777);
+
+  path.Append(NS_LITERAL_STRING_FROM_CSTRING("/keystore.enc"));
+
+  return NS_OK;
+}
+
+nsresult LoadFileToString(const nsCOMPtr<nsIFile>& file, nsACString& contents) {
+  PRFileDesc* desc;
+  nsresult rv = file->OpenNSPRFileDesc(PR_RDONLY, PR_IRUSR | PR_IWUSR, &desc);
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  unsigned char buf[1024];
+  int count = 0;
+  while ((count = PR_Read(desc, buf, 1024)) > 0) {
+    contents.Append(mozilla::Span<unsigned char>(buf, count));
+  }
+
+  if (count < 0) return mozilla::psm::GetXPCOMFromNSSError(PR_GetError());
+  return NS_OK;
+}
+
+nsresult AppendStringToFile(const nsCOMPtr<nsIFile>& file,
+                            nsACString& contents) {
+  PRFileDesc* desc;
+  nsresult rv = file->OpenNSPRFileDesc(PR_WRONLY | PR_CREATE_FILE | PR_APPEND,
+                                       PR_IRUSR | PR_IWUSR, &desc);
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  if (PR_Write(desc, contents.Data(), (int)contents.Length()) < 0) {
+    return mozilla::psm::GetXPCOMFromNSSError(PR_GetError());
+  }
+  return NS_OK;
+}
+
+nsresult LoadKeyFromDisk(nsAutoCString& identifier, nsCString& data,
+                         unsigned int len) {
+  nsCString fileContents;
+
+  nsAutoString filePath;
+  nsresult rv = GetOrCreateKeyFilePath(filePath);
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  nsCOMPtr<nsIFile> file;
+  rv = NS_NewLocalFile(filePath, getter_AddRefs(file));
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  rv = LoadFileToString(file, fileContents);
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  if (fileContents.Find(KEYSTORE_MAGIC) != 0) {
+    return NS_ERROR_INVALID_SIGNATURE;
+  }
+
+  nsAutoCString needle = identifier + ":"_ns;
+
+  int32_t keyLocation = fileContents.Find(needle.View());
+  if (keyLocation == kNotFound) {
+    return NS_ERROR_NOT_AVAILABLE;
+  }
+
+  keyLocation += (int32_t)needle.Length();
+
+  if (fileContents.Length() < keyLocation + len) {
+    return NS_ERROR_FILE_CORRUPTED;
+  }
+
+  data.Assign(fileContents.get() + keyLocation, len);
+  return NS_OK;
+}
+
+nsresult StoreKeyToDisk(nsAutoCString& identifier, const nsCString& key) {
+  nsAutoString filePath;
+  nsresult rv = GetOrCreateKeyFilePath(filePath);
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  nsCOMPtr<nsIFile> file;
+  rv = NS_NewLocalFile(filePath, getter_AddRefs(file));
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  bool needs_magic;
+  file->Exists(&needs_magic);
+
+  nsCString data;
+  if (!needs_magic) {
+    data.Append(KEYSTORE_MAGIC);
+  }
+
+  nsAutoCString keyLine = identifier + ":"_ns + key + "\n"_ns;
+  data.Append(keyLine);
+
+  return AppendStringToFile(file, data);
+}

--- a/security/keystore/Persist.h
+++ b/security/keystore/Persist.h
@@ -1,0 +1,11 @@
+/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*-
+ * vim: sw=2 ts=2 et lcs=trail\:.,tab\:>~ :
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "nsStringFwd.h"
+
+nsresult LoadKeyFromDisk(nsAutoCString& identifier, nsCString& data,
+                         unsigned int len);
+nsresult StoreKeyToDisk(nsAutoCString& identifier, const nsCString& key);

--- a/security/keystore/moz.build
+++ b/security/keystore/moz.build
@@ -1,0 +1,36 @@
+# -*- Mode: python; indent-tabs-mode: nil; tab-width: 40 -*-
+# vim: set filetype=python:
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+with Files("**"):
+    BUG_COMPONENT = ("Core", "Security: PSM")
+
+EXPORTS.mozilla.security += [
+    "KeyStorage.h",
+]
+
+UNIFIED_SOURCES += [
+    "KeyStorage.cpp",
+    "Persist.cpp",
+]
+
+MOZ_SRC_FILES += [
+    "KeyStorage.sys.mjs",
+]
+
+CXXFLAGS += [
+    "-Wextra",
+    "-Wunreachable-code",
+]
+
+# Gecko headers aren't warning-free enough for us to enable these warnings.
+CXXFLAGS += [
+    "-Wno-unused-parameter",
+]
+
+if CONFIG["CC_TYPE"] == "clang-cl":
+    AllowCompilerWarnings()  # workaround for bug 1090497
+
+FINAL_LIBRARY = "xul"

--- a/security/moz.build
+++ b/security/moz.build
@@ -9,6 +9,7 @@ with Files("**"):
 
 DIRS += [
     "/security/mls",
+    "/security/keystore",
 ]
 
 with Files("generate*.py"):

--- a/security/nss.symbols
+++ b/security/nss.symbols
@@ -443,6 +443,7 @@ PK11_ReferenceSlot
 PK11_ReferenceSymKey
 PK11_ResetToken
 PK11SDR_Decrypt
+PK11SDR_Encrypt
 PK11SDR_EncryptWithMechanism
 PK11_SetPasswordFunc
 PK11_SetSymKeyNickname

--- a/storage/mozIStorageAsyncConnection.idl
+++ b/storage/mozIStorageAsyncConnection.idl
@@ -414,4 +414,21 @@ interface mozIStorageAsyncConnection : nsISupports {
                          in mozIStorageCompletionCallback aCallback,
                          [optional] in unsigned long aPagesPerStep,
                          [optional] in unsigned long aStepDelayMs);
+
+  /**
+   * Attach another database to this connection.
+   *
+   * This has the same effect as if executing ATTACH DATABASE aPath as aName,
+   * but for encrypted databases it also automatically fetches their key and
+   * decrypts them. See the SQLite documentation for more details.
+   *
+   * @param aPath
+   *        The path to the database file that should be attached. May be in
+   *        URI form.
+   * @param aName
+   *        The name under which the database should be attached.
+   */
+  mozIStoragePendingStatement attachDatabase(in string aPath,
+                                             in string aName,
+                                             [optional] in mozIStorageStatementCallback aCallback);
 };

--- a/storage/mozStorageConnection.cpp
+++ b/storage/mozStorageConnection.cpp
@@ -6,7 +6,10 @@
 
 #include "BaseVFS.h"
 #include "ErrorList.h"
+#include "mozilla/security/KeyStorage.h"
+#include "ScopedNSSTypes.h"
 #include "nsError.h"
+#include "nsLocalFile.h"
 #include "nsThreadUtils.h"
 #include "nsIFile.h"
 #include "nsIFileURL.h"
@@ -1127,6 +1130,71 @@ nsresult Connection::initialize(nsIFile* aDatabaseFile) {
   return NS_OK;
 }
 
+nsresult Connection::initializeSecure(nsIFile* aDatabaseFile) {
+  NS_ASSERTION(aDatabaseFile, "Passed null file!");
+  NS_ASSERTION(!connectionReady(),
+               "Initialize called on already opened database!");
+  AUTO_PROFILER_LABEL("Connection::initialize", OTHER);
+
+  MOZ_RELEASE_ASSERT(EnsureNSSInitializedChromeOrContent(),
+                     "Could not initialize NSS.");
+
+  nsresult rv;
+
+  if (!mPrefBranch) {
+    nsCOMPtr<nsIPrefService> prefs =
+        do_GetService(NS_PREFSERVICE_CONTRACTID, &rv);
+    if (NS_FAILED(rv)) return rv;
+
+    rv = prefs->GetBranch(nullptr, getter_AddRefs(mPrefBranch));
+    if (NS_FAILED(rv)) return rv;
+  }
+
+  bool encryptionEnabled;
+  rv = mPrefBranch->GetBoolPref("security.storage.keystore.enabled",
+                                &encryptionEnabled);
+  if (NS_FAILED(rv) || !encryptionEnabled) {
+    return initialize(aDatabaseFile);
+  }
+
+  nsAutoCString telemetryFilename;
+  rv = aDatabaseFile->GetNativeLeafName(telemetryFilename);
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  nsCString aDBKey;
+  key::GetKeyForFile(aDatabaseFile, aDBKey);
+
+  // Do not set mFileURL here since this is database does not have an associated
+  // URL.
+  mDatabaseFile = aDatabaseFile;
+
+  nsCString telName;
+  aDatabaseFile->GetNativeLeafName(telName);
+
+  nsAutoString dbPath;
+  aDatabaseFile->GetPath(dbPath);
+
+  nsAutoCString dbSpec =
+      "file:"_ns + NS_ConvertUTF16toUTF8(dbPath) + "?key="_ns + aDBKey;
+
+  int srv = ::sqlite3_open_v2(dbSpec.get(), &mDBConn, mFlags | SQLITE_OPEN_URI,
+                              obfsvfs::GetVFSName());
+  if (srv != SQLITE_OK) {
+    ::sqlite3_close(mDBConn);
+    mDBConn = nullptr;
+    rv = convertResultCode(srv);
+    RecordOpenStatus(rv);
+    return rv;
+  }
+
+  rv = initializeInternal();
+
+  RecordOpenStatus(rv);
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  return NS_OK;
+}
+
 nsresult Connection::initialize(nsIFileURL* aFileURL) {
   NS_ASSERTION(aFileURL, "Passed null file URL!");
   NS_ASSERTION(!connectionReady(),
@@ -1272,7 +1340,7 @@ nsresult Connection::initializeInternal() {
 nsresult Connection::initializeOnAsyncThread(nsIFile* aStorageFile) {
   MOZ_ASSERT(!IsOnCurrentSerialEventTarget(eventTargetOpenedOn));
   nsresult rv = aStorageFile
-                    ? initialize(aStorageFile)
+                    ? initializeSecure(aStorageFile)
                     : initialize(kMozStorageMemoryStorageKey, VoidCString());
   if (NS_FAILED(rv)) {
     // Shutdown the async thread, since initialization failed.
@@ -1949,7 +2017,7 @@ nsresult Connection::initializeClone(Connection* aClone, bool aReadOnly) {
   } else if (mFileURL) {
     rv = aClone->initialize(mFileURL);
   } else {
-    rv = aClone->initialize(mDatabaseFile);
+    rv = aClone->initializeSecure(mDatabaseFile);
   }
   if (NS_FAILED(rv)) {
     return rv;
@@ -1978,6 +2046,23 @@ nsresult Connection::initializeClone(Connection* aClone, bool aReadOnly) {
           rv = aClone->CreateStatement("ATTACH DATABASE :path AS "_ns + name,
                                        getter_AddRefs(attachStmt));
           NS_ENSURE_SUCCESS(rv, rv);
+          if (!mPrefBranch) {
+            nsCOMPtr<nsIPrefService> prefs =
+                do_GetService(NS_PREFSERVICE_CONTRACTID, &rv);
+            NS_ENSURE_SUCCESS(rv, rv);
+
+            rv = prefs->GetBranch(nullptr, getter_AddRefs(mPrefBranch));
+            NS_ENSURE_SUCCESS(rv, rv);
+          }
+
+          bool encryptionEnabled;
+          rv = mPrefBranch->GetBoolPref("security.storage.keystore.enabled",
+                                        &encryptionEnabled);
+          if (NS_SUCCEEDED(rv) && encryptionEnabled) {
+            nsCString aDBKey;
+            key::GetKeyForPath(path.get(), aDBKey);
+            path = nsPrintfCString("file:%s?key=%s", path.get(), aDBKey.get());
+          }
           rv = attachStmt->BindUTF8StringByName("path"_ns, path);
           NS_ENSURE_SUCCESS(rv, rv);
           rv = attachStmt->Execute();
@@ -2586,6 +2671,50 @@ Connection::CreateTable(const char* aTableName, const char* aTableSchema) {
   int srv = executeSql(mDBConn, buf.get());
 
   return convertResultCode(srv);
+}
+
+NS_IMETHODIMP
+Connection::AttachDatabase(const char* aPath, const char* aName,
+                           mozIStorageStatementCallback* aCallback,
+                           mozIStoragePendingStatement** _handle) {
+  nsresult rv;
+  nsCString path;
+
+  if (!mPrefBranch) {
+    nsCOMPtr<nsIPrefService> prefs =
+        do_GetService(NS_PREFSERVICE_CONTRACTID, &rv);
+    NS_ENSURE_SUCCESS(rv, rv);
+
+    rv = prefs->GetBranch(nullptr, getter_AddRefs(mPrefBranch));
+    NS_ENSURE_SUCCESS(rv, rv);
+  }
+
+  bool encryptionEnabled;
+  rv = mPrefBranch->GetBoolPref("security.storage.keystore.enabled",
+                                &encryptionEnabled);
+  if (NS_SUCCEEDED(rv) && encryptionEnabled) {
+    nsCString aDBKey;
+    key::GetKeyForPath(aPath, aDBKey);
+    path = nsPrintfCString("file:%s?key=%s", aPath, aDBKey.get());
+  } else {
+    path = aPath;
+  }
+
+  nsCOMPtr<mozIStorageAsyncStatement> stmt;
+  rv = CreateAsyncStatement("ATTACH DATABASE :path AS "_ns + nsCString(aName),
+                            getter_AddRefs(stmt));
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  rv = stmt->BindUTF8StringByName("path"_ns, path);
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  nsCOMPtr<mozIStoragePendingStatement> pendingStatement;
+  rv = stmt->ExecuteAsync(aCallback, getter_AddRefs(pendingStatement));
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  pendingStatement.forget(_handle);
+
+  return NS_OK;
 }
 
 NS_IMETHODIMP

--- a/storage/mozStorageConnection.h
+++ b/storage/mozStorageConnection.h
@@ -10,6 +10,7 @@
 #include "nsCOMPtr.h"
 #include "mozilla/Atomics.h"
 #include "mozilla/Mutex.h"
+#include "nsIPrefBranch.h"
 #include "nsProxyRelease.h"
 #include "nsThreadUtils.h"
 #include "nsIInterfaceRequestor.h"
@@ -101,6 +102,15 @@ class Connection final : public mozIStorageConnection,
    *        does not exist.
    */
   nsresult initialize(nsIFile* aDatabaseFile);
+
+  /**
+   * Creates the connection to the encrypted database.
+   *
+   * @param aDatabaseFile
+   *        The nsIFile of the location of the database to open, or create if it
+   *        does not exist.
+   */
+  nsresult initializeSecure(nsIFile* aDatabaseFile);
 
   /**
    * Creates the connection to the database.
@@ -522,6 +532,8 @@ class Connection final : public mozIStorageConnection,
    */
   nsTHashSet<nsCString> mLoadedExtensions
       MOZ_GUARDED_BY(sharedAsyncExecutionMutex);
+
+  nsCOMPtr<nsIPrefBranch> mPrefBranch;
 };
 
 /**

--- a/storage/mozStorageService.cpp
+++ b/storage/mozStorageService.cpp
@@ -645,7 +645,7 @@ Service::OpenUnsharedDatabase(nsIFile* aDatabaseFile, uint32_t aConnectionFlags,
   NS_ENSURE_SUCCESS(rv, rv);
   RefPtr<Connection> msc = new Connection(this, flags, Connection::SYNCHRONOUS,
                                           telemetryFilename, interruptible);
-  rv = msc->initialize(aDatabaseFile);
+  rv = msc->initializeSecure(aDatabaseFile);
   NS_ENSURE_SUCCESS(rv, rv);
 
   msc.forget(_connection);

--- a/toolkit/components/places/Database.cpp
+++ b/toolkit/components/places/Database.cpp
@@ -7,12 +7,14 @@
 #include "mozilla/SpinEventLoopUntil.h"
 #include "mozilla/StaticPrefs_places.h"
 #include "mozilla/glean/PlacesMetrics.h"
+#include "mozilla/security/KeyStorage.h"
 
 #include "Database.h"
 
 #include "nsIInterfaceRequestorUtils.h"
 #include "nsIFile.h"
 
+#include "nsLocalFile.h"
 #include "nsNavBookmarks.h"
 #include "nsNavHistory.h"
 #include "nsPlacesTables.h"
@@ -21,6 +23,7 @@
 #include "nsPlacesMacros.h"
 #include "nsVariant.h"
 #include "SQLFunctions.h"
+#include "ScopedNSSTypes.h"
 #include "Helpers.h"
 #include "nsFaviconService.h"
 
@@ -334,12 +337,40 @@ nsresult SetupDurability(nsCOMPtr<mozIStorageConnection>& aDBConn,
 
 nsresult AttachDatabase(nsCOMPtr<mozIStorageConnection>& aDBConn,
                         const nsACString& aPath, const nsACString& aName) {
+  const char *aPathBuf, *aNameBuf;
+  aPath.GetData(&aPathBuf);
+  aName.GetData(&aNameBuf);
+
+  nsresult rv;
+  nsCString path;
+  nsCOMPtr<nsIPrefBranch> mPrefBranch;
+
+  nsCOMPtr<nsIPrefService> prefs =
+      do_GetService(NS_PREFSERVICE_CONTRACTID, &rv);
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  rv = prefs->GetBranch(nullptr, getter_AddRefs(mPrefBranch));
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  bool encryptionEnabled;
+  rv = mPrefBranch->GetBoolPref("security.storage.keystore.enabled",
+                                &encryptionEnabled);
+  if (NS_SUCCEEDED(rv) && encryptionEnabled) {
+    nsCString aDBKey;
+    storage::key::GetKeyForPath(aPathBuf, aDBKey);
+    path = nsPrintfCString("file:%s?key=%s", aPathBuf, aDBKey.get());
+  } else {
+    path = aPath;
+  }
+
   nsCOMPtr<mozIStorageStatement> stmt;
-  nsresult rv = aDBConn->CreateStatement("ATTACH DATABASE :path AS "_ns + aName,
-                                         getter_AddRefs(stmt));
+  rv = aDBConn->CreateStatement("ATTACH DATABASE :path AS "_ns + aName,
+                                getter_AddRefs(stmt));
   NS_ENSURE_SUCCESS(rv, rv);
-  rv = stmt->BindUTF8StringByName("path"_ns, aPath);
+
+  rv = stmt->BindUTF8StringByName("path"_ns, path);
   NS_ENSURE_SUCCESS(rv, rv);
+
   rv = stmt->Execute();
   NS_ENSURE_SUCCESS(rv, rv);
 

--- a/toolkit/components/places/PlacesSemanticHistoryDatabase.sys.mjs
+++ b/toolkit/components/places/PlacesSemanticHistoryDatabase.sys.mjs
@@ -138,7 +138,7 @@ export class PlacesSemanticHistoryDatabase {
       this.#databaseFolderPath,
       "places.sqlite"
     );
-    await conn.execute(`ATTACH DATABASE '${placesDbPath}' AS places`);
+    await conn.attachDatabase(placesDbPath, "places");
     return conn;
   }
 

--- a/toolkit/modules/Sqlite.sys.mjs
+++ b/toolkit/modules/Sqlite.sys.mjs
@@ -1218,6 +1218,10 @@ ConnectionData.prototype = Object.freeze({
       );
     });
   },
+
+  attachDatabase(path, name) {
+    return this._dbConn.attachDatabase(path, name);
+  },
 });
 
 /**
@@ -2058,6 +2062,10 @@ OpenedConnection.prototype = {
       pagesPerStep,
       stepDelayMs
     );
+  },
+
+  attachDatabase(path, name) {
+    return this._connectionData.attachDatabase(path, name);
   },
 };
 // This is frozen after the prototype has been assigned to allow TypeScript


### PR DESCRIPTION
Encrypt SQLite database whose connections are created in mozStorageService. Cloned and `ATTACH`ed connections are also affected. The mechanism is behind a new `security.storage.keystore.enabled`. The keys for the connections are stored, encrypted by the SDR, in a new `bikeshed/keystore.enc`.