### PR TITLE
FxCI: Revert to gecko workers until enterprise scopes are fixed

### DIFF
--- a/taskcluster/config.yml
+++ b/taskcluster/config.yml
@@ -817,7 +817,7 @@ workers:
             os: macosx
             worker-type:
                 by-level:
-                    '3': '{trust-domain}-3-b-osx-arm64'
+                    '3': 'gecko-3-b-osx-arm64'
                     default: 'gecko-1-b-osx-arm64'
         win10-64-2009-hw:
             provisioner: releng-hardware


### PR DESCRIPTION
@ahal this means #301 will have to be re-applied once the scopes are properly sets. All tasks have been failing since: https://treeherder.mozilla.org/jobs?repo=enterprise-firefox&revision=dcf6eb7b405d8521c64f17d5b47922ba0bf471fd