### PR TITLE
Encode download hash in telemetry as hex string

### DIFF
--- a/browser/components/downloads/DownloadsTelemetry.enterprise.sys.mjs
+++ b/browser/components/downloads/DownloadsTelemetry.enterprise.sys.mjs
@@ -229,12 +229,19 @@ export const DownloadsTelemetryEnterprise = {
         sizeBytes = 0;
       }
 
+      const hashBufferCString = download.saver.getSha256Hash();
+      const hashHex = hashBufferCString
+        ? new Uint8Array(
+            Array.from(hashBufferCString, c => c.charCodeAt(0))
+          ).toHex()
+        : "";
+
       const telemetryData = {
         filename: fileInfo.filename,
         file_path: fileInfo.file_path,
         extension: fileInfo.extension,
         mime_type: fileInfo.mime_type,
-        sha256_hash: download.saver.getSha256Hash() || "",
+        sha256_hash: hashHex,
         size_bytes: sizeBytes,
         source_url: sourceUrl || "",
         is_private: download.source?.isPrivate || false,

--- a/browser/components/downloads/test/unit/test_DownloadsTelemetry_enterprise.js
+++ b/browser/components/downloads/test/unit/test_DownloadsTelemetry_enterprise.js
@@ -131,6 +131,15 @@ add_task(async function test_enterprise_data_parsing() {
       isPrivate: false,
     },
     contentType: "application/pdf",
+    saver: {
+      getSha256Hash() {
+        const hardcodedHash =
+          "1234567890abcdef1234567890abcdeffedcba0987654321fedcba0987654321";
+        const hexIntArray = Uint8Array.fromHex(hardcodedHash);
+        const hashBufferCString = String.fromCharCode.apply(null, hexIntArray);
+        return hashBufferCString;
+      },
+    },
   };
 
   // Disable ping submission to prevent clearing telemetry data before we can inspect it
@@ -171,6 +180,11 @@ add_task(async function test_enterprise_data_parsing() {
       event.extra.mime_type,
       "application/pdf",
       "Should preserve MIME type"
+    );
+    Assert.equal(
+      event.extra.sha256_hash,
+      "1234567890abcdef1234567890abcdeffedcba0987654321fedcba0987654321",
+      "Should record decoded SHA 256 hash"
     );
     Assert.equal(
       event.extra.size_bytes,


### PR DESCRIPTION
The string returned from `getSha256Hash()` was a cstring byte array. We need to encode it as hex to be valid/readable json.