### PR TITLE
Bug 2012956 - Restore win11-64-24h2 worker-type alias

### DIFF
--- a/taskcluster/config.yml
+++ b/taskcluster/config.yml
@@ -857,7 +857,7 @@ workers:
             provisioner: '{trust-domain}-t'
             implementation: generic-worker
             os: windows
-            worker-type: '{alias}-alpha'
+            worker-type: '{alias}'
         win11-a64-24h2:
             provisioner: '{trust-domain}-t'
             implementation: generic-worker


### PR DESCRIPTION
We had issues getting IPv6 working on enterprise-t/win11-64-24h2 and defaulted to -alpha pool. We have resolved this and are now ready to revert this change in-tree.