### PR TITLE
Bug 2010334 - pass cron args to the decision task on git projects

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -589,7 +589,8 @@ tasks:
                                                --base-rev='${baseRev}' \
                                                --head-repository='${repoUrl}' \
                                                --head-ref='${ref}' \
-                                               --head-rev='${headRev}'
+                                               --head-rev='${headRev}' \
+                                               ${extraArgs}
 
                                   artifacts:
                                       'public':


### PR DESCRIPTION
We were setting the extraArgs variable but not using it.