### PR TITLE
Bug 2019055, 2019267 - Customize CrashReporter UI for policy autosubmits and Enterprise restart behavior

### DIFF
--- a/toolkit/crashreporter/client/app/src/config.rs
+++ b/toolkit/crashreporter/client/app/src/config.rs
@@ -90,6 +90,9 @@ const DEFAULT_PRODUCT: &str = "Firefox";
 pub struct Config {
     /// Whether reports should be automatically submitted.
     pub auto_submit: bool,
+    #[cfg(feature = "enterprise")]
+    /// Whether reports should be automatically and immediately submitted by policy.
+    pub policy_auto_submit: bool,
     /// Whether all threads of the process should be dumped (versus just the crashing thread).
     pub dump_all_threads: bool,
     /// Whether to delete the dump files after submission.
@@ -144,6 +147,10 @@ impl Config {
     #[cfg_attr(mock, allow(unused))]
     pub fn read_from_environment(&mut self) {
         self.auto_submit = env_bool(ekey!("AUTO_SUBMIT"));
+        #[cfg(feature = "enterprise")]
+        {
+            self.policy_auto_submit = env_bool(ekey!("POLICY_AUTO_SUBMIT"));
+        }
         self.dump_all_threads = env_bool(ekey!("DUMP_ALL_THREADS"));
         self.delete_dump = !env_bool(ekey!("NO_DELETE_DUMP"));
         self.run_memtest = env_bool(ekey!("RUN_MEMTEST"));

--- a/toolkit/crashreporter/client/app/src/lang/langpack.rs
+++ b/toolkit/crashreporter/client/app/src/lang/langpack.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::language_info::LanguageInfo;
-use super::zip::{read_archive_file_as_string, read_zip, Archive};
+use super::zip::{read_archive_file_as_string, read_archive_files_as_string, read_zip, Archive};
 use crate::config::installation_resource_path;
 use crate::std::path::{Path, PathBuf};
 use anyhow::Context;
@@ -163,8 +163,11 @@ fn read_archive_ftl_definitions(
     langpack: &mut Archive,
     language_identifier: &str,
 ) -> anyhow::Result<String> {
-    let path = format!("localization/{language_identifier}/crashreporter/crashreporter.ftl");
-    read_archive_file_as_string(langpack, &path)
+    let mut paths = Vec::new();
+    paths.push(format!("localization/{language_identifier}/crashreporter/crashreporter.ftl"));
+    #[cfg(feature = "enterprise")]
+    paths.push(format!("localization/{language_identifier}/crashreporter/crashreporter-enterprise.ftl"));
+    read_archive_files_as_string(langpack, &paths)
 }
 
 fn read_archive_ftl_branding(

--- a/toolkit/crashreporter/client/app/src/lang/language_info.rs
+++ b/toolkit/crashreporter/client/app/src/lang/language_info.rs
@@ -7,9 +7,22 @@ use anyhow::Context;
 use fluent::{bundle::FluentBundle, FluentResource};
 use unic_langid::LanguageIdentifier;
 
-const FALLBACK_FTL_FILE: &str = include_str!(mozbuild::srcdir_path!(
-    "/toolkit/locales/en-US/crashreporter/crashreporter.ftl"
-));
+cfg_if::cfg_if! {
+    if #[cfg(feature = "enterprise")] {
+        const FALLBACK_FTL_FILE: &str = concat!(
+            include_str!(mozbuild::srcdir_path!(
+                "/toolkit/locales/en-US/crashreporter/crashreporter.ftl"
+            )),
+            include_str!(mozbuild::srcdir_path!(
+                "/toolkit/locales/en-US/crashreporter/crashreporter-enterprise.ftl"
+            ))
+        );
+    } else {
+        const FALLBACK_FTL_FILE: &str = include_str!(mozbuild::srcdir_path!(
+            "/toolkit/locales/en-US/crashreporter/crashreporter.ftl"
+        ));
+    }
+}
 const FALLBACK_BRANDING_FILE: &str = include_str!(mozbuild::srcdir_path!(
     "/browser/branding/official/locales/en-US/brand.ftl"
 ));

--- a/toolkit/crashreporter/client/app/src/lang/omnijar.rs
+++ b/toolkit/crashreporter/client/app/src/lang/omnijar.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::language_info::LanguageInfo;
-use super::zip::{read_archive_file_as_string, read_zip};
+use super::zip::{read_archive_file_as_string, read_archive_files_as_string, read_zip};
 use crate::config::installation_resource_path;
 use crate::std::io::{BufRead, BufReader};
 use anyhow::Context;
@@ -30,9 +30,13 @@ pub fn read() -> anyhow::Result<Vec<LanguageInfo>> {
     let loaded: Vec<_> = locales
         .clone()
         .filter_map(|locale| {
-            match read_archive_file_as_string(
+            let mut paths = Vec::new();
+            paths.push(format!("localization/{locale}/crashreporter/crashreporter.ftl"));
+            #[cfg(feature = "enterprise")]
+            paths.push(format!("localization/{locale}/crashreporter/crashreporter-enterprise.ftl"));
+            match read_archive_files_as_string(
                 &mut zip,
-                &format!("localization/{locale}/crashreporter/crashreporter.ftl"),
+                &paths,
             ) {
                 Ok(v) => Some((locale.to_owned(), v)),
                 Err(e) => {

--- a/toolkit/crashreporter/client/app/src/lang/zip.rs
+++ b/toolkit/crashreporter/client/app/src/lang/zip.rs
@@ -38,3 +38,10 @@ pub fn read_archive_file_as_string(archive: &mut Archive, path: &str) -> anyhow:
         .with_context(|| format!("failed to read {path} from archive"))?;
     Ok(data)
 }
+
+/// Read files from a given zip archive as a string, with each file separated by a newline
+pub fn read_archive_files_as_string(archive: &mut Archive, paths: &[String]) -> anyhow::Result<String> {
+    Ok(paths.into_iter().map(|p| read_archive_file_as_string(archive, p.as_ref()))
+        .collect::<Result<Vec<_>, _>>()?
+        .join("\n"))
+}

--- a/toolkit/crashreporter/client/app/src/logic.rs
+++ b/toolkit/crashreporter/client/app/src/logic.rs
@@ -384,6 +384,7 @@ impl ReportCrash {
     }
 
     /// Restart the program.
+    #[cfg_attr(feature = "enterprise", allow(unused))]
     fn restart_process(&self) {
         self.config.restart_process();
     }
@@ -524,6 +525,7 @@ impl ReportCrash {
     }
 
     /// Restart the application and send the crash report.
+    #[cfg_attr(feature = "enterprise", allow(unused))]
     pub fn restart(&self) {
         // Get the program restarted before sending the report.
         self.restart_process();
@@ -535,6 +537,12 @@ impl ReportCrash {
     pub fn quit(&self) {
         let result = self.try_send();
         self.close_window(result.is_some());
+    }
+
+    #[cfg(feature = "enterprise")]
+    /// Quit without sending a crash report
+    pub fn just_quit(&self) {
+        self.close_window(false);
     }
 
     fn close_window(&self, report_sent: bool) {

--- a/toolkit/crashreporter/client/app/src/test.rs
+++ b/toolkit/crashreporter/client/app/src/test.rs
@@ -441,6 +441,7 @@ fn error_dialog() {
     .unwrap();
 }
 
+#[cfg(not(feature = "enterprise"))]
 #[test]
 fn error_dialog_restart() {
     let mut config = Config::default();
@@ -526,6 +527,7 @@ fn auto_submit() {
     test.assert_files().submitted();
 }
 
+#[cfg(not(feature = "enterprise"))]
 #[test]
 fn restart() {
     let mut test = GuiTest::new();
@@ -550,6 +552,7 @@ fn restart() {
     ran_process.assert_one();
 }
 
+#[cfg(not(feature = "enterprise"))]
 #[test]
 fn no_restart_with_windows_error_reporting() {
     let mut test = GuiTest::new();

--- a/toolkit/crashreporter/client/app/src/ui/mod.rs
+++ b/toolkit/crashreporter/client/app/src/ui/mod.rs
@@ -205,6 +205,9 @@ impl ReportCrashUI {
             close_window,
         } = state.borrow();
 
+        #[cfg(feature = "enterprise")]
+        let policy_auto_submit = config.policy_auto_submit;
+
         send_report.on_change(cc! { (logic) move |v| {
             let v = *v;
             logic.push(move |s| s.settings.borrow_mut().submit_report = v);
@@ -218,13 +221,36 @@ impl ReportCrashUI {
             logic.push(move |s| s.settings.borrow_mut().test_hardware = v);
         }});
 
-        let input_enabled = submit_state.mapped(|s| s == &SubmitState::Initial);
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "enterprise")] {
+                let input_enabled = if policy_auto_submit {
+                    data::Synchronized::new(false)
+                } else {
+                    submit_state.mapped(|s| s == &SubmitState::Initial)
+                };
+            } else {
+                let input_enabled = submit_state.mapped(|s| s == &SubmitState::Initial);
+            }
+        }
         let send_report_and_input_enabled =
             data::Synchronized::join(send_report, &input_enabled, |s, e| *s && *e);
+        #[cfg(feature = "enterprise")]
+        let close_enabled = if policy_auto_submit {
+            data::Synchronized::new(true)
+        } else {
+            submit_state.mapped(|s| s == &SubmitState::Initial)
+        };
 
         let submit_status_text = submit_state.mapped(cc! { (config) move |s| {
             config.string(match s {
+                #[cfg(not(feature = "enterprise"))]
                 SubmitState::Initial => "crashreporter-submit-status",
+                #[cfg(feature = "enterprise")]
+                SubmitState::Initial => if policy_auto_submit {
+                    "crashreporter-submit-status-policy"
+                } else {
+                    "crashreporter-submit-status-enterprise"
+                },
                 SubmitState::WaitingHardwareTests => "crashreporter-submit-waiting-hardware-tests",
                 SubmitState::InProgress => "crashreporter-submit-in-progress",
                 SubmitState::Success => "crashreporter-submit-success",
@@ -259,6 +285,9 @@ impl ReportCrashUI {
                 VBox margin(10) spacing(10) halign(Alignment::Fill) valign(Alignment::Fill) {
                     Label text(config.string("crashreporter-apology")) bold(true),
                     Label text(config.string("crashreporter-crashed-and-restore")),
+                    #[cfg(feature = "enterprise")]
+                    Label text(config.string(if policy_auto_submit {"crashreporter-policy-explanation"} else {"crashreporter-plea"})),
+                    #[cfg(not(feature = "enterprise"))]
                     Label text(config.string("crashreporter-plea")),
                     Checkbox["test-hardware"] checked(test_hardware)
                         label(config.string("crashreporter-checkbox-test-hardware"))
@@ -291,17 +320,31 @@ impl ReportCrashUI {
                     },
                     HBox valign(Alignment::End) halign(Alignment::End) spacing(10) affirmative_order(true)
                     {
+                        #[cfg(not(feature = "enterprise"))]
                         Button["restart"] visible(config.restart_command.is_some())
                             on_click(cc! { (logic) move || logic.push(|s| s.restart()) })
                             enabled(&input_enabled) hsize(160)
                         {
                             Label text(config.string("crashreporter-button-restart"))
                         },
+                        #[cfg(not(feature = "enterprise"))]
                         Button["quit"] on_click(cc! { (logic) move || logic.push(|s| s.quit()) })
                             enabled(&input_enabled) hsize(160)
                         {
                             Label text(config.string("crashreporter-button-quit"))
-                        }
+                        },
+                        #[cfg(feature = "enterprise")]
+                        Button["quit"] on_click(cc! { (logic) move || {
+                                if policy_auto_submit {
+                                    logic.push(|s| s.just_quit());
+                                } else {
+                                    logic.push(|s| s.quit());
+                                }
+                            } })
+                            enabled(&close_enabled) hsize(160)
+                        {
+                            Label text(config.string("crashreporter-button-ok"))
+                        },
                     }
                 }
             }

--- a/toolkit/locales/en-US/crashreporter/crashreporter-enterprise.ftl
+++ b/toolkit/locales/en-US/crashreporter/crashreporter-enterprise.ftl
@@ -1,0 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+crashreporter-policy-explanation = Your administrator has configured { -brand-short-name } to send crash reports automatically. Crash reports help diagnose problems and make { -brand-short-name } better.
+crashreporter-submit-status-enterprise = Your crash report will be submitted when you click OK.
+crashreporter-submit-status-policy = Your crash report will automatically be submitted.


### PR DESCRIPTION
Note: This does not add the behavior of auto-submitting yet, so even with the env variable for policy auto-submit, the crash report will be submitted on pressing the button in the crash reporter app rather than any earlier.

Enterprise crash reporter when policy is not on:
<img width="586" height="393" alt="image" src="https://github.com/user-attachments/assets/432bf772-d112-4034-ac49-ff84107e85c1" />

Enterprise crash reporter when policy is on:
<img width="586" height="393" alt="image" src="https://github.com/user-attachments/assets/bf706290-5811-4586-9e1c-d9ed633ce137" />


**Note:** The text at the bottom "Your crash report will automatically be submitted." should not end up being visible once the policy autosubmit behavior is implemented; that label is tied to the submit status, and the submit will be kicked off as the UI becomes visible, so users will instead see a progress bar/completion message.