### PR TITLE
Bug 2015690 - Use proper Treeherder routes based on current branch

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -475,11 +475,11 @@ tasks:
                                                 - "tc-treeherder.v2.${project}-pr.${headRev}"
                                                 - "index.${trustDomain}.v2.${project}-pr.revision.${headRev}.taskgraph.decision"
                                             'eventType == "push"':
-                                                - "tc-treeherder.v2.${project}.${headRev}"
+                                                - "tc-treeherder.v2.${shortRef}.${headRev}"
                                                 - "index.${trustDomain}.v2.${project}.latest.taskgraph.decision"
                                                 - "index.${trustDomain}.v2.${project}.revision.${headRev}.taskgraph.decision"
                                             'tasks_for == "action"':
-                                                - "tc-treeherder.v2.${project}.${headRev}"
+                                                - "tc-treeherder.v2.${shortRef}.${headRev}"
                                                 - "index.${trustDomain}.v2.${project}.revision.${headRev}.taskgraph.actions.${ownTaskId}"
                                             'tasks_for == "pr-action"':
                                                 - "tc-treeherder.v2.${project}-pr.${headRev}"

--- a/taskcluster/config.yml
+++ b/taskcluster/config.yml
@@ -6,6 +6,9 @@ trust-domain: enterprise
 project-repo-param-prefix: ''
 product-dir: 'browser'
 treeherder:
+    branch-map:
+        enterprise-main: enterprise-main
+        enterprise-release: enterprise-release
     group-names:
         'js-bench-sm': 'JavaScript shell benchmarks with Spidermonkey'
         'js-bench-v8': 'JavaScript shell benchmarks with Google V8'


### PR DESCRIPTION
There's a bit of co-ordination required here:

1. This needs to land around the same time as https://github.com/mozilla/treeherder/pull/9221 gets deployed to prod
2. We need https://phabricator.services.mozilla.com/D283329 (I plan to merge it to autoland soon). I can cherry-pick it over to `enterprise-main` if we want it faster though.