### PR TITLE
FxCI: Grant some scopes for build tasks on enterprise-firefox

### DIFF
--- a/taskcluster/gecko_taskgraph/transforms/build.py
+++ b/taskcluster/gecko_taskgraph/transforms/build.py
@@ -312,8 +312,7 @@ def add_enterprise_secret_scopes(config, jobs):
     """Enterprise builds re-use some secrets from the Gecko trust domain."""
     level = config.params["level"]
     for job in jobs:
-        attributes = job.get("attributes")
-        if "enterprise" in job["name"] or ("update-channel" in attributes.keys() and "enterprise" in attributes["update-channel"]):
+        if config.params["project"] == "enterprise-firefox":
             job.setdefault("scopes", []).extend(
                 [
                     f"secrets:get:project/releng/gecko/build/level-{level}/gls-gapi.data",


### PR DESCRIPTION
We will want PGO at some point so I think we can enable for any build ?