### PR TITLE
Bug 2009019 - Don't set 'taskId' when rendering actions

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -401,7 +401,7 @@ tasks:
                                   then: 3
                                   else: 1
                           in:
-                              taskId: '${ownTaskId}'
+                              taskId: {$if: 'eventType != "action"', then: '${ownTaskId}'}
                               taskGroupId: {$if: 'eventType == "action"', then: '${action.taskGroupId}', else: '${ownTaskId}'}
                               schedulerId: '${trustDomain}-level-${level}'
                               created: {$fromNow: ''}


### PR DESCRIPTION
The taskId is implicitly created by the hook service, so we can't define it in the task definition in addition.