### PR TITLE
Bug 2010300 - Enable searchfox job on enterprise-firefox.

### DIFF
--- a/.cron.yml
+++ b/.cron.yml
@@ -181,6 +181,7 @@ jobs:
           - mozilla-esr140
           - elm
           - cypress
+          - enterprise-firefox
       # For all non m-c jobs we just run once daily matching the 10 UTC
       # nightly which is designed to align with searchfox's AWS cron
       # jobs (for legacy reasons) rather than trying to align with


### PR DESCRIPTION
For https://bugzilla.mozilla.org/show_bug.cgi?id=2010300

If the automation is using the `.cron.yml` file in this repository, then I think modifying the file here will enable the searchfox jobs there.
Otherwise we would need to apply the change on f-m side.