### PR TITLE
Fix a couple errors in cron Decision task definitions

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -356,6 +356,7 @@ tasks:
                             'tasks_for in ["action", "cron", "pr-action"]':
                                 ownTaskId: '${ownTaskId}'
                                 ownerEmail: '${tasks_for}@noreply.mozilla.org'
+                                baseRepoUrl: '${repository.url}'
                                 repoUrl: '${repository.url}'
                                 project: '${repository.project}'
                                 ref: '${push.branch}'
@@ -382,8 +383,6 @@ tasks:
                                 baseRev: '${event.pull_request.base.sha}'
                                 headRev: '${event.pull_request.head.sha}'
                                 isPullRequest: true
-                            'tasks_for == "action"':
-                                baseRepoUrl: '${repository.url}'
                             'tasks_for == "pr-action"':
                                 baseRepoUrl: '${repository.base_url}'
                                 eventType: action

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -467,9 +467,9 @@ tasks:
                                                 - "tc-treeherder.v2.${project}-pr.${headRev}"
                                             'eventType == "cron"':
                                                 - "index.${trustDomain}.v2.${project}.latest.taskgraph.decision-${cron.job_name}"
-                                                - "index.${trustDomain}.v2.${project}.revision.${head_sha}.taskgraph.decision-${cron.job_name}"
+                                                - "index.${trustDomain}.v2.${project}.revision.${headRev}.taskgraph.decision-${cron.job_name}"
                                                 # list each cron task on this revision, so actions can find them
-                                                - 'index.${trustDomain}.v2.${project}.revision.${head_sha}.cron.${ownTaskId}'
+                                                - 'index.${trustDomain}.v2.${project}.revision.${headRev}.cron.${ownTaskId}'
                               scopes:
                                   $switch:
                                       isPullRequest:


### PR DESCRIPTION
I noticed the `searchfox-index` cron job was failing to render a Decision task. I validated these fixes against `staging-firefox`.