### PR TITLE
Allow PRs to all paths in mozilla/enterprise-firefox

### DIFF
--- a/.github/workflows/pr-handler.yml
+++ b/.github/workflows/pr-handler.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Check allowed paths
         id: paths
         continue-on-error: true
-        if: steps.team.outputs.is_member == 'true'
+        if: steps.team.outputs.is_member == 'true' && github.repository != 'mozilla/enterprise-firefox'
         run: |
           PATTERN=$(echo "${ALLOWED_PATHS}" | xargs | tr ' ' '|')
           if gh pr view "${PR}" --json files --jq '.files[].path' | grep -vE "^(${PATTERN})"; then
@@ -70,13 +70,13 @@ jobs:
           fi
 
       - name: Close PR
-        if: steps.team.outputs.is_member != 'true' || steps.paths.outputs.only_allowed != 'true'
+        if: steps.team.outputs.is_member != 'true' || (steps.paths.outputs.only_allowed != 'true' && github.repository != 'mozilla/enterprise-firefox')
         run: |
           gh pr close "${PR}" --comment "(Automated Close) Please do not file pull requests here, see https://firefox-source-docs.mozilla.org/contributing/how_to_submit_a_patch.html"
           gh pr lock "${PR}"
 
       - name: Add Lando link
-        if: (steps.team.outputs.is_member == 'true' && steps.paths.outputs.only_allowed == 'true') && github.event.action == 'opened'
+        if: steps.team.outputs.is_member == 'true' && (steps.paths.outputs.only_allowed == 'true' || github.repository == 'mozilla/enterprise-firefox') && github.event.action == 'opened'
         env:
           #
           # Set the following variables at the repository level [0].


### PR DESCRIPTION
Skip the ALLOWED_PATHS check for the enterprise-firefox repository, allowing team members to submit PRs that modify any files.