### PR TITLE
Bug 2014470 - Send crash reports to console URL

### DIFF
--- a/browser/branding/branding-common.mozbuild
+++ b/browser/branding/branding-common.mozbuild
@@ -40,3 +40,6 @@ def FirefoxBranding():
         JS_PREFERENCE_FILES += [
             "pref/firefox-enterprise.js",
         ]
+        FINAL_TARGET_FILES[".."].distribution += [
+            "distribution.ini",
+        ]

--- a/browser/branding/enterprise/distribution.ini
+++ b/browser/branding/enterprise/distribution.ini
@@ -1,0 +1,5 @@
+# Default partner distribution configuration file
+# Must be replaced as part of a repack for Enterprise builds
+
+[Preferences]
+enterprise.console.address=https://console.enterfox.eu

--- a/browser/installer/package-manifest.in
+++ b/browser/installer/package-manifest.in
@@ -168,6 +168,9 @@
 @BINPATH@/@MOZ_APP_NAME@
 #endif
 @RESPATH@/application.ini
+#ifdef MOZ_ENTERPRISE
+@RESPATH@/distribution/distribution.ini
+#endif
 #ifdef MOZ_UPDATER
 # update-settings.ini has been removed on macOS.
 #ifndef XP_MACOSX

--- a/browser/moz.configure
+++ b/browser/moz.configure
@@ -40,6 +40,8 @@ imply_option("--with-app-name", "firefox", when="--enable-enterprise")
 imply_option(
     "--with-branding", "browser/branding/enterprise", when="--enable-enterprise"
 )
+# Clear the default value to avoid mozilla.com url compiled into product
+imply_option("--with-crashreporter-url", "", when="--enable-enterprise")
 
 # Set UA name to "Firefox" for enterprise builds
 imply_option("MOZ_APP_UA_NAME", "Firefox", when="--enable-enterprise")

--- a/toolkit/xre/nsAppRunner.cpp
+++ b/toolkit/xre/nsAppRunner.cpp
@@ -4282,6 +4282,12 @@ int XREMain::XRE_mainInit(bool* aExitFlag) {
     }
   }
 
+#if defined(MOZ_ENTERPRISE)
+  XRE_ParseEnterpriseServerURL(*mAppData);
+  // Ignoring nsresult. If console url is not found in a release build, the
+  // default server url is empty and crash reports will fail to submit.
+#endif
+
   // Check sanity and correctness of app data.
 
   if (!mAppData->name) {

--- a/xpcom/build/nsXULAppAPI.h
+++ b/xpcom/build/nsXULAppAPI.h
@@ -250,6 +250,18 @@ nsresult XRE_AddManifestLocation(NSLocationType aType, nsIFile* aLocation);
  */
 nsresult XRE_ParseAppData(nsIFile* aINIFile, mozilla::XREAppData& aAppData);
 
+#if defined(MOZ_ENTERPRISE)
+/**
+ * Parse the distribution.ini file to read the enterprise console address. Use
+ * the console address to build the crash report URL to set in an existing
+ * nsXREAppData structure.
+ *
+ * @param aAppData The nsXREAppData structure on which to set the
+ * crashReporterURL.
+ */
+nsresult XRE_ParseEnterpriseServerURL(mozilla::XREAppData& aAppData);
+#endif
+
 const char* XRE_GeckoProcessTypeToString(GeckoProcessType aProcessType);
 const char* XRE_ChildProcessTypeToAnnotation(GeckoProcessType aProcessType);
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=2014470

Since crash reporting gets started very early before prefs are available, read console url directly from distribution.ini
- Null out the default server used in application.ini.h so that even if the distribution.ini file fails to be loaded, we don't send a crash report to a mozilla.com url.
- Add a default simplified distribution.ini that specifies console.enterfox.eu for local/non-repack builds