### PR TITLE
Bug 2014965 - Revert "FxCI: Add shippable stable routes"

### DIFF
--- a/taskcluster/gecko_taskgraph/transforms/task.py
+++ b/taskcluster/gecko_taskgraph/transforms/task.py
@@ -2091,35 +2091,6 @@ def add_android_shippable_multi_index_routes(config, task):
 
 
 @transforms.add
-def add_enterprise_index_routes(config, tasks):
-    for task in tasks:
-        if (
-            not "enterprise" in task["label"]
-            or "upload" in task["label"]
-            or not "shippable" in task["label"]
-            or task["label"].endswith("/debug")
-            or task["label"].startswith("enterprise-test")
-            or task["label"].startswith("test-")
-        ):
-            yield task
-            continue
-
-        routes = task.setdefault("routes", [])
-
-        template = "index.{trust-domain}.v2.{project}.shippable-packages.latest.{product}.{job-name}"
-
-        subs = config.params.copy()
-        subs["job-name"] = task["label"].split("/")[0]
-        subs["product"] = config.params["release_product"]
-        subs["trust-domain"] = config.graph_config["trust-domain"]
-        subs["project"] = get_project_alias(config)
-
-        routes.append(template.format(**subs))
-
-        yield task
-
-
-@transforms.add
 def add_index_routes(config, tasks):
     for task in tasks:
         index = task.get("index", {})

--- a/taskcluster/gecko_taskgraph/util/verify.py
+++ b/taskcluster/gecko_taskgraph/util/verify.py
@@ -393,59 +393,6 @@ def verify_trust_domain_v2_routes(
 
 
 @verifications.add("full_task_graph")
-def verify_trust_domain_v2_routes_enterprise(
-    task, taskgraph, scratch_pad, graph_config, parameters
-):
-    """
-    This function ensures that enterprise specific shippable tasks have stable routes
-    """
-
-    def has_one_route_with(what):
-        found_one_route_with = False
-        for route in routes:
-            if what in route:
-                found_one_route_with = True
-        if not found_one_route_with:
-            raise Exception(
-                f"The following task is missing a route with `{what}`: {task.label} -- {routes}"
-            )
-
-    if not task or not "enterprise" in task.label or task.label.endswith("/debug"):
-        return
-
-    route_prefix = "index.{}.v2".format(graph_config["trust-domain"])
-    task_dict = task.task
-    routes = task_dict.get("routes", [])
-
-    # if "signing" in task.label:
-    #    has_one_route_with(".signed.")
-
-    for route in routes:
-        if not "tc-treeherder" in route and not route.startswith(route_prefix):
-            raise Exception(
-                f"The following task has a route with invalid index `{task.label}`: {route}"
-            )
-
-    if (
-        "upload" in task.label
-        or not "shippable" in task.label
-        or task.label.startswith("enterprise-test")
-        or task.label.startswith("test-")
-        or task.label.startswith("build-signing")
-        or task.label.startswith("build-mac-signing")
-    ):
-        return
-
-    has_one_route_with(".shippable-packages.latest.")
-
-    for route in routes:
-        if "/" in route:
-            raise Exception(
-                f"The following task has a route with invalid index `{task.label}`: {route}"
-            )
-
-
-@verifications.add("full_task_graph")
 def verify_routes_notification_filters(
     task, taskgraph, scratch_pad, graph_config, parameters
 ):


### PR DESCRIPTION
This reverts commit 6adeaa0e6628d46f2280b0a409cf39b608481381.

We dont need anymore this specific shippable-packages index, and it would collide beetween branchees.