### PR TITLE
Encrypt SQLite databases from mozStorageService

### DIFF
--- a/browser/components/backup/tests/marionette/manifest.toml
+++ b/browser/components/backup/tests/marionette/manifest.toml
@@ -46,3 +46,4 @@ support-files = [
 skip-if = [
   "os == 'linux' && os_version == '22.04' && arch == 'x86_64' && display == 'wayland'", # 1924781: Gnome keyring not unlocked
 ]
+prefs = ["security.storage.encryption.sqlite.enabled=false"]

--- a/browser/components/enterprisepolicies/tests/xpcshell/test_sorted_alphabetically.js
+++ b/browser/components/enterprisepolicies/tests/xpcshell/test_sorted_alphabetically.js
@@ -3,6 +3,8 @@
 
 "use strict";
 
+do_get_profile();
+
 function checkArrayIsSorted(array, msg) {
   let sorted = true;
   let sortedArray = array.slice().sort(function (a, b) {

--- a/dom/cache/Connection.cpp
+++ b/dom/cache/Connection.cpp
@@ -244,6 +244,13 @@ Connection::CreateTable(const char* aTable, const char* aSchema) {
 }
 
 NS_IMETHODIMP
+Connection::AttachDatabase(const char* aPath, const char* aName,
+                           mozIStorageStatementCallback* aCallback,
+                           mozIStoragePendingStatement** _handle) {
+  return mBase->AttachDatabase(aPath, aName, aCallback, _handle);
+}
+
+NS_IMETHODIMP
 Connection::SetGrowthIncrement(int32_t aIncrement,
                                const nsACString& aDatabase) {
   return mBase->SetGrowthIncrement(aIncrement, aDatabase);

--- a/dom/cache/test/marionette/manifest.toml
+++ b/dom/cache/test/marionette/manifest.toml
@@ -3,6 +3,7 @@ subsuite = "integration"
 tags = "inc-origin-init os_integration"
 
 ["test_cacheapi_encryption_PBM.py"]
+prefs = ["security.storage.encryption.sqlite.enabled=false"]
 
 ["test_caches_delete_cleanup_after_shutdown.py"]
 skip-if = [

--- a/dom/cache/test/mochitest/test_cache_padding.html
+++ b/dom/cache/test/mochitest/test_cache_padding.html
@@ -105,7 +105,7 @@ function fetchOpaqueResponse(url) {
 // [3] https://searchfox.org/firefox-main/rev/3aff965e839b7872bf48a9803b80669ca49276ac/security/manager/ssl/TransportSecurityInfo.cpp#114
 // [4] https://searchfox.org/firefox-main/rev/3aff965e839b7872bf48a9803b80669ca49276ac/dom/cache/DBSchema.cpp#255
 function equalOrOffByOneGrowthChunk(a, b, message) {
-  if (SpecialPowers.getBoolPref("browser.privatebrowsing.autostart") && a != b) {
+  if ((SpecialPowers.getBoolPref("browser.privatebrowsing.autostart") || SpecialPowers.getBoolPref("storage.security.sqlite.enabled")) && a != b) {
     b += 32768;
   }
   is(a, b, message);

--- a/dom/indexedDB/test/marionette/manifest.toml
+++ b/dom/indexedDB/test/marionette/manifest.toml
@@ -1,5 +1,6 @@
 [DEFAULT]
 subsuite = "integration"
 tags = "inc-origin-init os_integration"
+prefs = ["security.storage.encryption.sqlite.enabled=false"]
 
 ["test_IDB_encryption_PBM.py"]

--- a/extensions/permissions/PermissionManager.cpp
+++ b/extensions/permissions/PermissionManager.cpp
@@ -36,6 +36,7 @@
 #include "mozIStorageConnection.h"
 #include "mozIStorageStatement.h"
 #include "mozStorageCID.h"
+#include "ScopedNSSTypes.h"
 
 #include "nsAppDirectoryServiceDefs.h"
 #include "nsComponentManagerUtils.h"
@@ -865,6 +866,9 @@ nsresult PermissionManager::Init() {
   }
 
   AddIdleDailyMaintenanceJob();
+
+  MOZ_RELEASE_ASSERT(EnsureNSSInitializedChromeOrContent(),
+                     "Could not initialize NSS.");
 
   MOZ_ASSERT(!mThread);
   NS_ENSURE_SUCCESS(NS_NewNamedThread("Permission", getter_AddRefs(mThread)),

--- a/modules/libpref/init/StaticPrefList.yaml
+++ b/modules/libpref/init/StaticPrefList.yaml
@@ -18224,6 +18224,12 @@
   value: false
   mirror: always
 
+# Enable sqlite database encryption
+- name: security.storage.encryption.sqlite.enabled
+  type: bool
+  value: true
+  mirror: once
+
 - name: security.tls13.aes_128_gcm_sha256
   type: RelaxedAtomicBool
   value: true

--- a/netwerk/base/idna_glue/src/lib.rs
+++ b/netwerk/base/idna_glue/src/lib.rs
@@ -13,7 +13,7 @@ use idna::uts46::ProcessingSuccess;
 use idna::uts46::Uts46;
 use nserror::*;
 use nsstring::*;
-use percent_encoding::percent_decode;
+use percent_encoding::{percent_decode, percent_encode, CONTROLS, AsciiSet};
 
 /// The URL deny list plus asterisk and double quote.
 /// Using AsciiDenyList::URL is https://bugzilla.mozilla.org/show_bug.cgi?id=1815926 .
@@ -258,4 +258,11 @@ pub unsafe extern "C" fn mozilla_net_recover_keyword_from_punycode(
             sink.append(label);
         }
     }
+}
+
+/// Percent-encodes a string.
+#[no_mangle]
+pub unsafe extern "C" fn mozilla_net_percent_encode(src: &nsACString, dst: &mut nsACString) {
+    static CHARS: AsciiSet = CONTROLS.add(b'%');
+    dst.assign(&percent_encode(src, &CHARS).to_string())
 }

--- a/security/keystore/KeyStorage.cpp
+++ b/security/keystore/KeyStorage.cpp
@@ -1,0 +1,60 @@
+/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*-
+ * vim: sw=2 ts=2 et lcs=trail\:.,tab\:>~ :
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "KeyStorage.h"
+
+#include "Persist.h"
+
+#include "mozilla/Logging.h"
+#include "GMPUtils.h"
+#include "nsLocalFile.h"
+#include "ScopedNSSTypes.h"
+
+namespace mozilla::storage::key {
+void Shutdown() { ShutdownStorage(); }
+mozilla::LogModule* GetKeyStorageLog() {
+  static mozilla::LazyLogModule sLog("KeyStorage");
+
+  return sLog;
+}
+
+nsresult GetKeyByPath(const char* aPath, nsCString& aKey) {
+  nsCOMPtr<nsIFile> file = new nsLocalFile();
+  nsresult rv = file->InitWithNativePath(nsCString(aPath));
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  return GetKeyByFile(*file, aKey);
+}
+
+nsresult GetKeyByFile(nsIFile& aFile, nsCString& aKeyString) {
+  nsAutoString profile_path;
+  nsresult rv = GetCurrentProfilePath(profile_path);
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  nsAutoString realFile;
+  rv = aFile.GetPath(realFile);
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  nsCOMPtr<nsIFile> profile = new nsLocalFile();
+  rv = profile->InitWithPath(profile_path);
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  nsAutoCString filename;
+  rv = aFile.GetRelativePath(profile, filename);
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  MOZ_LOG(GetKeyStorageLog(), LogLevel::Debug,
+          ("Fetching key for %s", filename.get()));
+
+  UniqueSECItem key(::SECITEM_AllocItem(nullptr, nullptr, 0));
+  rv = FetchOrCreateKey(filename, key.get());
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  aKeyString = mozilla::ToHexString(key->data, key->len);
+
+  return NS_OK;
+}
+}  // namespace mozilla::storage::key

--- a/security/keystore/KeyStorage.h
+++ b/security/keystore/KeyStorage.h
@@ -1,0 +1,23 @@
+/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*-
+ * vim: sw=2 ts=2 et lcs=trail\:.,tab\:>~ :
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef KeyStorage_h
+#define KeyStorage_h
+
+#include "nsIFile.h"
+#include "nsStringFwd.h"
+#include "mozilla/Logging.h"
+
+namespace mozilla::storage::key {
+void Shutdown();
+
+mozilla::LogModule* GetKeyStorageLog();
+
+nsresult GetKeyByPath(const char* aPath, nsCString& aKey);
+nsresult GetKeyByFile(nsIFile& aFile, nsCString& aKey);
+}  // namespace mozilla::storage::key
+
+#endif  // KeyStorage_h

--- a/security/keystore/Persist.cpp
+++ b/security/keystore/Persist.cpp
@@ -1,0 +1,466 @@
+/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*-
+ * vim: sw=2 ts=2 et lcs=trail\:.,tab\:>~ :
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "Persist.h"
+
+#include "mozilla/Base64.h"
+#include "mozilla/dom/quota/QuotaManager.h"
+#include "mozilla/MozPromise.h"
+#include "mozilla/SyncRunnable.h"
+#include "nsAppDirectoryServiceDefs.h"
+#include "nsCOMPtr.h"
+#include "nsCRTGlue.h"
+#include "nsTHashMap.h"
+#include "nsThreadUtils.h"
+#include "nsHashtablesFwd.h"
+#include "nsIToolkitProfileService.h"
+#include "nsIFile.h"
+#include "nsIProperties.h"
+#include "nsNetUtil.h"
+#include "nsNSSHelper.h"
+#include "NSSErrorsService.h"
+#include "nsServiceManagerUtils.h"
+#include "nsStreamUtils.h"
+#include "pk11sdr.h"
+#include "prerror.h"
+#include "prio.h"
+#include "ScopedNSSTypes.h"
+
+#include "KeyStorage.h"
+
+#define KEYSTORE_MAGIC "# mozilla secure key storage\n"
+#define KEYSTORE_PATH FILE_PATH_SEPARATOR "keystore.db"
+#define SYSTEM_KEY_NAME "system"
+
+namespace mozilla::storage::key {
+
+struct Key {
+  mozilla::UniqueSECItem key;
+  mozilla::UniqueSECItem iv;
+
+  Key() = default;
+
+  Key(mozilla::UniqueSECItem key, mozilla::UniqueSECItem iv)
+      : key(std::move(key)), iv(std::move(iv)) {}
+
+  Key(const Key& other)
+      : key(SECITEM_DupItem(other.key.get())),
+        iv(SECITEM_DupItem(other.iv.get())) {}
+
+  Key(Key&&) = default;
+
+  Key& operator=(Key&&) = default;
+};
+
+mozilla::StaticMutex sKeyMutex;
+MOZ_RUNINIT static nsTHashMap<nsCString, Key> sKeyMap;
+constinit static mozilla::UniquePK11SymKey sSystemKey;
+constinit nsString sProfilePath;
+
+void ShutdownStorage() {
+  mozilla::StaticMutexAutoLock lock(sKeyMutex);
+  sSystemKey.reset(nullptr);
+  sKeyMap.Clear();
+  sProfilePath.Truncate();
+}
+
+void SetCurrentProfilePath(const nsAString& aPath) { sProfilePath = aPath; }
+
+nsresult GetCurrentProfilePath(nsAString& aPath) {
+  if (NS_WARN_IF(sProfilePath.IsEmpty())) {
+    sProfilePath = NS_ConvertUTF8toUTF16(PR_GetEnv("XPCSHELL_TEST_PROFILE_DIR"));
+  }
+  aPath = sProfilePath;
+  return NS_OK;
+}
+
+/// Create path directory for keystore file
+nsresult GetKeyStorePath(nsAString& aPath) {
+  nsresult rv = GetCurrentProfilePath(aPath);
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  aPath.Append(NS_LITERAL_STRING_FROM_CSTRING(KEYSTORE_PATH));
+
+  return NS_OK;
+}
+
+/// Load file contents into string
+nsresult LoadFileToString(const nsCOMPtr<nsIFile>& aFile,
+                          nsACString& aContents) {
+  nsCOMPtr<nsIInputStream> stream;
+  nsresult rv = NS_NewLocalFileInputStream(getter_AddRefs(stream), aFile.get());
+  // Manually return for fnf error, to avoid having a misleading error message
+  // in the logs. This is an expected case, that is handled elsewhere
+  if (rv == NS_ERROR_FILE_NOT_FOUND) return NS_ERROR_FILE_NOT_FOUND;
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  return NS_ConsumeStream(stream, UINT32_MAX, aContents);
+}
+
+/// Open file for appending and write string to it
+nsresult AppendStringToFile(const nsCOMPtr<nsIFile>& aFile,
+                            nsACString& aContents) {
+  nsCOMPtr<nsIOutputStream> stream;
+  nsresult rv = NS_NewLocalFileOutputStream(
+      getter_AddRefs(stream), aFile.get(),
+      PR_WRONLY | PR_CREATE_FILE | PR_APPEND, PR_IRUSR | PR_IWUSR);
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  uint32_t count;
+  rv = stream->Write(aContents.Data(), aContents.Length(), &count);
+  NS_ENSURE_SUCCESS(rv, rv);
+  if (count != aContents.Length()) return NS_ERROR_FAILURE;
+
+  return NS_OK;
+}
+
+/// Import a single, encoded and encrypted key, and encoded IV as `path`
+nsresult ImportKey(const nsCString& aPath, const nsCString& aEncodedKey,
+                   const nsCString& aEncodedIV) {
+  sKeyMutex.AssertCurrentThreadOwns();
+
+  // Key and IV are encoded Base64 strings
+  nsCString encryptedKey, stringIV;
+
+  nsresult rv = mozilla::Base64Decode(aEncodedKey, encryptedKey);
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  rv = mozilla::Base64Decode(aEncodedIV, stringIV);
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  // Key and IV need to go into heap-allocated SECItems, because they may be
+  // stored into sKeyMap, which outlives encryptedKey/stringIV
+  mozilla::UniqueSECItem key(::SECITEM_AllocItem(nullptr, nullptr, 0));
+  SECStatus stat =
+      SECITEM_MakeItem(nullptr, key.get(), (unsigned char*)encryptedKey.Data(),
+                       encryptedKey.Length());
+  if (stat != SECSuccess) return MapSECStatus(stat);
+
+  mozilla::UniqueSECItem iv(::SECITEM_AllocItem(nullptr, nullptr, 0));
+  stat = SECITEM_MakeItem(nullptr, iv.get(), (unsigned char*)stringIV.Data(),
+                          stringIV.Length());
+  if (stat != SECSuccess) return MapSECStatus(stat);
+
+  // Keystore contains one (1) "system" key which encrypts all other keys
+  if (aPath == SYSTEM_KEY_NAME) {
+    mozilla::UniqueSECItem result(::SECITEM_AllocItem(nullptr, nullptr, 0));
+
+    // "System" key is encrypted through the SDR
+    stat = PK11SDR_Decrypt(key.get(), result.get(), nullptr);
+    if (stat != SECSuccess) return MapSECStatus(stat);
+
+    mozilla::UniquePK11SlotInfo slot(PK11_GetInternalSlot());
+    if (!slot) {
+      return NS_ERROR_FAILURE;
+    }
+
+    sSystemKey = mozilla::UniquePK11SymKey(
+        PK11_ImportSymKey(slot.get(), CKM_AES_GCM, PK11_OriginUnwrap,
+                          CKA_ENCRYPT | CKA_DECRYPT, result.get(), nullptr));
+
+    if (!sSystemKey) {
+      return NS_ERROR_FAILURE;
+    }
+  } else {
+    sKeyMap.InsertOrUpdate(aPath, Key{std::move(key), std::move(iv)});
+  }
+
+  return NS_OK;
+}
+
+/// Load keys from keystore file to memory
+nsresult LoadKeysFromDisk() {
+  sKeyMutex.AssertCurrentThreadOwns();
+
+  nsCString fileContents;
+
+  // Get the file to the key store in the profile and turn it into a file ref
+  nsAutoString filePath;
+  nsresult rv = GetKeyStorePath(filePath);
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  if (!sKeyMap.IsEmpty()) {
+    // Keys were loaded on another thread during GetKeyStorePath
+    return NS_OK;
+  }
+
+  nsCOMPtr<nsIFile> file;
+  rv = NS_NewLocalFile(filePath, getter_AddRefs(file));
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  // Load all the file contents into one string
+  rv = LoadFileToString(file, fileContents);
+  if (rv == nsresult::NS_ERROR_FILE_NOT_FOUND) {
+    // Non existent keystore is OK and will be handled outside of this
+    // function
+    return NS_OK;
+  }
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  // Verify keystore file
+  if (fileContents.Find(KEYSTORE_MAGIC) != 0) {
+    return NS_ERROR_INVALID_SIGNATURE;
+  }
+
+  // Go through each line
+  for (const auto& line : fileContents.Split('\n')) {
+    int32_t delimiter1 = line.Find(":"_ns.View());
+    int32_t delimiter2 = line.RFind(":"_ns.View());
+    // Ignore invalid or incomplete lines
+    if (delimiter1 == kNotFound || delimiter1 == delimiter2) continue;
+
+    // Each line holds a path/identifier, a key and an IV
+    nsCString path, encodedKey, encodedIV;
+    path.Assign(line.Data(), delimiter1);
+
+    encodedKey.Assign(line.Data() + delimiter1 + 1,
+                      delimiter2 - delimiter1 - 1);
+
+    encodedIV.Assign(line.Data() + delimiter2 + 1,
+                     line.Length() - delimiter2 - 1);
+
+    rv = ImportKey(path, encodedKey, encodedIV);
+    NS_ENSURE_SUCCESS(rv, rv);
+  }
+  return NS_OK;
+}
+
+/// Create "system" key
+/// `keyOut` will contain the SDR encrypted key bytes
+/// `SYSTEM_KEY` will the a AES-GCM PK11SymKey created from those bytes
+nsresult CreateSystemKey(Key& aKeyOut) {
+  sKeyMutex.AssertCurrentThreadOwns();
+
+  // Every key is 32 bytes long
+  mozilla::UniqueSECItem key =
+      mozilla::UniqueSECItem(::SECITEM_AllocItem(nullptr, nullptr, 32));
+  if (!key) return NS_ERROR_FAILURE;
+
+  // Key data is random
+  SECStatus stat = PK11_GenerateRandom(key->data, key->len);
+  if (stat != SECSuccess) return MapSECStatus(stat);
+
+  mozilla::UniqueSECItem encryptedKey(nullptr);
+
+  mozilla::UniquePK11SlotInfo slot(PK11_GetInternalSlot());
+  if (!slot) {
+    return NS_ERROR_FAILURE;
+  }
+
+  sSystemKey = mozilla::UniquePK11SymKey(
+      PK11_ImportSymKey(slot.get(), CKM_AES_GCM, PK11_OriginUnwrap,
+                        CKA_ENCRYPT | CKA_DECRYPT, key.get(), nullptr));
+
+  if (!sSystemKey) {
+    return NS_ERROR_FAILURE;
+  }
+
+  // Use the default SDR key
+  SECItem keyid = {siBuffer, nullptr, 0};
+
+  // PK11SDR_EncryptWithMechanism will allocate the needed buffer in SECItem
+  encryptedKey.reset(::SECITEM_AllocItem(nullptr, nullptr, 0));
+
+  stat = PK11SDR_EncryptWithMechanism(nullptr, &keyid, CKM_AES_CBC, key.get(),
+                                      encryptedKey.get(), nullptr);
+  if (stat != SECSuccess) return MapSECStatus(stat);
+
+  aKeyOut =
+      Key{std::move(encryptedKey),
+          mozilla::UniqueSECItem(::SECITEM_AllocItem(nullptr, nullptr, 0))};
+
+  return NS_OK;
+}
+
+/// Create a new key
+nsresult CreateKey(nsAutoCString& aIdentifier, Key& aKeyOut) {
+  // Every key is 32 bytes long
+  mozilla::UniqueSECItem key =
+      mozilla::UniqueSECItem(::SECITEM_AllocItem(nullptr, nullptr, 32));
+  if (!key) return NS_ERROR_FAILURE;
+
+  // Key data is random
+  SECStatus stat = PK11_GenerateRandom(key->data, key->len);
+  if (stat != SECSuccess) return MapSECStatus(stat);
+
+  mozilla::UniqueSECItem encryptedKey(nullptr);
+  // IV exists regardless of wether the key is "system"
+  mozilla::UniqueSECItem iv(::SECITEM_AllocItem(nullptr, nullptr, 12));
+  if (!iv) return NS_ERROR_FAILURE;
+
+  // IV data is also random
+  stat = PK11_GenerateRandom(iv->data, iv->len);
+  if (stat != SECSuccess) return MapSECStatus(stat);
+
+  CK_GCM_PARAMS gcm_params;
+  gcm_params.pIv = (CK_BYTE_PTR)iv->data;
+  gcm_params.ulIvLen = iv->len;
+  gcm_params.ulIvBits = iv->len * 8;
+  gcm_params.pAAD = (CK_BYTE_PTR)aIdentifier.get();
+  gcm_params.ulAADLen = aIdentifier.Length();
+  gcm_params.ulTagBits = 128;
+
+  SECItem gcm_item;
+  gcm_item.type = siBuffer;
+  gcm_item.data = (unsigned char*)&gcm_params;
+  gcm_item.len = sizeof(gcm_params);
+
+  // PK11_Encrypt needs an existing buffer
+  encryptedKey.reset(::SECITEM_AllocItem(nullptr, nullptr, 64));
+  if (!encryptedKey) return NS_ERROR_FAILURE;
+
+  unsigned int encrypted_len = 0;
+
+  stat =
+      PK11_Encrypt(sSystemKey.get(), CKM_AES_GCM, &gcm_item, encryptedKey->data,
+                   &encrypted_len, encryptedKey->len, key->data, key->len);
+  if (stat != SECSuccess) return MapSECStatus(stat);
+
+  // Resize buffer to actual length
+  stat = SECITEM_ReallocItemV2(nullptr, encryptedKey.get(), encrypted_len);
+  if (stat != SECSuccess) return MapSECStatus(stat);
+
+  aKeyOut = Key{std::move(encryptedKey), std::move(iv)};
+
+  return NS_OK;
+}
+
+// Append key to key store file, creating it if needed
+nsresult WriteKeyToDisk(nsAutoCString& aIdentifier, Key& aKey) {
+  sKeyMutex.AssertCurrentThreadOwns();
+
+  // Key and IV need Base64 encoding for disk storage
+  nsCString encodedKey, encodedIV;
+  nsresult rv = mozilla::Base64Encode((const char*)aKey.key->data,
+                                      aKey.key->len, encodedKey);
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  rv = mozilla::Base64Encode((const char*)aKey.iv->data, aKey.iv->len,
+                             encodedIV);
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  // Get the file to the key store in the profile and turn it into a file ref
+  nsAutoString filePath;
+  rv = GetKeyStorePath(filePath);
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  nsCOMPtr<nsIFile> file;
+  rv = NS_NewLocalFile(filePath, getter_AddRefs(file));
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  // If the file doesn't exist, we need to write the magic before anything
+  // else
+  bool file_exists;
+  rv = file->Exists(&file_exists);
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  nsCString fileString;
+  if (!file_exists) {
+    fileString.Append(KEYSTORE_MAGIC);
+  }
+
+  nsAutoCString keyEntry =
+      aIdentifier + ":"_ns + encodedKey + ":"_ns + encodedIV + "\n"_ns;
+  fileString.Append(keyEntry);
+
+  return AppendStringToFile(file, fileString);
+}
+
+/// Create "system" key
+nsresult InitializeKeys() {
+  nsAutoCString system(SYSTEM_KEY_NAME);
+
+  Key key = {0, 0};
+
+  nsresult rv = CreateSystemKey(key);
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  rv = WriteKeyToDisk(system, key);
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  return NS_OK;
+}
+
+// Decrypt key with "system" key
+SECStatus DecryptKey(Key& aKey, nsAutoCString& aIdentifier, SECItem* aData) {
+  CK_GCM_PARAMS gcm_params;
+  gcm_params.pIv = (CK_BYTE_PTR)aKey.iv->data;
+  gcm_params.ulIvLen = aKey.iv->len;
+  gcm_params.ulIvBits = aKey.iv->len * 8;
+  gcm_params.pAAD = (CK_BYTE_PTR)aIdentifier.get();
+  gcm_params.ulAADLen = aIdentifier.Length();
+  gcm_params.ulTagBits = 128;
+
+  SECItem gcm_item;
+  gcm_item.type = siBuffer;
+  gcm_item.data = (unsigned char*)&gcm_params;
+  gcm_item.len = sizeof(gcm_params);
+
+  SECITEM_AllocItem(nullptr, aData, 32);
+  if (!aData->data) {
+    PR_SetError(PR_OUT_OF_MEMORY_ERROR, 0);
+    return SECFailure;
+  }
+
+  unsigned int decrypted_len = 0;
+
+  SECStatus stat =
+      PK11_Decrypt(sSystemKey.get(), CKM_AES_GCM, &gcm_item, aData->data,
+                   &decrypted_len, aData->len, aKey.key->data, aKey.key->len);
+
+  aData->len = decrypted_len;
+
+  return stat;
+}
+
+/// Obtain requested key assuming owned mutex
+nsresult FetchOrCreateKey(nsAutoCString& aIdentifier, SECItem* aData) {
+  mozilla::StaticMutexAutoLock lock(sKeyMutex);
+
+  nsresult rv;
+  // Load keys if it hasn't happened yet
+  if (sKeyMap.IsEmpty()) {
+    MOZ_LOG(mozilla::storage::key::GetKeyStorageLog(), mozilla::LogLevel::Debug,
+            ("Reading keys from disk"));
+    rv = LoadKeysFromDisk();
+    NS_ENSURE_SUCCESS(rv, rv);
+    // No keys loaded, so the keystore didn't exist before. Create it!
+    if (sSystemKey == nullptr) {
+      MOZ_LOG(mozilla::storage::key::GetKeyStorageLog(),
+              mozilla::LogLevel::Debug, ("Initializing key storage"));
+      rv = InitializeKeys();
+      NS_ENSURE_SUCCESS(rv, rv);
+    }
+  }
+
+  // Key doesn't exist after keys have been loaded. Create it!
+  if (!sKeyMap.Contains(aIdentifier)) {
+    Key key = {};
+    rv = CreateKey(aIdentifier, key);
+    NS_ENSURE_SUCCESS(rv, rv);
+
+    MOZ_LOG(mozilla::storage::key::GetKeyStorageLog(), mozilla::LogLevel::Debug,
+            ("Writing key to disk: %s", aIdentifier.get()));
+
+    // Copy key. WriteKeyToDisk may halt to wait for another thread to fetch a
+    // key, which needs to know that `identifier` already has a key.
+    sKeyMap.InsertOrUpdate(aIdentifier, Key(key));
+
+    rv = WriteKeyToDisk(aIdentifier, key);
+    NS_ENSURE_SUCCESS(rv, rv);
+  }
+
+  // Decrypt requested key with "system" key
+  // Must be accessed through visitor, because UniqueSECItems can't be
+  // copied and nsTHashMap doesn't return references throught Get()
+  SECStatus stat = sKeyMap.WithEntryHandle(
+      aIdentifier, [&aIdentifier, &aData](auto entryHandle) {
+        return DecryptKey(entryHandle.Data(), aIdentifier, aData);
+      });
+  return MapSECStatus(stat);
+}
+
+}  // namespace mozilla::storage::key

--- a/security/keystore/Persist.h
+++ b/security/keystore/Persist.h
@@ -1,0 +1,24 @@
+/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*-
+ * vim: sw=2 ts=2 et lcs=trail\:.,tab\:>~ :
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef Persist_h
+#define Persist_h
+
+#include "mozilla/StaticMutex.h"
+#include "nsStringFwd.h"
+#include "seccomon.h"
+
+namespace mozilla::storage::key {
+extern mozilla::StaticMutex sKeyMutex;
+
+void ShutdownStorage();
+
+void SetCurrentProfilePath(const nsAString& aPath);
+nsresult GetCurrentProfilePath(nsAString& aPath);
+nsresult FetchOrCreateKey(nsAutoCString& aIdentifier, SECItem* aData);
+}  // namespace mozilla::storage::key
+
+#endif  // Persist_h

--- a/security/keystore/moz.build
+++ b/security/keystore/moz.build
@@ -1,0 +1,39 @@
+# -*- Mode: python; indent-tabs-mode: nil; tab-width: 40 -*-
+# vim: set filetype=python:
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+with Files("**"):
+    BUG_COMPONENT = ("Core", "Security: PSM")
+
+EXPORTS.mozilla.security += [
+    "KeyStorage.h",
+    "Persist.h"
+]
+
+UNIFIED_SOURCES += [
+    "KeyStorage.cpp",
+    "Persist.cpp",
+]
+
+include("/ipc/chromium/chromium-config.mozbuild")
+
+COMPILE_FLAGS['WARNINGS_CXXFLAGS'] += [
+    "-Wextra",
+    "-Wunreachable-code",
+]
+
+# Gecko headers aren't warning-free enough for us to enable these warnings.
+CXXFLAGS += [
+    "-Wno-unused-parameter",
+]
+
+if CONFIG["CC_TYPE"] == "clang-cl":
+    AllowCompilerWarnings()  # workaround for bug 1090497
+
+FINAL_LIBRARY = "xul"
+
+BROWSER_CHROME_MANIFESTS += [
+    "tests/browser/browser.toml",
+]

--- a/security/keystore/tests/browser/browser.toml
+++ b/security/keystore/tests/browser/browser.toml
@@ -1,0 +1,4 @@
+[DEFAULT]
+prefs = ["security.storage.encryption.sqlite.enabled=true"]
+
+["browser_connect.js"]

--- a/security/keystore/tests/browser/browser_connect.js
+++ b/security/keystore/tests/browser/browser_connect.js
@@ -1,0 +1,57 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+// Test that database connections work with enabled keystore encryption.
+
+"use strict";
+
+const lazy = {};
+
+ChromeUtils.defineESModuleGetters(lazy, {
+  Sqlite: "resource://gre/modules/Sqlite.sys.mjs",
+});
+
+add_task(async function testSecurityEnableEncryption() {
+  is(
+    Services.prefs.getBoolPref("security.storage.encryption.sqlite.enabled"),
+    true,
+    "security.storage.encryption.sqlite.enabled should be enabled"
+  );
+
+  let conn = await lazy.Sqlite.openConnection({
+    path: "test_encryption_connect.sqlite",
+  });
+
+  is(conn._connectionData._open, true, "Connection should be open");
+
+  let res = await conn.execute("SELECT 1;");
+  is(res[0].getResultByIndex(0), 1, "'SELECT 1;' should return 1");
+
+  await conn.execute("CREATE TABLE IF NOT EXISTS test (value TEXT);");
+  await conn.execute("INSERT INTO test (value) VALUES ('hello');");
+
+  conn.close();
+
+  let profileDir = await Services.dirsvc.get("ProfD", Ci.nsIFile).hostPath();
+
+  is(
+    await IOUtils.exists(profileDir + "/keystore.db"),
+    true,
+    "bikeshed/keystore.enc should exist"
+  );
+
+  is(
+    await IOUtils.exists(profileDir + "/test_encryption_connect.sqlite"),
+    true,
+    "test_encryption_connect.sqlite should exist"
+  );
+
+  conn = await lazy.Sqlite.openConnection({
+    path: "test_encryption_connect.sqlite",
+  });
+
+  res = await conn.execute("SELECT value FROM test;");
+
+  let values = res.map(row => row.getResultByName("value"));
+  is(values[0], "hello", "Test `value` should be `'hello'`");
+});

--- a/security/moz.build
+++ b/security/moz.build
@@ -8,6 +8,7 @@ with Files("**"):
 DIRS += [
     "/security/lockstore",
     "/security/mls",
+    "/security/keystore",
 ]
 
 with Files("generate*.py"):

--- a/storage/StorageProfileObserver.cpp
+++ b/storage/StorageProfileObserver.cpp
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#include "StorageProfileObserver.h"
+
+#include "mozilla/security/Persist.h"
+#include "nsAppDirectoryServiceDefs.h"
+#include "nsDirectoryServiceUtils.h"
+#include "nsIFile.h"
+
+namespace mozilla::storage {
+
+NS_IMPL_ISUPPORTS(StorageProfileObserver, nsIObserver)
+
+NS_IMETHODIMP
+StorageProfileObserver::Observe(nsISupports* aSubject, const char* aTopic,
+                                const char16_t* aData) {
+  if (strcmp(aTopic, "profile-do-change") != 0) {
+    return NS_OK;
+  }
+  NS_DebugBreak(NS_DEBUG_WARNING, "profile-do-change observed", nullptr, __FILE__, __LINE__);
+
+  nsCOMPtr<nsIFile> profileDir;
+  nsresult rv = NS_GetSpecialDirectory(NS_APP_USER_PROFILE_50_DIR,
+                                       getter_AddRefs(profileDir));
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  nsAutoString path;
+  rv = profileDir->GetPath(path);
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  key::SetCurrentProfilePath(path);
+  return NS_OK;
+}
+
+}  // namespace mozilla::storage

--- a/storage/StorageProfileObserver.h
+++ b/storage/StorageProfileObserver.h
@@ -1,0 +1,25 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef StorageProfileObserver_h
+#define StorageProfileObserver_h
+
+#include "nsIObserver.h"
+
+namespace mozilla::storage {
+
+class StorageProfileObserver final : public nsIObserver {
+ public:
+  NS_DECL_ISUPPORTS
+  NS_DECL_NSIOBSERVER
+
+  StorageProfileObserver() = default;
+
+ private:
+  ~StorageProfileObserver() = default;
+};
+
+}  // namespace mozilla::storage
+
+#endif  // StorageProfileObserver_h

--- a/storage/build/components.conf
+++ b/storage/build/components.conf
@@ -22,4 +22,11 @@ Classes = [
         'constructor': 'mozilla::storage::VacuumManager::getSingleton',
         'categories': {'idle-daily': 'MozStorage Vacuum Manager'},
     },
+    {
+        'cid': '{a4a0a98c-7d3e-4de0-8e1a-6e4c7890f372}',
+        'contract_ids': ['@mozilla.org/storage/profile-observer;1'],
+        'type': 'mozilla::storage::StorageProfileObserver',
+        'headers': ['/storage/StorageProfileObserver.h'],
+        'categories': {'profile-do-change': 'MozStorage Profile Observer'},
+    },
 ]

--- a/storage/moz.build
+++ b/storage/moz.build
@@ -76,6 +76,7 @@ UNIFIED_SOURCES += [
     "QuotaVFS.cpp",
     "ReadOnlyNoLockVFS.cpp",
     "StorageBaseStatementInternal.cpp",
+    "StorageProfileObserver.cpp",
     "VacuumManager.cpp",
     "Variant.cpp",
 ]

--- a/storage/mozIStorageAsyncConnection.idl
+++ b/storage/mozIStorageAsyncConnection.idl
@@ -413,4 +413,22 @@ interface mozIStorageAsyncConnection : nsISupports {
                          in mozIStorageCompletionCallback aCallback,
                          [optional] in unsigned long aPagesPerStep,
                          [optional] in unsigned long aStepDelayMs);
+
+  /**
+   * Attach another database to this connection.
+   *
+   * This has the same effect as if executing ATTACH DATABASE aPath as aName,
+   * but when database encryption is enabled it opens the encrypted database
+   * file with the .enc extension and automatically fetches their key and
+   * decrypts them. See the SQLite documentation for more details.
+   *
+   * @param aPath
+   *        The path to the database file that should be attached. May be in
+   *        URI form.
+   * @param aName
+   *        The name under which the database should be attached.
+   */
+  mozIStoragePendingStatement attachDatabase(in string aPath,
+                                             in string aName,
+                                             [optional] in mozIStorageStatementCallback aCallback);
 };

--- a/storage/mozStorageConnection.cpp
+++ b/storage/mozStorageConnection.cpp
@@ -4,7 +4,10 @@
 
 #include "BaseVFS.h"
 #include "ErrorList.h"
+#include "ScopedNSSTypes.h"
+#include "nsNetUtil.h"
 #include "nsError.h"
+#include "nsLocalFile.h"
 #include "nsThreadUtils.h"
 #include "nsIFile.h"
 #include "nsIFileURL.h"
@@ -19,7 +22,9 @@
 #include "mozilla/ErrorNames.h"
 #include "mozilla/dom/quota/QuotaObject.h"
 #include "mozilla/ScopeExit.h"
+#include "mozilla/security/KeyStorage.h"
 #include "mozilla/SpinEventLoopUntil.h"
+#include "mozilla/StaticPrefs_security.h"
 #include "mozilla/StaticPrefs_storage.h"
 
 #include "mozIStorageCompletionCallback.h"
@@ -248,6 +253,37 @@ void basicFunctionHelper(sqlite3_context* aCtx, int aArgc,
     ::sqlite3_result_error(aCtx, "User function returned invalid data type",
                            -1);
   }
+}
+
+void PreparePathForURI(nsACString& aPath) {
+#ifdef _WIN32
+  if (aPath.Find(R"(\\?\)") == 0) {
+    aPath.Cut(0, 4);
+  }
+
+  aPath.ReplaceChar('\\', '/');
+  if (std::isalpha(aPath[0]) && aPath[1] == ':') aPath.Insert('/', 0);
+#endif
+  nsAutoCString tmp(aPath);
+  mozilla_net_percent_encode(&tmp, &aPath);
+}
+
+nsresult ExtractURIPathAndQuery(const char* uri, nsCString& path,
+                                nsCString& query) {
+  if (strstr(uri, "file:") != uri) {
+    return NS_ERROR_FAILURE;
+  }
+  const char* queryDelim = strstr(uri, "?");
+  // strstr returns nullptr if it can't find "?" or aPath if it is empty
+  if (!queryDelim || queryDelim == uri) {
+    return NS_ERROR_FAILURE;
+  }
+
+  path.AssignASCII(mozilla::Span<const char>(uri + 5, queryDelim));
+  query.AssignASCII(
+      mozilla::Span<const char>(queryDelim + 1, uri + strlen(uri)));
+
+  return NS_OK;
 }
 
 RefPtr<QuotaObject> GetQuotaObject(sqlite3_file* aFile, bool obfuscatingVFS) {
@@ -804,6 +840,7 @@ Connection::Connection(Service* aService, int aFlags,
       mOpenNotExclusive(aOpenNotExclusive),
       mAsyncExecutionThreadShuttingDown(false),
       mConnectionClosed(false),
+      mDatabaseEncrypted(false),
       mGrowthChunkSize(0) {
   MOZ_ASSERT(!mIgnoreLockingMode || mFlags & SQLITE_OPEN_READONLY,
              "Can't ignore locking for a non-readonly connection!");
@@ -1067,6 +1104,10 @@ nsresult Connection::initialize(nsIFile* aDatabaseFile) {
                "Initialize called on already opened database!");
   AUTO_PROFILER_LABEL("Connection::initialize", OTHER);
 
+  if (StaticPrefs::security_storage_encryption_sqlite_enabled_AtStartup()) {
+    return initializeSecure(aDatabaseFile);
+  }
+
   // Do not set mFileURL here since this is database does not have an associated
   // URL.
   mDatabaseFile = aDatabaseFile;
@@ -1098,7 +1139,7 @@ nsresult Connection::initialize(nsIFile* aDatabaseFile) {
     mDBConn = nullptr;
     rv = convertResultCode(srv);
     RecordOpenStatus(rv);
-    return rv;
+    NS_ENSURE_SUCCESS(rv, rv);
   }
 
   rv = initializeInternal();
@@ -1165,6 +1206,17 @@ nsresult Connection::initialize(nsIFileURL* aFileURL) {
                          return true;
                        }));
 
+  if (StaticPrefs::security_storage_encryption_sqlite_enabled_AtStartup()) {
+    // If a key was manually passed already, assume it is correct
+    if (!hasKey) {
+      hasKey = true;
+      nsCString dbKey;
+      rv = key::GetKeyByFile(*mDatabaseFile, dbKey);
+      NS_ENSURE_SUCCESS(rv, rv);
+      spec += (query.IsEmpty() ? "?key="_ns : "&key="_ns) + dbKey;
+    }
+  }
+
   bool exclusive =
       StaticPrefs::storage_sqlite_exclusiveLock_enabled() && !mOpenNotExclusive;
 
@@ -1178,13 +1230,77 @@ nsresult Connection::initialize(nsIFileURL* aFileURL) {
     mDBConn = nullptr;
     rv = convertResultCode(srv);
     RecordOpenStatus(rv);
-    return rv;
+    NS_ENSURE_SUCCESS(rv, rv);
   }
 
   rv = initializeInternal();
   RecordOpenStatus(rv);
   NS_ENSURE_SUCCESS(rv, rv);
 
+  return NS_OK;
+}
+
+nsresult Connection::initializeSecure(nsIFile* aDatabaseFile) {
+  NS_ASSERTION(aDatabaseFile, "Passed null file!");
+  NS_ASSERTION(!connectionReady(),
+               "Initialize called on already opened database!");
+  AUTO_PROFILER_LABEL("Connection::initializeSecure", OTHER);
+
+  MOZ_LOG(key::GetKeyStorageLog(), LogLevel::Debug, ("Initializing NSS"));
+
+  MOZ_RELEASE_ASSERT(EnsureNSSInitializedChromeOrContent(),
+                     "Could not initialize NSS.");
+
+  MOZ_LOG(key::GetKeyStorageLog(), LogLevel::Debug,
+          ("Initializing encrypted database connection"));
+
+  nsresult rv;
+
+  // Do not set mFileURL here since this is database does not have an associated
+  // URL.
+  mDatabaseFile = aDatabaseFile;
+  mDatabaseEncrypted = true;
+
+  nsAutoCString dbPath;
+  {
+    nsAutoString path;
+    rv = aDatabaseFile->GetPath(path);
+    NS_ENSURE_SUCCESS(rv, rv);
+    dbPath = NS_ConvertUTF16toUTF8(path);
+  }
+
+  // Get the key for the database from the key storage.
+  nsCString dbKey;
+  rv = key::GetKeyByFile(*aDatabaseFile, dbKey);
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  MOZ_LOG(key::GetKeyStorageLog(), LogLevel::Debug,
+          ("Fetched database encryption key"));
+
+  PreparePathForURI(dbPath);
+
+  // Create URI to pass key to obfsvfs.
+  nsAutoCString dbSpec =
+      "file:"_ns + dbPath + "?key="_ns + dbKey;
+
+  int srv = ::sqlite3_open_v2(dbSpec.get(), &mDBConn, mFlags | SQLITE_OPEN_URI,
+                              obfsvfs::GetVFSName());
+  if (srv != SQLITE_OK) {
+    MOZ_LOG(key::GetKeyStorageLog(), LogLevel::Debug,
+            ("Initialization failed"));
+    ::sqlite3_close(mDBConn);
+    mDBConn = nullptr;
+    rv = convertResultCode(srv);
+    RecordOpenStatus(rv);
+    NS_ENSURE_SUCCESS(rv, rv);
+  }
+
+  rv = initializeInternal();
+
+  RecordOpenStatus(rv);
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  MOZ_LOG(key::GetKeyStorageLog(), LogLevel::Debug, ("Initialization success"));
   return NS_OK;
 }
 
@@ -1975,6 +2091,16 @@ nsresult Connection::initializeClone(Connection* aClone, bool aReadOnly) {
           rv = aClone->CreateStatement("ATTACH DATABASE :path AS "_ns + name,
                                        getter_AddRefs(attachStmt));
           NS_ENSURE_SUCCESS(rv, rv);
+
+          if (mDatabaseEncrypted) {
+            nsCString aDBKey;
+            rv = key::GetKeyByPath(path.get(), aDBKey);
+            NS_ENSURE_SUCCESS(rv, rv);
+
+            PreparePathForURI(path);
+            // Create a URI to pass the key to obfsvfs
+            path = nsPrintfCString("file:%s?key=%s", path.get(), aDBKey.get());
+          }
           rv = attachStmt->BindUTF8StringByName("path"_ns, path);
           NS_ENSURE_SUCCESS(rv, rv);
           rv = attachStmt->Execute();
@@ -2176,7 +2302,10 @@ Connection::AsyncVacuum(mozIStorageCompletionCallback* aCallback,
 
 NS_IMETHODIMP
 Connection::GetDefaultPageSize(int32_t* _defaultPageSize) {
-  *_defaultPageSize = Service::kDefaultPageSize;
+  if (mDatabaseEncrypted)
+    *_defaultPageSize = 8192;
+  else
+    *_defaultPageSize = Service::kDefaultPageSize;
   return NS_OK;
 }
 
@@ -2583,6 +2712,60 @@ Connection::CreateTable(const char* aTableName, const char* aTableSchema) {
   int srv = executeSql(mDBConn, buf.get());
 
   return convertResultCode(srv);
+}
+
+NS_IMETHODIMP
+Connection::AttachDatabase(const char* aPath, const char* aName,
+                           mozIStorageStatementCallback* aCallback,
+                           mozIStoragePendingStatement** _handle) {
+  nsresult rv;
+  nsCString uri;
+
+  bool encryptionEnabled =
+      StaticPrefs::security_storage_encryption_sqlite_enabled_AtStartup();
+  if (encryptionEnabled) {
+    nsCString dbKey, path, query;
+
+    rv = ExtractURIPathAndQuery(aPath, path, query);
+
+    if (rv == NS_OK) {
+      rv = key::GetKeyByPath(path.get(), dbKey);
+      NS_ENSURE_SUCCESS(rv, rv);
+
+      PreparePathForURI(path);
+
+      uri = nsPrintfCString("file:%s?%s&key=%s", path.get(), query.get(),
+                            dbKey.get());
+    } else {
+      rv = key::GetKeyByPath(aPath, dbKey);
+      NS_ENSURE_SUCCESS(rv, rv);
+
+      nsCString uriString;
+      uriString.AssignASCII(aPath);
+
+      PreparePathForURI(uriString);
+
+      uri = nsPrintfCString("file:%s?key=%s", uriString.get(), dbKey.get());
+    }
+  } else {
+    uri = aPath;
+  }
+
+  nsCOMPtr<mozIStorageAsyncStatement> stmt;
+  rv = CreateAsyncStatement("ATTACH DATABASE :path AS "_ns + nsCString(aName),
+                            getter_AddRefs(stmt));
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  rv = stmt->BindUTF8StringByName("path"_ns, uri);
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  nsCOMPtr<mozIStoragePendingStatement> pendingStatement;
+  rv = stmt->ExecuteAsync(aCallback, getter_AddRefs(pendingStatement));
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  pendingStatement.forget(_handle);
+
+  return NS_OK;
 }
 
 NS_IMETHODIMP

--- a/storage/mozStorageConnection.h
+++ b/storage/mozStorageConnection.h
@@ -8,6 +8,7 @@
 #include "nsCOMPtr.h"
 #include "mozilla/Atomics.h"
 #include "mozilla/Mutex.h"
+#include "nsIPrefBranch.h"
 #include "nsProxyRelease.h"
 #include "nsThreadUtils.h"
 #include "nsIInterfaceRequestor.h"
@@ -108,6 +109,15 @@ class Connection final : public mozIStorageConnection,
    * it does not exist.
    */
   nsresult initialize(nsIFileURL* aFileURL);
+
+  /**
+   * Creates the connection to the encrypted database.
+   *
+   * @param aDatabaseFile
+   *        The nsIFile of the location of the database to open, or create if it
+   *        does not exist.
+   */
+  nsresult initializeSecure(nsIFile* aDatabaseFile);
 
   /**
    * Same as initialize, but to be used on the async thread.
@@ -507,6 +517,11 @@ class Connection final : public mozIStorageConnection,
    * sharedAsyncExecutionMutex.
    */
   bool mConnectionClosed;
+
+  /**
+   * Set to true if the underlying database file is encrypted on disk.
+   */
+  bool mDatabaseEncrypted;
 
   /**
    * Stores the growth increment chunk size, set through SetGrowthIncrement().

--- a/storage/test/unit/xpcshell.toml
+++ b/storage/test/unit/xpcshell.toml
@@ -20,6 +20,7 @@ support-files = [
 ["test_bug-444233.js"]
 
 ["test_cache_size.js"]
+prefs = ["security.storage.encryption.sqlite.enabled=false"]
 
 ["test_chunk_growth.js"]
 # Bug 676981: test fails consistently on Android
@@ -43,6 +44,7 @@ run-if = [
 ["test_connection_interrupt.js"]
 
 ["test_connection_online_backup.js"]
+prefs = ["security.storage.encryption.sqlite.enabled=false"]
 
 ["test_default_journal_size_limit.js"]
 
@@ -59,6 +61,7 @@ run-if = [
 ["test_minimizeMemory.js"]
 
 ["test_page_size_is_32k.js"]
+prefs = ["security.storage.encryption.sqlite.enabled=false"]
 
 ["test_persist_journal.js"]
 
@@ -67,6 +70,7 @@ run-if = [
 ["test_retry_on_busy.js"]
 
 ["test_sqlite_secure_delete.js"]
+prefs = ["security.storage.encryption.sqlite.enabled=false"]
 
 ["test_statement_executeAsync.js"]
 

--- a/toolkit/components/places/ConcurrentConnection.cpp
+++ b/toolkit/components/places/ConcurrentConnection.cpp
@@ -387,26 +387,23 @@ void ConcurrentConnection::SetupConnection() {
 
 nsresult ConcurrentConnection::AttachDatabase(const nsString& aFileName,
                                               const nsCString& aSchemaName) {
-  // No reason to cache this statement, so not using GetStatement here.
-  nsCOMPtr<mozIStorageAsyncStatement> stmt;
-  nsresult rv = mConn->CreateAsyncStatement(
-      "ATTACH DATABASE :path AS "_ns + DATABASE_FAVICONS_SCHEMANAME,
-      getter_AddRefs(stmt));
-  NS_ENSURE_SUCCESS(rv, rv);
-
   nsCOMPtr<nsIFile> databaseFile =
       GetDatabaseFileInProfile(DATABASE_FAVICONS_FILENAME);
-  NS_ENSURE_SUCCESS(rv, rv);
+
   nsString path;
-  rv = databaseFile->GetPath(path);
-  NS_ENSURE_SUCCESS(rv, rv);
-  rv = stmt->BindStringByName("path"_ns, path);
+  nsresult rv = databaseFile->GetPath(path);
   NS_ENSURE_SUCCESS(rv, rv);
 
   nsCOMPtr<mozIStoragePendingStatement> ps;
   nsCOMPtr<mozIStorageStatementCallback> cb = MakeAndAddRef<CallbackOnError>(
       this, &ConcurrentConnection::CloseConnection);
-  rv = stmt->ExecuteAsync(cb, getter_AddRefs(ps));
+
+  NS_ConvertUTF16toUTF8 utf8Path(path);
+
+  const char *cPath = utf8Path.get();
+  const char *cSchema = DATABASE_FAVICONS_SCHEMANAME.AsString().get();
+
+  rv = mConn->AttachDatabase(cPath, cSchema, cb, getter_AddRefs(ps));
   NS_ENSURE_SUCCESS(rv, rv);
 
   return NS_OK;

--- a/toolkit/components/places/Database.cpp
+++ b/toolkit/components/places/Database.cpp
@@ -6,13 +6,16 @@
 #include "mozilla/ScopeExit.h"
 #include "mozilla/SpinEventLoopUntil.h"
 #include "mozilla/StaticPrefs_places.h"
+#include "mozilla/StaticPrefs_security.h"
 #include "mozilla/glean/PlacesMetrics.h"
+#include "mozilla/security/KeyStorage.h"
 
 #include "Database.h"
 
 #include "nsIInterfaceRequestorUtils.h"
 #include "nsIFile.h"
 
+#include "nsLocalFile.h"
 #include "nsNavBookmarks.h"
 #include "nsNavHistory.h"
 #include "nsPlacesTables.h"
@@ -21,6 +24,7 @@
 #include "nsPlacesMacros.h"
 #include "nsVariant.h"
 #include "SQLFunctions.h"
+#include "ScopedNSSTypes.h"
 #include "Helpers.h"
 #include "nsFaviconService.h"
 
@@ -334,12 +338,28 @@ nsresult SetupDurability(nsCOMPtr<mozIStorageConnection>& aDBConn,
 
 nsresult AttachDatabase(nsCOMPtr<mozIStorageConnection>& aDBConn,
                         const nsACString& aPath, const nsACString& aName) {
+  nsresult rv;
+  nsCString path;
+  path = aPath;
+
+  bool encryptionEnabled =
+      StaticPrefs::security_storage_encryption_sqlite_enabled_AtStartup();
+  if (encryptionEnabled) {
+    nsCString dbKey;
+    rv = storage::key::GetKeyByPath(path.get(), dbKey);
+    NS_ENSURE_SUCCESS(rv, rv);
+
+    path = nsPrintfCString("file:%s?key=%s", path.get(), dbKey.get());
+  }
+
   nsCOMPtr<mozIStorageStatement> stmt;
-  nsresult rv = aDBConn->CreateStatement("ATTACH DATABASE :path AS "_ns + aName,
-                                         getter_AddRefs(stmt));
+  rv = aDBConn->CreateStatement("ATTACH DATABASE :path AS "_ns + aName,
+                                getter_AddRefs(stmt));
   NS_ENSURE_SUCCESS(rv, rv);
-  rv = stmt->BindUTF8StringByName("path"_ns, aPath);
+
+  rv = stmt->BindUTF8StringByName("path"_ns, path);
   NS_ENSURE_SUCCESS(rv, rv);
+
   rv = stmt->Execute();
   NS_ENSURE_SUCCESS(rv, rv);
 

--- a/toolkit/components/places/PlacesSemanticHistoryDatabase.sys.mjs
+++ b/toolkit/components/places/PlacesSemanticHistoryDatabase.sys.mjs
@@ -138,7 +138,7 @@ export class PlacesSemanticHistoryDatabase {
       this.#databaseFolderPath,
       "places.sqlite"
     );
-    await conn.execute(`ATTACH DATABASE '${placesDbPath}' AS places`);
+    await conn.attachDatabase(placesDbPath, "places");
     return conn;
   }
 

--- a/toolkit/modules/Sqlite.sys.mjs
+++ b/toolkit/modules/Sqlite.sys.mjs
@@ -1218,6 +1218,20 @@ ConnectionData.prototype = Object.freeze({
       );
     });
   },
+
+  attachDatabase(path, name) {
+    return new Promise((resolve, reject) => {
+      this._dbConn.attachDatabase(path, name, {
+        handleResult(result) {},
+        handleError(error) {
+          reject(error);
+        },
+        handleCompletion(result) {
+          resolve(result);
+        },
+      });
+    });
+  },
 });
 
 /**
@@ -2058,6 +2072,10 @@ OpenedConnection.prototype = {
       pagesPerStep,
       stepDelayMs
     );
+  },
+
+  attachDatabase(path, name) {
+    return this._connectionData.attachDatabase(path, name);
   },
 };
 // This is frozen after the prototype has been assigned to allow TypeScript

--- a/toolkit/profile/nsToolkitProfileService.cpp
+++ b/toolkit/profile/nsToolkitProfileService.cpp
@@ -7,6 +7,7 @@
 #include "mozilla/Preferences.h"
 #include "mozilla/HelperMacros.h"
 #include "mozilla/ScopeExit.h"
+#include "mozilla/security/Persist.h"
 #include "mozilla/Services.h"
 #include "mozilla/UniquePtr.h"
 #include "mozilla/UniquePtrExtensions.h"
@@ -1619,6 +1620,10 @@ nsresult nsToolkitProfileService::SelectStartupProfile(
         mCurrent->GetRootDir(aRootDir);
         mCurrent->GetLocalDir(aLocalDir);
 
+        nsAutoString path;
+        (*aRootDir)->GetPath(path);
+        storage::key::SetCurrentProfilePath(path);
+
         return NS_OK;
       }
     }
@@ -1637,6 +1642,11 @@ nsresult nsToolkitProfileService::SelectStartupProfile(
     lf.forget(aRootDir);
     localDir.forget(aLocalDir);
     NS_IF_ADDREF(*aProfile = profile);
+
+    nsAutoString path;
+    (*aRootDir)->GetPath(path);
+    storage::key::SetCurrentProfilePath(path);
+
     return NS_OK;
   }
 
@@ -1671,6 +1681,10 @@ nsresult nsToolkitProfileService::SelectStartupProfile(
     NS_ENSURE_SUCCESS(rv, rv);
 
     NS_IF_ADDREF(*aProfile = mCurrent);
+
+    nsAutoString path;
+    (*aRootDir)->GetPath(path);
+    storage::key::SetCurrentProfilePath(path);
 
     localDir.forget(aLocalDir);
 
@@ -1726,6 +1740,10 @@ nsresult nsToolkitProfileService::SelectStartupProfile(
 
       mCurrent->GetRootDir(aRootDir);
       mCurrent->GetLocalDir(aLocalDir);
+
+      nsAutoString path;
+      (*aRootDir)->GetPath(path);
+      storage::key::SetCurrentProfilePath(path);
 
       NS_ADDREF(*aProfile = mCurrent);
       return NS_OK;
@@ -1842,6 +1860,10 @@ nsresult nsToolkitProfileService::SelectStartupProfile(
     file.forget(aRootDir);
     localDir.forget(aLocalDir);
 
+    nsAutoString path;
+    (*aRootDir)->GetPath(path);
+    storage::key::SetCurrentProfilePath(path);
+
     // Background tasks never use profiles known to the profile service.
     *aProfile = nullptr;
 
@@ -1938,6 +1960,11 @@ nsresult nsToolkitProfileService::SelectStartupProfile(
             rootDir.forget(aRootDir);
             profile->GetLocalDir(aLocalDir);
             profile.forget(aProfile);
+
+            nsAutoString path;
+            (*aRootDir)->GetPath(path);
+            storage::key::SetCurrentProfilePath(path);
+
             return NS_OK;
           }
 
@@ -1978,6 +2005,10 @@ nsresult nsToolkitProfileService::SelectStartupProfile(
       mCurrent->GetLocalDir(aLocalDir);
       NS_ADDREF(*aProfile = mCurrent);
 
+      nsAutoString path;
+      (*aRootDir)->GetPath(path);
+      storage::key::SetCurrentProfilePath(path);
+
       *aDidCreate = true;
       return NS_OK;
     }
@@ -1999,6 +2030,10 @@ nsresult nsToolkitProfileService::SelectStartupProfile(
   mCurrent->GetRootDir(aRootDir);
   mCurrent->GetLocalDir(aLocalDir);
   NS_ADDREF(*aProfile = mCurrent);
+
+  nsAutoString path;
+  (*aRootDir)->GetPath(path);
+  storage::key::SetCurrentProfilePath(path);
 
   return NS_OK;
 }

--- a/xpcom/build/XPCOMInit.cpp
+++ b/xpcom/build/XPCOMInit.cpp
@@ -77,6 +77,8 @@
 #include "mozilla/LateWriteChecks.h"
 
 #include "mozilla/scache/StartupCache.h"
+#include "mozilla/security/KeyStorage.h"
+#include "mozilla/security/Persist.h"
 
 #include "base/at_exit.h"
 #include "base/command_line.h"
@@ -714,6 +716,8 @@ nsresult ShutdownXPCOM(nsIServiceManager* aServMgr) {
 
   // Release shared memory which might be borrowed by the JS engine.
   xpc::SelfHostedShmem::Shutdown();
+
+  mozilla::storage::key::Shutdown();
 
   // After all threads have been joined and the component manager has been shut
   // down, any remaining objects that could be holding NSS resources (should)


### PR DESCRIPTION
Encrypt SQLite database whose connections are created in mozStorageService. Cloned and `ATTACH`ed connections are also affected. The mechanism is behind a new `security.storage.keystore.enabled`. The keys for the connections are stored, encrypted by the SDR, in a new `bikeshed/keystore.enc`.