### PR TITLE
Bug 2016108 - also index action tasks on pull requests

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -483,6 +483,7 @@ tasks:
                                                 - "index.${trustDomain}.v2.${project}.revision.${headRev}.taskgraph.actions.${ownTaskId}"
                                             'tasks_for == "pr-action"':
                                                 - "tc-treeherder.v2.${project}-pr.${headRev}"
+                                                - "index.${trustDomain}.v2.${project}-pr.revision.${headRev}.taskgraph.actions.${ownTaskId}"
                                             'eventType == "cron"':
                                                 - "index.${trustDomain}.v2.${project}.latest.taskgraph.decision-${cron.job_name}"
                                                 - "index.${trustDomain}.v2.${project}.revision.${headRev}.taskgraph.decision-${cron.job_name}"

--- a/taskcluster/gecko_taskgraph/actions/util.py
+++ b/taskcluster/gecko_taskgraph/actions/util.py
@@ -194,6 +194,15 @@ def fetch_graph_and_labels(parameters, graph_config):
         for task_id in list_tasks(namespace):
             fetches.append(e.submit(fetch_action, task_id))
 
+        if not fetches:
+            pr_namespace = "{}.v2.{}-pr.revision.{}.taskgraph.actions".format(
+                graph_config["trust-domain"],
+                parameters["project"],
+                parameters[head_rev_param],
+            )
+            for task_id in list_tasks(pr_namespace):
+                fetches.append(e.submit(fetch_action, task_id))
+
         # Similarly for cron tasks..
         def fetch_cron(task_id):
             logger.info(f"fetching label-to-taskid.json for cron task {task_id}")


### PR DESCRIPTION
This lets `fetch_graph_and_labels` and in turn actions like add-new-tasks look up all tasks from that commit.