### PR TITLE
Point to new partner repack manifest repos

### DIFF
--- a/taskcluster/config.yml
+++ b/taskcluster/config.yml
@@ -499,11 +499,11 @@ partner-urls:
                     beta|release.*:
                         by-release-level:
                             production: 'git@github.com:mozilla-partners/repack-manifests.git'
-                            staging: 'git@github.com:moz-releng-automation-stage/repack-manifests.git'
+                            staging: 'git@github.com:mozilla-partners/staging-repack-manifests.git'
                     esr.*:
                         by-release-level:
                             production: 'git@github.com:mozilla-partners/esr-repack-manifests.git'
-                            staging: 'git@github.com:moz-releng-automation-stage/esr-repack-manifests.git'
+                            staging: 'git@github.com:mozilla-partners/staging-esr-repack-manifests.git'
     release-partner-attribution:
         by-release-product:
             default: null
@@ -513,11 +513,11 @@ partner-urls:
                     beta|release.*:
                         by-release-level:
                             production: 'git@github.com:mozilla-partners/repack-manifests.git'
-                            staging: 'git@github.com:moz-releng-automation-stage/repack-manifests.git'
+                            staging: 'git@github.com:mozilla-partners/staging-repack-manifests.git'
                     esr.*:
                         by-release-level:
                             production: 'git@github.com:mozilla-partners/esr-repack-manifests.git'
-                            staging: 'git@github.com:moz-releng-automation-stage/esr-repack-manifests.git'
+                            staging: 'git@github.com:mozilla-partners/staging-esr-repack-manifests.git'
     release-eme-free-repack:
         by-release-product:
             default: null
@@ -527,7 +527,7 @@ partner-urls:
                     beta|release.*:
                         by-release-level:
                             production: 'git@github.com:mozilla-partners/mozilla-EME-free-manifest.git'
-                            staging: 'git@github.com:moz-releng-automation-stage/mozilla-EME-free-manifest.git'
+                            staging: 'git@github.com:mozilla-partners/staging-mozilla-EME-free-manifest.git'
     enterprise-repack:
         by-release-product:
             default: null

--- a/taskcluster/config.yml
+++ b/taskcluster/config.yml
@@ -533,11 +533,11 @@ partner-urls:
             default: null
             firefox-enterprise:
                 by-release-type:
-                    default: 'git@github.com:mozilla/enterprise-manifests.git'
+                    default: 'git@github.com:mozilla-partners/staging-enterprise-manifests.git'
                     beta|release.*:
                         by-release-level:
-                            production: 'git@github.com:mozilla/enterprise-manifests.git'
-                            staging: 'git@github.com:mozilla/enterprise-manifests.git'
+                            production: 'git@github.com:mozilla-partners/enterprise-manifests.git'
+                            staging: 'git@github.com:mozilla-partners/staging-enterprise-manifests.git'
 
 
 task-priority:

--- a/taskcluster/gecko_taskgraph/util/partners.py
+++ b/taskcluster/gecko_taskgraph/util/partners.py
@@ -40,7 +40,7 @@ LOGIN_QUERY = """query {
 # Returns the contents of default.xml from a manifest repository
 MANIFEST_QUERY = """query {
   repository(owner:"%(owner)s", name:"%(repo)s") {
-    object(expression: "master:%(file)s") {
+    object(expression: "HEAD:%(file)s") {
       ... on Blob {
         text
       }


### PR DESCRIPTION
Once this lands we should archive `mozilla/enterprise-repack` and `mozilla/enterprise-manifests`.

Anyone who needs access to these repos should file a bug similar to bug 2014233 (requesting access to the `enterprise-partners-admins` team)
