### PR TITLE
Show detailed network errors in Felt login UI

### DIFF
--- a/browser/components/enterprise/modules/ConsoleClient.sys.mjs
+++ b/browser/components/enterprise/modules/ConsoleClient.sys.mjs
@@ -240,6 +240,98 @@ export const ConsoleClient = {
   },
 
   /**
+   * Gets the error name for a channel status code.
+   *
+   * @param {number} status - The channel status code
+   * @returns {string} Human-readable error name
+   */
+  _getErrorNameForStatus(status) {
+    try {
+      const nssErrorsService = Cc[
+        "@mozilla.org/nss_errors_service;1"
+      ].getService(Ci.nsINSSErrorsService);
+      return nssErrorsService.getErrorName(status);
+    } catch {
+      // Not an NSS error, check common network error codes
+      const networkErrors = {
+        [Cr.NS_ERROR_UNKNOWN_HOST]: "unknown-host",
+        [Cr.NS_ERROR_CONNECTION_REFUSED]: "connection-refused",
+        [Cr.NS_ERROR_NET_TIMEOUT]: "net-timeout",
+        [Cr.NS_ERROR_NET_RESET]: "net-reset",
+        [Cr.NS_ERROR_NET_INTERRUPT]: "net-interrupt",
+        [Cr.NS_ERROR_OFFLINE]: "offline",
+      };
+      return networkErrors[status] || `error-code-${status}`;
+    }
+  },
+
+  /**
+   * Fetch-like wrapper that exposes detailed network errors.
+   * Uses XMLHttpRequest internally to access channel.status on error,
+   * which native fetch() does not expose.
+   *
+   * Limitations compared to native fetch():
+   * - Response object only has: ok, status, json(), text()
+   * - Missing: statusText, headers, url, redirected, clone(),
+   *   arrayBuffer(), blob(), formData()
+   * - json()/text() can be called multiple times (no body consumption)
+   *
+   * @param {string} url - The URL to fetch
+   * @param {object} options - Fetch-like options
+   * @param {string} [options.method="GET"] - HTTP method
+   * @param {object} [options.headers={}] - Request headers
+   * @param {string|null} [options.body=null] - Request body
+   * @returns {Promise<{ok: boolean, status: number, json: Function, text: Function}>}
+   */
+  _xhrFetch(url, { method = "GET", headers = {}, body = null } = {}) {
+    return new Promise((resolve, reject) => {
+      const xhr = new XMLHttpRequest();
+      xhr.open(method, url, true);
+
+      // Handle both plain objects and Headers instances
+      const headerEntries = Headers.isInstance(headers)
+        ? headers.entries()
+        : Object.entries(headers);
+      for (const [key, value] of headerEntries) {
+        xhr.setRequestHeader(key, value);
+      }
+
+      xhr.onload = () => {
+        const response = {
+          ok: xhr.status >= 200 && xhr.status < 300,
+          status: xhr.status,
+          json() {
+            try {
+              return Promise.resolve(JSON.parse(xhr.responseText));
+            } catch (e) {
+              return Promise.reject(e);
+            }
+          },
+          text: () => Promise.resolve(xhr.responseText),
+        };
+        resolve(response);
+      };
+
+      xhr.onerror = () => {
+        const errorName = xhr.channel
+          ? this._getErrorNameForStatus(xhr.channel.status)
+          : "NetworkError";
+        reject(new TypeError(errorName));
+      };
+
+      xhr.ontimeout = () => {
+        reject(new TypeError("NS_ERROR_NET_TIMEOUT"));
+      };
+
+      xhr.onabort = () => {
+        reject(new TypeError("NS_BINDING_ABORTED"));
+      };
+
+      xhr.send(body);
+    });
+  },
+
+  /**
    * Collect the device posture data and send them to the console.
    *
    * @returns {Promise<{posture: string}>} Token reported by console.
@@ -248,7 +340,7 @@ export const ConsoleClient = {
     const devicePosture = this._collectDevicePosture();
     const url = this.constructURI(this._paths.DEVICE_POSTURE);
 
-    const res = await fetch(url, {
+    const res = await this._xhrFetch(url, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -305,12 +397,13 @@ export const ConsoleClient = {
     const headers = new Headers({});
     const accessToken = await this.getAccessToken();
     headers.set("Authorization", `Bearer ${accessToken}`);
+    headers.set("Accept", "application/json");
     if (jsonBody !== null) {
       headers.set("Content-Type", "application/json");
     }
 
     const url = this.constructURI(path);
-    const res = await fetch(url, {
+    const res = await this._xhrFetch(url, {
       method,
       headers,
       body: jsonBody === null ? undefined : JSON.stringify(jsonBody),
@@ -404,7 +497,7 @@ export const ConsoleClient = {
       let res;
       try {
         const url = this.constructURI(this._paths.TOKEN);
-        res = await fetch(url, {
+        res = await this._xhrFetch(url, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
@@ -417,7 +510,7 @@ export const ConsoleClient = {
         });
       } catch (cause) {
         throw new InvalidAuthError(
-          "Token refresh request failed",
+          `Token refresh request failed: ${cause.message}`,
           "TOKEN_REFRESH_FAILED",
           { cause }
         );

--- a/browser/extensions/felt/content/felt.xhtml
+++ b/browser/extensions/felt/content/felt.xhtml
@@ -82,11 +82,15 @@
           </form>
         </div>
         <div class="felt-browser-error is-hidden">
-          <span
+          <div
             class="felt-browser-error-multiple-crashes is-hidden"
             data-l10n-id="felt-browser-error-multiple-crashes"
           >
-          </span>
+          </div>
+          <div class="felt-browser-error-connection is-hidden">
+            <span data-l10n-id="felt-browser-error-connection"></span>
+            <span class="felt-browser-error-details"></span>
+          </div>
         </div>
         <span
           class="felt-powered-by text-deemphasized"

--- a/browser/extensions/felt/content/locales/felt.ftl
+++ b/browser/extensions/felt/content/locales/felt.ftl
@@ -13,6 +13,15 @@ felt-sso-input-email =
 felt-sso-continue-btn =
     .label = Continue
 felt-browser-error-multiple-crashes = { -brand-short-name } crashed multiple times
+felt-browser-error-connection = Unable to connect to the console. Please contact your administrator.
+
+# Network error details
+felt-error-unknown-host = Server not found
+felt-error-connection-refused = Connection refused
+felt-error-net-timeout = Connection timed out
+felt-error-net-reset = Connection was reset
+felt-error-net-interrupt = Connection was interrupted
+felt-error-offline = Host is offline
 felt-powered-by =
     Powered by { -vendor-short-name }
 # $version is the version of Felt, not Firefox/Enterprise Browser.

--- a/browser/extensions/felt/content/styles/felt.css
+++ b/browser/extensions/felt/content/styles/felt.css
@@ -168,7 +168,13 @@ body:has(#notification-popup-box[open]) .felt:not(#notification-popup-box .felt)
   /* stylelint-disable-next-line */
   left: 8px;
   font-size: medium;
