### PR TITLE
Bug 2003628 - Add a pullRequests policy for Enterprise Firefox

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -49,6 +49,8 @@
 ---
 version: 1
 reporting: checks-v1
+policy:
+    pullRequests: collaborators
 tasks:
     # NOTE: support for actions in ci-admin requires that the `tasks` property be an array *before* JSON-e rendering
     # takes place.


### PR DESCRIPTION
This policy needs to exist on the default branch before the Taskcluster Github service will start attempting to create Decision tasks on PRs.