### PR TITLE
Bug 2016108 - index pull-request decision tasks

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -473,6 +473,7 @@ tasks:
                                       - $switch:
                                             isPullRequest:
                                                 - "tc-treeherder.v2.${project}-pr.${headRev}"
+                                                - "index.${trustDomain}.v2.${project}-pr.revision.${headRev}.taskgraph.decision"
                                             'eventType == "push"':
                                                 - "tc-treeherder.v2.${project}.${headRev}"
                                                 - "index.${trustDomain}.v2.${project}.latest.taskgraph.decision"


### PR DESCRIPTION
action tasks rely on this to find the on-push graph, and we can use the `${project}-pr` namespace for this purpose.