-  /* stylelint-disable-next-line stylelint-plugin-mozilla/use-design-tokens */
-  color: var(--icon-color-critical);
+  color: var(--text-color-error);
   font-weight: var(--font-weight-bold);
+}
+
+.felt-browser-error-details {
+  display: block;
+  font-weight: normal;
+  font-size: small;
+  margin-top: var(--space-xsmall);
 }

--- a/browser/extensions/felt/content/window.js
+++ b/browser/extensions/felt/content/window.js
@@ -20,8 +20,62 @@ ChromeUtils.defineESModuleGetters(lazy, {
 // Will at least make move forward marionette
 Services.obs.notifyObservers(window, "browser-delayed-startup-finished");
 
+const ErrorReport = {
+  _wrapper: null,
+
+  init() {
+    this._wrapper = document.querySelector(".felt-browser-error");
+  },
+
+  reset() {
+    if (!this._wrapper) {
+      return;
+    }
+    if (this._wrapper.classList.contains("is-hidden")) {
+      return;
+    }
+    this._wrapper.classList.add("is-hidden");
+    const errors = this._wrapper.querySelectorAll(
+      ".felt-browser-error > div:not(.is-hidden)"
+    );
+    errors.forEach(e => e.classList.add("is-hidden"));
+  },
+
+  async update(errorType, details = null) {
+    if (!this._wrapper) {
+      return;
+    }
+    const errorElement = this._wrapper.querySelector(`.${errorType}`);
+    if (!errorElement) {
+      return;
+    }
+    if (details) {
+      const detailsElement = errorElement.querySelector(
+        ".felt-browser-error-details"
+      );
+      if (detailsElement) {
+        const l10nId = `felt-error-${details}`;
+        const translated = await document.l10n.formatValue(l10nId);
+        detailsElement.textContent = translated || details;
+      }
+    }
+    errorElement.classList.remove("is-hidden");
+    this._wrapper.classList.remove("is-hidden");
+  },
+};
+
 async function connectToConsole(email) {
-  const posture = await lazy.ConsoleClient.sendDevicePosture();
+  ErrorReport.reset();
+
+  let posture;
+  try {
+    posture = await lazy.ConsoleClient.sendDevicePosture();
+  } catch (err) {
+    console.error(`FeltExtension: Failed to connect to console: ${err}`);
+    ErrorReport.update("felt-browser-error-connection", err.message);
+    return;
+  }
+
   if (!posture) {
     // TODO: Currently we don't check the posture yet. In the future we need to handle rejected device posture
     return;
@@ -101,10 +155,7 @@ function informAboutPotentialStartupFailure() {
   if (window.location.search) {
     const errorClass = new URLSearchParams(window.location.search).get("error");
     if (errorClass) {
-      document
-        .querySelector(".felt-browser-error")
-        .classList.remove("is-hidden");
-      document.querySelector(`.${errorClass}`).classList.remove("is-hidden");
+      ErrorReport.update(errorClass);
     }
   }
 }
@@ -195,6 +246,7 @@ function setupPopupNotifications() {
 window.addEventListener(
   "load",
   () => {
+    ErrorReport.init();
     setupMarionetteEnvironment();
     setupPopupNotifications();
     listenFormEmailSubmission();

--- a/testing/enterprise/felt_browser_console_error.json
+++ b/testing/enterprise/felt_browser_console_error.json
@@ -1,0 +1,3 @@
+{
+  "test_felt_00_connection_error_display": {}
+}

--- a/testing/enterprise/felt_tests.py
+++ b/testing/enterprise/felt_tests.py
@@ -565,7 +565,7 @@ class FeltTests(EnterpriseTestsBase):
                 self._logger.info(f"Zombie found as {self._browser_pid}")
                 return True
 
-    def test_felt_00_chrome_on_email_submit(self, exp):
+    def submit_email(self, email_address="random@mozilla.com"):
         self._driver.set_context("chrome")
         self._logger.info("Submitting email in chrome context ...")
         email = self.get_elem("#felt-form__email")
@@ -580,13 +580,18 @@ class FeltTests(EnterpriseTestsBase):
             arguments[0].dispatchEvent(new Event('input', { bubbles: true }));
             """,
             email,
-            "random@mozilla.com",
+            email_address,
         )
 
         self._logger.info("Submitting email by clicking")
         btn = self.get_elem("#felt-form__sign-in-btn")
         btn.click()
+        self._driver.set_context("content")
 
+    def test_felt_00_chrome_on_email_submit(self, exp):
+        self.submit_email()
+
+        self._driver.set_context("chrome")
         self._logger.info("Email submitted and SSO browser displayed")
         sso_content_ready = self.get_elem(".felt-login__sso")
         assert sso_content_ready, "The SSO content is displayed"

--- a/testing/enterprise/test_felt_browser_console_error.py
+++ b/testing/enterprise/test_felt_browser_console_error.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import sys
+
+from felt_tests import FeltTests
+
+
+class FeltConsoleError(FeltTests):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def teardown(self):
+        if not hasattr(self, "_child_driver"):
+            self._manually_closed_child = True
+        return super().teardown()
+
+    def test_felt_00_connection_error_display(self, exp):
+        console_addr = "http://127.0.0.1:1"
+        self.set_string_pref("enterprise.console.address", console_addr)
+
+        self.submit_email()
+
+        self._driver.set_context("chrome")
+        error = self.get_elem(".felt-browser-error-connection")
+        message = error.get_property("textContent").strip()
+        assert "Unable to connect" in message, f"Unexpected error message: {message}"
+
+        details = self.get_elem(".felt-browser-error-details")
+        details_text = details.get_property("textContent").strip()
+        assert details_text, "No error details shown"
+
+        self._driver.set_context("content")
+        return True
+
+
+if __name__ == "__main__":
+    FeltConsoleError(
+        "felt_browser_console_error.json",
+        firefox=sys.argv[1],
+        geckodriver=sys.argv[2],
+        profile_root=sys.argv[3],
+        cli_args=["-feltUI"],
+    )


### PR DESCRIPTION
When connecting to the enterprise console fails (e.g., due to an expired certificate), the error was a generic "NetworkError when attempting to fetch resource" which made debugging difficult.

This change:
- Adds _xhrFetch() wrapper in ConsoleClient that uses XMLHttpRequest internally to access channel.status (a Gecko extension) on network errors
- Converts status codes to readable names (e.g., SEC_ERROR_EXPIRED_CERTIFICATE) using nsINSSErrorsService
- Displays the specific error in the Felt login UI
- Replaces all fetch() calls with _xhrFetch() for consistent error handling (we could argue about this one)