### PR TITLE
Bug 2010518 - Derive networking endpoint prefs

### DIFF
--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -1583,9 +1583,10 @@ pref("app.feedback.baseURL", "https://ideas.mozilla.org/");
 
 pref("security.certerrors.permanentOverride", true);
 pref("security.certerrors.mitm.priming.enabled", true);
-pref("security.certerrors.mitm.priming.endpoint", "https://mitmdetection.services.mozilla.com/");
 #ifdef MOZ_ENTERPRISE
 pref("security.certerrors.mitm.priming.endpoint", "");
+#else
+pref("security.certerrors.mitm.priming.endpoint", "https://mitmdetection.services.mozilla.com/");
 #endif
 pref("security.certerrors.mitm.auto_enable_enterprise_roots", true);
 

--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -1584,6 +1584,9 @@ pref("app.feedback.baseURL", "https://ideas.mozilla.org/");
 pref("security.certerrors.permanentOverride", true);
 pref("security.certerrors.mitm.priming.enabled", true);
 pref("security.certerrors.mitm.priming.endpoint", "https://mitmdetection.services.mozilla.com/");
+#ifdef MOZ_ENTERPRISE
+pref("security.certerrors.mitm.priming.endpoint", "");
+#endif
 pref("security.certerrors.mitm.auto_enable_enterprise_roots", true);
 
 // Whether the bookmark panel should be shown when bookmarking a page.

--- a/browser/components/BrowserComponents.manifest
+++ b/browser/components/BrowserComponents.manifest
@@ -22,6 +22,9 @@ category browser-before-ui-startup resource:///modules/AboutHomeStartupCache.sys
 category browser-before-ui-startup resource:///modules/AccountsGlue.sys.mjs AccountsGlue.init
 category browser-before-ui-startup moz-src:///browser/modules/ObserverForwarder.sys.mjs ObserverForwarder.init
 category browser-before-ui-startup moz-src:///browser/components/ipprotection/IPProtectionService.sys.mjs IPProtectionService.maybeEarlyInit
+#ifdef MOZ_ENTERPRISE
+category browser-before-ui-startup resource:///modules/enterprise/EnterpriseEndpoints.sys.mjs EnterpriseEndpoints.init
+#endif
 
 # Browser window lifecycle consumers
 category browser-window-domcontentloaded-before-tabbrowser resource:///modules/BrowserDOMWindow.sys.mjs BrowserDOMWindow.setupInWindow

--- a/browser/components/enterprise/EnterpriseEndpoints.sys.mjs
+++ b/browser/components/enterprise/EnterpriseEndpoints.sys.mjs
@@ -7,19 +7,19 @@ const CONSOLE_ADDRESS_PREF = "enterprise.console.address";
 const ENDPOINT_PREFS = [
   {
     pref: "security.certerrors.mitm.priming.endpoint",
-    path: "/api/misc/mitm/",
+    path: "api/misc/mitm/",
   },
   {
     pref: "captivedetect.canonicalURL",
-    path: "/api/misc/portal/canonical.html",
+    path: "api/misc/portal/canonical.html",
   },
   {
     pref: "network.connectivity-service.IPv4.url",
-    path: "/api/misc/connectivity?ipv4",
+    path: "api/misc/connectivity?ipv4",
   },
   {
     pref: "network.connectivity-service.IPv6.url",
-    path: "/api/misc/connectivity?ipv6",
+    path: "api/misc/connectivity?ipv6",
   },
 ];
 

--- a/browser/components/enterprise/EnterpriseEndpoints.sys.mjs
+++ b/browser/components/enterprise/EnterpriseEndpoints.sys.mjs
@@ -1,0 +1,49 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const CONSOLE_ADDRESS_PREF = "enterprise.console.address";
+
+const ENDPOINT_PREFS = [
+  {
+    pref: "security.certerrors.mitm.priming.endpoint",
+    path: "/api/misc/mitm/",
+  },
+  {
+    pref: "captivedetect.canonicalURL",
+    path: "/api/misc/portal/canonical.html",
+  },
+  {
+    pref: "network.connectivity-service.IPv4.url",
+    path: "/api/misc/connectivity?ipv4",
+  },
+  {
+    pref: "network.connectivity-service.IPv6.url",
+    path: "/api/misc/connectivity?ipv6",
+  },
+];
+
+export const EnterpriseEndpoints = {
+  init() {
+    const consoleAddress = Services.prefs.getStringPref(
+      CONSOLE_ADDRESS_PREF,
+      ""
+    );
+    if (!consoleAddress) {
+      return;
+    }
+
+    let baseURL;
+    try {
+      baseURL = new URL(consoleAddress);
+    } catch {
+      return;
+    }
+
+    const defaultBranch = Services.prefs.getDefaultBranch("");
+    for (const { pref, path } of ENDPOINT_PREFS) {
+      const url = new URL(path, baseURL).href;
+      defaultBranch.setStringPref(pref, url);
+    }
+  },
+};

