### PR TITLE
Convert to expires_at immediately at ingestion.

### DIFF
--- a/browser/components/enterprise/modules/ConsoleClient.sys.mjs
+++ b/browser/components/enterprise/modules/ConsoleClient.sys.mjs
@@ -543,7 +543,8 @@ export const ConsoleClient = {
       }
 
       const { access_token, refresh_token, expires_in } = await res.json();
-      Services.felt.setTokens(access_token, refresh_token, expires_in);
+      const expires_at = Math.floor(Date.now() / 1000) + Number(expires_in);
+      Services.felt.setTokens(access_token, refresh_token, expires_at);
     })().finally(() => {
       this._refreshPromise = null;
     });

--- a/browser/extensions/felt/content/FeltProcessParent.sys.mjs
+++ b/browser/extensions/felt/content/FeltProcessParent.sys.mjs
@@ -184,7 +184,7 @@ export class FeltProcessParent extends JSProcessActorParent {
             Services.felt.setTokens(
               data.access_token,
               data.refresh_token,
-              data.expires_in
+              data.expires_at
             );
             break;
           }
@@ -643,7 +643,8 @@ export class FeltProcessParent extends JSProcessActorParent {
             refresh_token = "",
             expires_in = 0,
           } = message.data;
-          Services.felt.setTokens(access_token, refresh_token, expires_in);
+          const expires_at = Math.floor(Date.now() / 1000) + Number(expires_in);
+          Services.felt.setTokens(access_token, refresh_token, expires_at);
 
           // TODO: Bug 2003001 - Pass user info from Felt to Firefox to avoid network request on startup
           this.loggedInUserInfo =

--- a/browser/extensions/felt/rust/nsIFelt.idl
+++ b/browser/extensions/felt/rust/nsIFelt.idl
@@ -56,8 +56,9 @@ interface nsIFelt : nsISupports {
   [must_use]
   ACString getAccessTokenIfValid();
 
+  // expires_at is a Unix timestamp in seconds (UTC).
   [must_use]
-  void setTokens(in ACString access_token, in ACString refresh_token, in long long expires_in);
+  void setTokens(in ACString access_token, in ACString refresh_token, in long long expires_at);
 
   [must_use]
   void sendExtensionReady();

--- a/browser/extensions/felt/rust/src/components.rs
+++ b/browser/extensions/felt/rust/src/components.rs
@@ -153,13 +153,10 @@ impl FeltXPCOM {
         &self,
         access_token: *const nsACString,
         refresh_token: *const nsACString,
-        expires_in: i64,
+        expires_at: i64,
     ) -> nserror::nsresult {
         let access_token = unsafe { (*access_token).to_string() };
         let refresh_token = unsafe { (*refresh_token).to_string() };
-        let expires_at = UtcDateTime::now()
-            .unix_timestamp()
-            .saturating_add(expires_in);
         match TOKENS.write() {
             Ok(mut t) => {
                 *t = Tokens {

--- a/testing/enterprise/test_felt_browser_exit_tokens.py
+++ b/testing/enterprise/test_felt_browser_exit_tokens.py
@@ -5,6 +5,7 @@
 
 import os
 import sys
+import time
 
 sys.path.append(os.path.dirname(__file__))
 
@@ -58,7 +59,7 @@ class BrowserExitTokens(FeltTests):
 
         self.access_token = "1bf8d2cb-9f72-4788-a770-3cf9cc60f30c"
         self.refresh_token = "82b2d9eb-f0e3-44af-8106-790e7a744d1f"
-        self.expires_in = 3600
+        self.expires_at = int(time.time()) + 3600
 
         assert browser_tokens[0] != self.access_token, (
             f"Access token differs: {browser_tokens[0]} vs {self.access_token}"
@@ -72,7 +73,7 @@ class BrowserExitTokens(FeltTests):
             """
             Services.felt.setTokens(arguments[0], arguments[1], arguments[2]);
             """,
-            [self.access_token, self.refresh_token, self.expires_in],
+            [self.access_token, self.refresh_token, self.expires_at],
         )
         self._child_driver.set_context("content")
 


### PR DESCRIPTION
Prevent subtle API bugs mixing `expires_in` vs `expires_at`.

There are regressions with this in https://github.com/mozilla/enterprise-firefox/pull/432