### PR TITLE
ci: use 'baseRepoUrl' when assuming scopes in Decision task

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -418,7 +418,7 @@ tasks:
                           scopes:
                               $switch:
                                   isPullRequest:
-                                      - 'assume:repo:github.com/${event.pull_request.base.repo.full_name}:${eventType}'
+                                      - 'assume:repo:${baseRepoUrl[8:]}:${eventType}'
                                   'eventType == "push"':
                                       - 'assume:repo:${repoUrl[8:]}:branch:${shortRef}'
                           dependencies: []


### PR DESCRIPTION
Minor improvement (syncs with what landed in firefox-main)