### PR TITLE
Bug 2016108 - support action tasks on pull request graphs

### DIFF
--- a/taskcluster/gecko_taskgraph/actions/registry.py
+++ b/taskcluster/gecko_taskgraph/actions/registry.py
@@ -6,6 +6,7 @@ from collections import namedtuple
 from types import FunctionType
 
 from mozbuild.util import memoize
+from mozilla_repo_urls import parse
 from taskgraph import create
 from taskgraph.config import load_graph_config
 from taskgraph.parameters import Parameters
@@ -168,13 +169,17 @@ def register_callback_action(
                 return None
 
             # gather up the common decision-task-supplied data for this action
-            repo_param = "{}head_repository".format(
+            base_repo_param = "{}base_repository".format(
+                graph_config["project-repo-param-prefix"]
+            )
+            head_repo_param = "{}head_repository".format(
                 graph_config["project-repo-param-prefix"]
             )
             repository = {
-                "url": parameters[repo_param],
+                "url": parameters[head_repo_param],
                 "project": parameters["project"],
                 "level": parameters["level"],
+                "base_url": parameters[base_repo_param],
             }
 
             revision = parameters[
@@ -236,10 +241,15 @@ def register_callback_action(
             if "/" in permission:
                 raise Exception("`/` is not allowed in action names; use `-`")
 
+            if parameters["tasks_for"].startswith("github-pull-request"):
+                hookId = f"in-tree-pr-action-{level}-{permission}/{tcyml_hash}"
+            else:
+                hookId = f"in-tree-action-{level}-{permission}/{tcyml_hash}"
+
             rv.update({
                 "kind": "hook",
                 "hookGroupId": f"project-{trustDomain}",
-                "hookId": f"in-tree-action-{level}-{permission}/{tcyml_hash}",
+                "hookId": hookId,
                 "hookPayload": {
                     # provide the decision-task parameters as context for triggerHook
                     "decision": {
@@ -312,15 +322,20 @@ def sanity_check_task_scope(callback, parameters, graph_config):
     else:
         raise Exception(f"No action with cb_name {callback}")
 
-    repo_param = "{}head_repository".format(graph_config["project-repo-param-prefix"])
-    head_repository = parameters[repo_param]
-    expected_scope = f"assume:repo:{head_repository[8:]}:action:{action.permission}"
+    base_repo_param = "{}base_repository".format(graph_config["project-repo-param-prefix"])
+    parsed_base_url = parse(parameters[base_repo_param])
+    head_repo_param = "{}head_repository".format(graph_config["project-repo-param-prefix"])
+    parsed_head_url = parse(parameters[head_repo_param])
+    action_scope = f"assume:{parsed_head_url.taskcluster_role_prefix}:action:{action.permission}"
+    pr_action_scope = f"assume:{parsed_base_url.taskcluster_role_prefix}:pr-action:{action.permission}"
 
     # the scope should appear literally; no need for a satisfaction check. The use of
     # get_current_scopes here calls the auth service through the Taskcluster Proxy, giving
     # the precise scopes available to this task.
-    if expected_scope not in taskcluster.get_current_scopes():
-        raise Exception(f"Expected task scope {expected_scope} for this action")
+    if not set((action_scope, pr_action_scope)) & set(taskcluster.get_current_scopes()):
+        raise ValueError(
+            f"Expected task scope {action_scope} or {pr_action_scope} for this action"
+        )
 
 
 def trigger_action_callback(

--- a/taskcluster/gecko_taskgraph/util/taskgraph.py
+++ b/taskcluster/gecko_taskgraph/util/taskgraph.py
@@ -6,6 +6,7 @@
 Tools for interacting with existing taskgraphs.
 """
 
+from taskcluster import TaskclusterRestFailure
 from taskgraph.util.taskcluster import find_task_id, get_artifact
 
 
@@ -13,13 +14,22 @@ def find_decision_task(parameters, graph_config):
     """Given the parameters for this action, find the taskId of the decision
     task"""
     head_rev_param = "{}head_rev".format(graph_config["project-repo-param-prefix"])
-    return find_task_id(
-        "{}.v2.{}.revision.{}.taskgraph.decision".format(
-            graph_config["trust-domain"],
-            parameters["project"],
-            parameters[head_rev_param],
+    try:
+        return find_task_id(
+            "{}.v2.{}.revision.{}.taskgraph.decision".format(
+                graph_config["trust-domain"],
+                parameters["project"],
+                parameters[head_rev_param],
+            )
         )
-    )
+    except TaskclusterRestFailure:
+        return find_task_id(
+            "{}.v2.{}-pr.revision.{}.taskgraph.decision".format(
+                graph_config["trust-domain"],
+                parameters["project"],
+                parameters[head_rev_param],
+            )
+        )
 
 
 def find_existing_tasks(previous_graph_ids):


### PR DESCRIPTION
Update actions registry to use pr-action hooks for pull-request graphs, and update find_decision_task to be able to find on-push decision tasks indexed in the `{project}-pr` namespace.