### PR TITLE
Don't record file size before downloads complete.

### DIFF
--- a/browser/components/downloads/metrics.yaml
+++ b/browser/components/downloads/metrics.yaml
@@ -104,10 +104,6 @@ downloads:
         description: >
           The MIME type of the downloaded file as reported by the server.
         type: string
-      size_bytes:
-        description: >
-          The size of the downloaded file in bytes.
-        type: quantity
       source_url_domain:
         description: >
           The domain from which the file was downloaded.

--- a/toolkit/components/downloads/DownloadCore.sys.mjs
+++ b/toolkit/components/downloads/DownloadCore.sys.mjs
@@ -705,7 +705,7 @@ Download.prototype = {
 #ifdef MOZ_ENTERPRISE
   /**
    * Records telemetry when a download attempt starts in MOZ_ENTERPRISE builds.
-   * Collects filename, extension, MIME type, file size, source domain, and private browsing status.
+   * Collects filename, extension, MIME type, source domain, and private browsing status.
    */
   _recordDownloadAttempt() {
     try {
@@ -736,7 +736,6 @@ Download.prototype = {
         filename,
         extension: fileExtension,
         mime_type: this.contentType || "",
-        size_bytes: this.totalBytes || 0,
         source_url_domain: sourceDomain,
         is_private: this.source.isPrivate || false,
       });


### PR DESCRIPTION
Should be recorded on completion, not on start.