--- a/browser/components/enterprise/moz.build
+++ b/browser/components/enterprise/moz.build
@@ -9,9 +9,12 @@ with Files("**"):
 
 EXTRA_JS_MODULES.enterprise += [
     "EnterpriseCommon.sys.mjs",
+    "EnterpriseEndpoints.sys.mjs",
     "EnterpriseHandler.sys.mjs",
     "modules/ConsoleClient.sys.mjs",
     "modules/EnterpriseAccountsStorage.sys.mjs",
 ]
 
 JAR_MANIFESTS += ["jar.mn"]
+
+XPCSHELL_TESTS_MANIFESTS += ["tests/xpcshell/xpcshell.toml"]

--- a/browser/components/enterprise/tests/xpcshell/test_enterprise_endpoints.js
+++ b/browser/components/enterprise/tests/xpcshell/test_enterprise_endpoints.js
@@ -1,0 +1,126 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+const { AppConstants } = ChromeUtils.importESModule(
+  "resource://gre/modules/AppConstants.sys.mjs"
+);
+
+const CONSOLE_ADDRESS_PREF = "enterprise.console.address";
+
+const ENDPOINT_PREFS = [
+  {
+    pref: "security.certerrors.mitm.priming.endpoint",
+    path: "/api/misc/mitm/",
+  },
+  {
+    pref: "captivedetect.canonicalURL",
+    path: "/api/misc/portal/canonical.html",
+  },
+  {
+    pref: "network.connectivity-service.IPv4.url",
+    path: "/api/misc/connectivity?ipv4",
+  },
+  {
+    pref: "network.connectivity-service.IPv6.url",
+    path: "/api/misc/connectivity?ipv6",
+  },
+];
+
+const { EnterpriseEndpoints } = ChromeUtils.importESModule(
+  "resource:///modules/enterprise/EnterpriseEndpoints.sys.mjs"
+);
+
+function clear_state() {
+  Services.prefs.clearUserPref(CONSOLE_ADDRESS_PREF);
+  for (const { pref } of ENDPOINT_PREFS) {
+    Services.prefs.clearUserPref(pref);
+    Services.prefs.getDefaultBranch("").setStringPref(pref, "");
+  }
+}
+
+add_setup(async function () {
+  registerCleanupFunction(() => {
+    clear_state();
+  });
+});
+
+add_task(clear_state);
+
+add_task(
+  {
+    skip_if: () => !AppConstants.MOZ_ENTERPRISE,
+  },
+  async function test_endpoints_derived_from_console_address() {
+    Services.prefs.setStringPref(
+      CONSOLE_ADDRESS_PREF,
+      "https://console.example.com"
+    );
+
+    EnterpriseEndpoints.init();
+
+    for (const { pref, path } of ENDPOINT_PREFS) {
+      Assert.equal(
+        Services.prefs.getStringPref(pref),
+        `https://console.example.com${path}`,
+        `${pref} should be derived from console address`
+      );
+    }
+  }
+);
+add_task(clear_state);
+
+add_task(
+  {
+    skip_if: () => !AppConstants.MOZ_ENTERPRISE,
+  },
+  async function test_empty_console_address_leaves_prefs_empty() {
+    Services.prefs.setStringPref(CONSOLE_ADDRESS_PREF, "");
+
+    EnterpriseEndpoints.init();
+
+    for (const { pref } of ENDPOINT_PREFS) {
+      Assert.equal(
+        Services.prefs.getStringPref(pref),
+        "",
+        `${pref} should remain empty when console address is empty`
+      );
+    }
+  }
+);
+add_task(clear_state);
+
+add_task(
+  {
+    skip_if: () => !AppConstants.MOZ_ENTERPRISE,
+  },
+  async function test_user_value_not_clobbered() {
+    Services.prefs.setStringPref(
+      CONSOLE_ADDRESS_PREF,
+      "https://console.example.com"
+    );
+    Services.prefs.setStringPref(
+      "security.certerrors.mitm.priming.endpoint",
+      "https://custom.example.com/mitm"
+    );
+
+    EnterpriseEndpoints.init();
+
+    Assert.equal(
+      Services.prefs.getStringPref("security.certerrors.mitm.priming.endpoint"),
+      "https://custom.example.com/mitm",
+      "User-set pref should not be overwritten by default-branch derivation"
+    );
+
+    const defaultValue = Services.prefs
+      .getDefaultBranch("")
+      .getStringPref("security.certerrors.mitm.priming.endpoint");
+    Assert.equal(
+      defaultValue,
+      "https://console.example.com/api/misc/mitm/",
+      "Default branch should still have the derived value"
+    );
+  }
+);
+add_task(clear_state);

