### PR TITLE
Bug 2017609 - fix treeherder platform for enterprise repack jobs

### DIFF
--- a/taskcluster/kinds/enterprise-repack-repackage/kind.yml
+++ b/taskcluster/kinds/enterprise-repack-repackage/kind.yml
@@ -62,3 +62,4 @@ tasks:
                 linux.*: [mar]
                 macosx64\b.*: [dmg, mar, pkg]
                 win64\b.*: [installer, mar]
+        treeherder-group: Rpk-Ent-Rpk

--- a/taskcluster/kinds/enterprise-repack/kind.yml
+++ b/taskcluster/kinds/enterprise-repack/kind.yml
@@ -57,7 +57,7 @@ only-for-build-platforms:
 tasks:
     linux64-enterprise-shippable:
         treeherder:
-            platform: linux64-enterprise/opt
+            platform: linux64-enterprise-shippable/opt
             symbol: Rpk-Ent
         attributes:
             shippable: true
@@ -76,7 +76,7 @@ tasks:
     macosx64-enterprise-shippable:
         treeherder:
             symbol: Rpk-Ent
-            platform: osx-cross-enterprise/opt
+            platform: osx-cross-enterprise-shippable/opt
         attributes:
             shippable: true
             build_platform: macosx64-enterprise-shippable
@@ -85,7 +85,7 @@ tasks:
     win64-enterprise-shippable:
         treeherder:
             symbol: Rpk-Ent
-            platform: windows2012-64-enterprise/opt
+            platform: windows2012-64-enterprise-shippable/opt
         attributes:
             shippable: true
             build_platform: win64-enterprise-shippable


### PR DESCRIPTION
Make them inherit the platform from the corresponding builds.