### PR TITLE
Split FeltTests into base class and test methods

### DIFF
--- a/testing/enterprise/felt_tests.py
+++ b/testing/enterprise/felt_tests.py
@@ -351,7 +351,7 @@ def serve(
     )
 
 
-class FeltTests(EnterpriseTestsBase):
+class FeltTestsBase(EnterpriseTestsBase):
     def __init__(
         self,
         json,
@@ -588,6 +588,8 @@ class FeltTests(EnterpriseTestsBase):
         btn.click()
         self._driver.set_context("content")
 
+
+class FeltTests(FeltTestsBase):
     def test_felt_00_chrome_on_email_submit(self, exp):
         self.submit_email()
 

--- a/testing/enterprise/test_felt_browser_console_error.py
+++ b/testing/enterprise/test_felt_browser_console_error.py
@@ -5,10 +5,10 @@
 
 import sys
 
-from felt_tests import FeltTests
+from felt_tests import FeltTestsBase
 
 
-class FeltConsoleError(FeltTests):
+class FeltConsoleError(FeltTestsBase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 


### PR DESCRIPTION
Extract FeltTestsBase with helpers so FeltConsoleError can extend it without inheriting test methods that would change UI state before its own test runs.

Was broken by PR #337