### PR TITLE
Telemetry gaps downloads

### DIFF
--- a/browser/components/downloads/DownloadsTelemetry.enterprise.sys.mjs
+++ b/browser/components/downloads/DownloadsTelemetry.enterprise.sys.mjs
@@ -234,8 +234,8 @@ export const DownloadsTelemetryEnterprise = {
         file_path: fileInfo.file_path,
         extension: fileInfo.extension,
         mime_type: fileInfo.mime_type,
-        sha256_hash: download.saver.getSha256Hash(),
-        size_bytes: sizeBytes,
+        sha256_hash: download.saver.getSha256Hash() || "",
+        size_bytes: sizeBytes || 0,
         source_url: sourceUrl || "",
         is_private: download.source?.isPrivate || false,
       };

--- a/browser/components/downloads/DownloadsTelemetry.enterprise.sys.mjs
+++ b/browser/components/downloads/DownloadsTelemetry.enterprise.sys.mjs
@@ -226,7 +226,7 @@ export const DownloadsTelemetryEnterprise = {
       // Get file size
       let sizeBytes = download.target?.size;
       if (typeof sizeBytes !== "number" || sizeBytes < 0) {
-        sizeBytes = null;
+        sizeBytes = 0;
       }
 
       const telemetryData = {
@@ -235,7 +235,7 @@ export const DownloadsTelemetryEnterprise = {
         extension: fileInfo.extension,
         mime_type: fileInfo.mime_type,
         sha256_hash: download.saver.getSha256Hash() || "",
-        size_bytes: sizeBytes || 0,
+        size_bytes: sizeBytes,
         source_url: sourceUrl || "",
         is_private: download.source?.isPrivate || false,
       };

--- a/browser/components/downloads/DownloadsTelemetry.enterprise.sys.mjs
+++ b/browser/components/downloads/DownloadsTelemetry.enterprise.sys.mjs
@@ -133,17 +133,19 @@ export const DownloadsTelemetryEnterprise = {
    * Processes file information based on the configured logging policy.
    *
    * @param {string} filename - The filename (basename)
+   * @param {string} file_path - The full path of the file
    * @param {string} extension - The file extension
    * @param {string} mimeType - The MIME type
    * @returns {object} Object with filename, extension, and mime_type based on policy
    */
-  _processFileInfo(filename, extension, mimeType) {
+  _processFileInfo(filename, file_path, extension, mimeType) {
     const policy = this._getFileLoggingPolicy();
 
     switch (policy) {
       case "none":
         return {
           filename: "",
+          file_path: "",
           extension: "",
           mime_type: "",
         };
@@ -152,6 +154,7 @@ export const DownloadsTelemetryEnterprise = {
         // Only log extension and MIME type, no filename
         return {
           filename: "",
+          file_path: "",
           extension: extension || "",
           mime_type: mimeType || "",
         };
@@ -160,6 +163,7 @@ export const DownloadsTelemetryEnterprise = {
       default:
         return {
           filename: filename || "",
+          file_path: file_path || "",
           extension: extension || "",
           mime_type: mimeType || "",
         };
@@ -181,16 +185,17 @@ export const DownloadsTelemetryEnterprise = {
     try {
       // Extract filename from target path
       let filename = null;
-      if (download.target?.path) {
+      let file_path = download.target?.path;
+      if (file_path) {
         try {
           // PathUtils is available as a global WebIDL binding in this context.
-          filename = PathUtils.filename(download.target.path);
+          filename = PathUtils.filename(file_path);
         } catch (pathErr) {
           console.warn(
             `[DownloadsTelemetryEnterprise] PathUtils failed, falling back to split:`,
             pathErr
           );
-          const parts = download.target.path.split(/[/\\]/);
+          const parts = file_path.split(/[/\\]/);
           filename = parts[parts.length - 1] || "";
         }
       }
@@ -208,7 +213,12 @@ export const DownloadsTelemetryEnterprise = {
       let mimeType = download.contentType || "";
 
       // Process file information based on enterprise policy configuration
-      const fileInfo = this._processFileInfo(filename, extension, mimeType);
+      const fileInfo = this._processFileInfo(
+        filename,
+        file_path,
+        extension,
+        mimeType
+      );
 
       // Process source URL based on enterprise policy configuration
       let sourceUrl = this._processSourceUrl(download.source?.url);
@@ -221,6 +231,7 @@ export const DownloadsTelemetryEnterprise = {
 
       const telemetryData = {
         filename: fileInfo.filename,
+        file_path: fileInfo.file_path,
         extension: fileInfo.extension,
         mime_type: fileInfo.mime_type,
         size_bytes: sizeBytes,

--- a/browser/components/downloads/DownloadsTelemetry.enterprise.sys.mjs
+++ b/browser/components/downloads/DownloadsTelemetry.enterprise.sys.mjs
@@ -234,6 +234,7 @@ export const DownloadsTelemetryEnterprise = {
         file_path: fileInfo.file_path,
         extension: fileInfo.extension,
         mime_type: fileInfo.mime_type,
+        sha256_hash: download.saver.getSha256Hash(),
         size_bytes: sizeBytes,
         source_url: sourceUrl || "",
         is_private: download.source?.isPrivate || false,

--- a/browser/components/downloads/metrics.yaml
+++ b/browser/components/downloads/metrics.yaml
@@ -112,9 +112,10 @@ downloads:
         description: >
           The MIME type of the downloaded file as reported by the server.
         type: string
-      source_url_domain:
+      source_url:
         description: >
-          The domain from which the file was downloaded.
+          The download source URL. Collection level configurable via enterprise
+          policy DownloadTelemetryUrlLogging: "full" (default), "domain", or "none".
         type: string
       is_private:
         description: >

--- a/browser/components/downloads/metrics.yaml
+++ b/browser/components/downloads/metrics.yaml
@@ -64,6 +64,10 @@ downloads:
         description: >
           The MIME type of the downloaded file as reported by the server.
         type: string
+      sha256_hash:
+        description: >
+          The SHA256 hash of the downloaded file.
+        type: string
       size_bytes:
         description: >
           The size of the downloaded file in bytes.

--- a/browser/components/downloads/metrics.yaml
+++ b/browser/components/downloads/metrics.yaml
@@ -52,6 +52,10 @@ downloads:
         description: >
           The filename (basename only) of the downloaded file.
         type: string
+      file_path:
+        description: >
+          The download path of the downloaded file.
+        type: string
       extension:
         description: >
           The file extension of the downloaded file (e.g., "pdf", "exe").
@@ -95,6 +99,10 @@ downloads:
       filename:
         description: >
           The filename (basename only) of the downloaded file.
+        type: string
+      file_path:
+        description: >
+          The download path of the downloaded file.
         type: string
       extension:
         description: >

--- a/browser/components/downloads/test/unit/test_DownloadsTelemetry_enterprise.js
+++ b/browser/components/downloads/test/unit/test_DownloadsTelemetry_enterprise.js
@@ -158,6 +158,11 @@ add_task(async function test_enterprise_data_parsing() {
       "Should extract correct filename"
     );
     Assert.equal(
+      event.extra.file_path,
+      "/home/user/Downloads/document.pdf",
+      "Should record correct file path"
+    );
+    Assert.equal(
       event.extra.extension,
       "pdf",
       "Should extract correct extension"

--- a/toolkit/components/downloads/DownloadCore.sys.mjs
+++ b/toolkit/components/downloads/DownloadCore.sys.mjs
@@ -710,7 +710,8 @@ Download.prototype = {
   _recordDownloadAttempt() {
     try {
       // Extract filename from path
-      const pathParts = this.target.path.split(/[/\\]/);
+      const path = this.target.path;
+      const pathParts = path.split(/[/\\]/);
       const filename = pathParts[pathParts.length - 1] || "";
 
       // Extract file extension
@@ -734,6 +735,7 @@ Download.prototype = {
       // Record the telemetry event
       Glean.downloads.downloadAttempt.record({
         filename,
+        file_path: path,
         extension: fileExtension,
         mime_type: this.contentType || "",
         source_url_domain: sourceDomain,

--- a/toolkit/components/downloads/DownloadCore.sys.mjs
+++ b/toolkit/components/downloads/DownloadCore.sys.mjs
@@ -848,7 +848,7 @@ Download.prototype = {
         file_path: fileInfo.file_path,
         extension: fileInfo.extension,
         mime_type: fileInfo.mime_type,
-        source_url: sourceUrl,
+        source_url: sourceUrl || "",
         is_private: this.source.isPrivate || false,
       });
 


### PR DESCRIPTION
Add file path and file hash to download telemetry for enterprise.

Also fix download_attempted telemetry to obey url/file telemetry prefs and use same 'source_url' key.