### PR TITLE
Bug 2016062 - use a specific shipping-product for firefox-enterprise builds

### DIFF
--- a/taskcluster/config.yml
+++ b/taskcluster/config.yml
@@ -417,6 +417,7 @@ release-promotion:
         - 'fennec'
         - 'firefox'
         - 'firefox-android'
+        - 'firefox-enterprise'
     rebuild-kinds:
         - docker-image
         - fetch

--- a/taskcluster/gecko_taskgraph/target_tasks.py
+++ b/taskcluster/gecko_taskgraph/target_tasks.py
@@ -491,6 +491,9 @@ def target_tasks_enterprise_firefox_with_tests(
         ):
             return False
 
+        if task.attributes.get("shipping_product") not in (None, "firefox-enterprise"):
+            return False
+
         build_platform = task.attributes.get("build_platform")
         build_type = task.attributes.get("build_type")
         shippable = task.attributes.get("shippable", False)

--- a/taskcluster/kinds/build/linux.yml
+++ b/taskcluster/kinds/build/linux.yml
@@ -62,7 +62,7 @@ linux64-enterprise-shippable/opt:
         enable-build-signing: true
         enable-full-crashsymbols: true
     shipping-phase: build
-    shipping-product: firefox
+    shipping-product: firefox-enterprise
     treeherder:
         platform: linux64-enterprise-shippable/opt
         symbol: Bpgo(Bent)
@@ -114,7 +114,6 @@ linux64-enterprise/opt:
     attributes:
         enable-full-crashsymbols: true
     shipping-phase: build
-    shipping-product: firefox
     treeherder:
         platform: linux64-enterprise/opt
         symbol: Bent
@@ -1875,7 +1874,7 @@ linux64-aarch64-enterprise-shippable/opt:
         enable-full-crashsymbols: true
         skip-verify-test-packaging: true
     shipping-phase: build
-    shipping-product: firefox
+    shipping-product: firefox-enterprise
     treeherder:
         platform: linux64-aarch64-enterprise-shippable/opt
         symbol: Bpgo(Bent)

--- a/taskcluster/kinds/build/macosx.yml
+++ b/taskcluster/kinds/build/macosx.yml
@@ -217,7 +217,7 @@ macosx64-enterprise-shippable/opt:
         enable-build-signing: true
         enable-full-crashsymbols: true
     shipping-phase: build
-    shipping-product: firefox
+    shipping-product: firefox-enterprise
     treeherder:
         platform: osx-cross-enterprise-shippable/opt
         symbol: Bpgo(Bent)
@@ -256,7 +256,6 @@ macosx64-enterprise/opt:
         enable-build-signing: true
         enable-full-crashsymbols: true
     shipping-phase: build
-    shipping-product: firefox
     treeherder:
         platform: osx-cross-enterprise/opt
         symbol: Bent

--- a/taskcluster/kinds/build/windows.yml
+++ b/taskcluster/kinds/build/windows.yml
@@ -485,7 +485,7 @@ win64-enterprise-shippable/opt:
         enable-build-signing: true
         enable-full-crashsymbols: true
     shipping-phase: build
-    shipping-product: firefox
+    shipping-product: firefox-enterprise
     treeherder:
         platform: windows2012-64-enterprise-shippable/opt
         symbol: Bpgo(Bent)
@@ -541,7 +541,6 @@ win64-enterprise/opt:
         enable-build-signing: true
         enable-full-crashsymbols: true
     shipping-phase: build
-    shipping-product: firefox
     treeherder:
         platform: windows2012-64-enterprise/opt
         symbol: Bent

--- a/taskcluster/kinds/enterprise-repack-mac-notarization/kind.yml
+++ b/taskcluster/kinds/enterprise-repack-mac-notarization/kind.yml
@@ -24,6 +24,6 @@ tasks:
         from-deps:
             group-by: partner-repack-ids
             copy-attributes: true
-        shipping-product: firefox
+        shipping-product: firefox-enterprise
         # TODO: shipping-phase: promote
         copy-repack-ids: true

--- a/taskcluster/kinds/enterprise-repack-mac-signing/kind.yml
+++ b/taskcluster/kinds/enterprise-repack-mac-signing/kind.yml
@@ -23,6 +23,6 @@ tasks:
     enterprise-repack-mac-signing:
         from-deps:
             group-by: partner-repack-ids
-        shipping-product: firefox
+        shipping-product: firefox-enterprise
         # TODO: shipping-phase: promote
         repacks-per-chunk: 1

--- a/taskcluster/kinds/enterprise-repack/kind.yml
+++ b/taskcluster/kinds/enterprise-repack/kind.yml
@@ -30,7 +30,7 @@ task-defaults:
             in-tree: "partner-repack"
         chain-of-trust: true
         max-run-time: 7200
-    shipping-product: firefox
+    shipping-product: firefox-enterprise
     shipping-phase: build
     run:
         using: mozharness


### PR DESCRIPTION
Use it in target_tasks_enterprise_firefox_with_tests to avoid scheduling tons of irrelevant firefox-only tasks.