--- a/browser/components/enterprise/tests/xpcshell/test_enterprise_endpoints.js
+++ b/browser/components/enterprise/tests/xpcshell/test_enterprise_endpoints.js
@@ -12,19 +12,19 @@ const CONSOLE_ADDRESS_PREF = "enterprise.console.address";
 const ENDPOINT_PREFS = [
   {
     pref: "security.certerrors.mitm.priming.endpoint",
-    path: "/api/misc/mitm/",
+    path: "api/misc/mitm/",
   },
   {
     pref: "captivedetect.canonicalURL",
-    path: "/api/misc/portal/canonical.html",
+    path: "api/misc/portal/canonical.html",
   },
   {
     pref: "network.connectivity-service.IPv4.url",
-    path: "/api/misc/connectivity?ipv4",
+    path: "api/misc/connectivity?ipv4",
   },
   {
     pref: "network.connectivity-service.IPv6.url",
-    path: "/api/misc/connectivity?ipv6",
+    path: "api/misc/connectivity?ipv6",
   },
 ];
 
@@ -63,7 +63,7 @@ add_task(
     for (const { pref, path } of ENDPOINT_PREFS) {
       Assert.equal(
         Services.prefs.getStringPref(pref),
-        `https://console.example.com${path}`,
+        `https://console.example.com/${path}`,
         `${pref} should be derived from console address`
       );
     }

--- a/browser/components/enterprise/tests/xpcshell/xpcshell.toml
+++ b/browser/components/enterprise/tests/xpcshell/xpcshell.toml
@@ -1,0 +1,4 @@
+[DEFAULT]
+firefox-appdir = "browser"
+
+["test_enterprise_endpoints.js"]

--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -3283,11 +3283,12 @@ pref("network.connectivity-service.enabled", true);
 pref("network.connectivity-service.DNSv4.domain", "example.org");
 pref("network.connectivity-service.DNSv6.domain", "example.org");
 pref("network.connectivity-service.DNS_HTTPS.domain", "cloudflare-dns.com");
-pref("network.connectivity-service.IPv4.url", "http://detectportal.firefox.com/success.txt?ipv4");
-pref("network.connectivity-service.IPv6.url", "http://detectportal.firefox.com/success.txt?ipv6");
 #ifdef MOZ_ENTERPRISE
 pref("network.connectivity-service.IPv4.url", "");
 pref("network.connectivity-service.IPv6.url", "");
+#else
+pref("network.connectivity-service.IPv4.url", "http://detectportal.firefox.com/success.txt?ipv4");
+pref("network.connectivity-service.IPv6.url", "http://detectportal.firefox.com/success.txt?ipv6");
 #endif
 
 pref("network.trr.uri", "");
@@ -3305,9 +3306,10 @@ pref("network.trr.builtin-excluded-domains", "localhost,local");
 // Used for progressive rollout of LNA for ETP strict users
 pref("network.lna.etp.enabled", true);
 
-pref("captivedetect.canonicalURL", "http://detectportal.firefox.com/canonical.html");
 #ifdef MOZ_ENTERPRISE
 pref("captivedetect.canonicalURL", "");
+#else
+pref("captivedetect.canonicalURL", "http://detectportal.firefox.com/canonical.html");
 #endif
 pref("captivedetect.canonicalContent", "<meta http-equiv=\"refresh\" content=\"0;url=https://support.mozilla.org/kb/captive-portal\"/>");
 pref("captivedetect.maxWaitingTime", 5000);

--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -3285,6 +3285,10 @@ pref("network.connectivity-service.DNSv6.domain", "example.org");
 pref("network.connectivity-service.DNS_HTTPS.domain", "cloudflare-dns.com");
 pref("network.connectivity-service.IPv4.url", "http://detectportal.firefox.com/success.txt?ipv4");
 pref("network.connectivity-service.IPv6.url", "http://detectportal.firefox.com/success.txt?ipv6");
+#ifdef MOZ_ENTERPRISE
+pref("network.connectivity-service.IPv4.url", "");
+pref("network.connectivity-service.IPv6.url", "");
+#endif
 
 pref("network.trr.uri", "");
 // credentials to pass to DOH end-point
@@ -3302,6 +3306,9 @@ pref("network.trr.builtin-excluded-domains", "localhost,local");
 pref("network.lna.etp.enabled", true);
 
 pref("captivedetect.canonicalURL", "http://detectportal.firefox.com/canonical.html");
+#ifdef MOZ_ENTERPRISE
+pref("captivedetect.canonicalURL", "");
+#endif
 pref("captivedetect.canonicalContent", "<meta http-equiv=\"refresh\" content=\"0;url=https://support.mozilla.org/kb/captive-portal\"/>");
 pref("captivedetect.maxWaitingTime", 5000);
 pref("captivedetect.pollingTime", 3000);


### PR DESCRIPTION
Instead of hardcoding MITM detection, captive portal, and connectivity check URLs, derive them from enterprise.console.address at startup. The defaults are cleared in enterprise builds and EnterpriseEndpoints sets them on the default pref branch so user overrides take precedence.