### PR TITLE
Bug 2006563, Bug 2006564 - Small improvements to FELT login UI email field

### DIFF
--- a/browser/extensions/felt/content/locales/felt.ftl
+++ b/browser/extensions/felt/content/locales/felt.ftl
@@ -9,7 +9,6 @@ felt-sso-title = Sign in
 felt-sso-input-email =
     .description = Use your organizational-issued email
     .label = Work email
-    .accesskey = E
 felt-sso-continue-btn =
     .label = Continue
 felt-browser-error-multiple-crashes = { -brand-short-name } crashed multiple times

--- a/browser/extensions/felt/content/window.js
+++ b/browser/extensions/felt/content/window.js
@@ -84,6 +84,8 @@ async function listenFormEmailSubmission() {
     signInBtn.disabled = emailInput.value.trim() === "";
   });
 
+  emailInput.focus();
+
   // <moz-button> does not trigger the native "submit" event on <form>
   // so we manually handle submission on button click and when Enter is pressed
   signInBtn.addEventListener("click", () => {


### PR DESCRIPTION
- Since access keys are not available in the UI, remove the 'E' access key from "Work email" to avoid confusing underlining of the 'e'.
- Focus the work email field on launch since the only expected interaction is to fill in the field.