### PR TITLE
Bug 2005147 - Enterprise: Store felt.json next to profiles

### DIFF
--- a/browser/extensions/felt/FeltStorage.sys.mjs
+++ b/browser/extensions/felt/FeltStorage.sys.mjs
@@ -17,7 +17,10 @@ export const FeltStorage = {
    *
    * @type {string}
    */
-  FELT_FILE_PATH: PathUtils.join(PathUtils.profileDir, "felt.json"),
+  FELT_FILE_PATH: PathUtils.join(
+    Services.dirsvc.get("UAppData", Ci.nsIFile).path,
+    "felt.json"
+  ),
 
   async init() {
     this._feltStorage = new lazy.JSONFile({


### PR DESCRIPTION
Make sure to store the felt.json file next to Firefox Enterprise profiles. The FELT profile is living in a temporary directory that may get obliterated any time (especially reboot), defeating the purpose of felt.json in that case.