### PR TITLE
Enable Telemetry in Enterprise builds by default.

### DIFF
--- a/build/mozconfig.common.enterprise
+++ b/build/mozconfig.common.enterprise
@@ -1,6 +1,10 @@
 ac_add_options --enable-application=browser
 ac_add_options --enable-enterprise
 
+# Enterprise builds use Telemetry for security logging,
+# and it goes to the console, so enable it by default.
+ac_add_options MOZ_TELEMETRY_REPORTING=1
+
 ac_add_options --enable-strip
 
 ### For a debug build uncomment below and comment --enable-strip


### PR DESCRIPTION
While we disable legacy Telemetry, Glean Telemetry is used for security events that are logged to the console, so we want to enable it by default.