### PR TITLE
Bug 2014126 - Remove searchfox android, ios, and wpt jobs.

### DIFF
--- a/taskcluster/gecko_taskgraph/target_tasks.py
+++ b/taskcluster/gecko_taskgraph/target_tasks.py
@@ -1191,11 +1191,8 @@ def target_tasks_searchfox(full_task_graph, parameters, graph_config):
         "searchfox-macosx64-aarch64-searchfox/debug",
         "searchfox-win64-searchfox/opt",
         "searchfox-win64-searchfox/debug",
-        "searchfox-android-aarch64-searchfox/debug",
-        "searchfox-ios-searchfox/debug",
         "source-test-file-metadata-bugzilla-components",
         "source-test-file-metadata-test-info-all",
-        "source-test-wpt-metadata-summary",
     ]
 
 


### PR DESCRIPTION
for [bug 2014126](https://bugzilla.mozilla.org/show_bug.cgi?id=2014126)

As requested, remove android and ios.
Also, apparently no wpt jobs are triggered there, so removed the wpt metadata summary.
