### PR TITLE
Bug 2010334 - Prepend actions / cron ref with 'refs/heads' to avoid r…

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -359,7 +359,8 @@ tasks:
                                 baseRepoUrl: '${repository.url}'
                                 repoUrl: '${repository.url}'
                                 project: '${repository.project}'
-                                ref: '${push.branch}'
+                                # Prepending 'refs/heads' ensures `run-task` won't attempt to fetch tags.
+                                ref: "refs/heads/${push.branch}"
                                 baseRev: '${push.revision}'
                                 headRev: '${push.revision}'
                       - $switch:


### PR DESCRIPTION
…un-task pulling tags

Without this clue, run-task pulls all tags just in case the passed in ref is a tag, which currently results in a timeout due to how many tags Gecko has.

We know that the value passed in for actions / cron will always be a branch, so we can avoid this by being explicit.