### PR TITLE
Revert "Bug 2012535 - Use public-key-credential on macOS for Enterprise"

### DIFF
--- a/security/mac/hardenedruntime/production/firefox.browser.xml
+++ b/security/mac/hardenedruntime/production/firefox.browser.xml
@@ -25,10 +25,16 @@
     <key>com.apple.security.smartcard</key><true/>
 
     <!-- Required for com.apple.developer.web-browser.public-key-credential -->
+    <!--
+    TODO: DISABLE UNTIL GRANTED OFFICIALLY
     <key>com.apple.application-identifier</key>
     <string>43AQ936H96.org.mozilla.firefox</string>
+    -->
 
     <!-- For platform passkey (webauthn) support -->
+    <!--
+    TODO: DISABLE UNTIL GRANTED OFFICIALLY
     <key>com.apple.developer.web-browser.public-key-credential</key><true/>
+    -->
   </dict>
 </plist>


### PR DESCRIPTION
This reverts commit 57b9710745d481f6b013d3b8bb26b64a71bd019e.