### PR TITLE
Fix mozcloud stage repack name

### DIFF
--- a/taskcluster/gecko_taskgraph/decision.py
+++ b/taskcluster/gecko_taskgraph/decision.py
@@ -138,7 +138,7 @@ PER_PROJECT_PARAMETERS = {
                             "linux64-aarch64-enterprise-shippable",
                         ],
                     },
-                    "stageMozGCP": {
+                    "mozcloudStage": {
                         "locales": ["en-US"],
                         "platforms": [
                             "linux64-enterprise-shippable",
@@ -161,7 +161,7 @@ PER_PROJECT_PARAMETERS = {
                             "win64-enterprise-shippable",
                         ],
                     },
-                    "stageMozGCP": {
+                    "mozcloudStage": {
                         "locales": ["en-US"],
                         "platforms": [
                             "win64-enterprise-shippable",
@@ -189,7 +189,7 @@ PER_PROJECT_PARAMETERS = {
                             "win64-enterprise-shippable",
                         ],
                     },
-                    "stageMozGCP": {
+                    "mozcloudStage": {
                         "locales": ["en-US"],
                         "platforms": [
                             "linux64-enterprise-shippable",
@@ -218,7 +218,7 @@ PER_PROJECT_PARAMETERS = {
                             "win64-enterprise-shippable",
                         ],
                     },
-                    "stageMozGCP": {
+                    "mozcloudStage": {
                         "locales": ["en-US"],
                         "platforms": [
                             "linux64-enterprise-shippable",
@@ -246,7 +246,7 @@ PER_PROJECT_PARAMETERS = {
                             "win64-enterprise-shippable",
                         ],
                     },
-                    "stageMozGCP": {
+                    "mozcloudStage": {
                         "locales": ["en-US"],
                         "platforms": [
                             "linux64-enterprise-shippable",

--- a/taskcluster/gecko_taskgraph/target_tasks.py
+++ b/taskcluster/gecko_taskgraph/target_tasks.py
@@ -480,6 +480,9 @@ def target_tasks_enterprise_firefox_with_tests(
     )
 
     def filter(task):
+        if "shippable" in task.label and "enterprise" in task.label:
+            return True
+
         # Enabling tests suites triggers many jobs not required, limit execution
         # to enterprise builds for now
         if task.kind in ["test", "mochitest"] and "enterprise" not in task.label:

--- a/taskcluster/gecko_taskgraph/util/verify.py
+++ b/taskcluster/gecko_taskgraph/util/verify.py
@@ -275,20 +275,20 @@ def verify_task_graph_symbol_enterprise(
                                 expected_symbol="sample/enterfox/en-US",
                             )
 
-                        if "stageMozGCP" in task.label:
+                        if "mozcloudStage" in task.label:
                             task_matcher_exception_generator(
                                 "repacks MSI",
                                 task.label,
                                 "repackage-enterprise-repack-msi",
                                 symbol=symbol,
-                                expected_symbol="sample/stageMozGCP/en-US",
+                                expected_symbol="sample/mozcloudStage/en-US",
                             )
                             task_matcher_exception_generator(
                                 "repacks MSI signed",
                                 task.label,
                                 "repackage-signing-enterprise-repack-msi",
                                 symbol=symbol,
-                                expected_symbol="sample/stageMozGCP/en-US",
+                                expected_symbol="sample/mozcloudStage/en-US",
                             )
 
                 if "macosx64" in task.label:
@@ -340,20 +340,20 @@ def verify_task_graph_symbol_enterprise(
                                 expected_symbol="sample/enterfox/en-US",
                             )
 
-                        if "stageMozGCP" in task.label:
+                        if "mozcloudStage" in task.label:
                             task_matcher_exception_generator(
                                 "repacks mac signing",
                                 task.label,
                                 "enterprise-repack-mac-signing",
                                 symbol=symbol,
-                                expected_symbol="sample/stageMozGCP/en-US",
+                                expected_symbol="sample/mozcloudStage/en-US",
                             )
                             task_matcher_exception_generator(
                                 "repacks mac notarization",
                                 task.label,
                                 "enterprise-repack-mac-notarization",
                                 symbol=symbol,
-                                expected_symbol="sample/stageMozGCP/en-US",
+                                expected_symbol="sample/mozcloudStage/en-US",
                             )
 
                     if "build-mac-" in task.label:
@@ -400,13 +400,13 @@ def verify_task_graph_symbol_enterprise(
                                 expected_symbol="sample/enterfox/en-US",
                             )
 
-                        if "stageMozGCP" in task.label:
+                        if "mozcloudStage" in task.label:
                             task_matcher_exception_generator(
                                 "repacks deb package",
                                 task.label,
                                 "repackage-enterprise-repack-deb",
                                 symbol=symbol,
-                                expected_symbol="sample/stageMozGCP/en-US",
+                                expected_symbol="sample/mozcloudStage/en-US",
                             )
 
 


### PR DESCRIPTION
It appears that the repacks are pulling from https://github.com/mozilla-partners/enterprise-repacks where the repack for staging is called `mozcloudStage`. The [failed builds](https://treeherder.mozilla.org/jobs?repo=enterprise-firefox&selectedTaskRun=CA0Ud57lRfCN27_DB31Q3A.0&revision=288c89f3799d1318319e71d6447c59cc79e236e4) after adding `stageMozGCP` show the build trying to find a `stageMozGCP` artifact from a build, but the [artifacts](https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/PGfXRmNmQNGMEDNZ0xGNSw/artifacts) actually contain a `mozcloudStage` one.

I don't know if/how the https://github.com/mozilla/enterprise-repack comes into play but it may need adjustment as well.