### PR TITLE
Bug 2022201 - Fix neterror pages

### DIFF
--- a/toolkit/content/errors/net-errors.mjs
+++ b/toolkit/content/errors/net-errors.mjs
@@ -7,11 +7,6 @@
  * These include NS_ERROR_* codes and URL parameter error codes.
  */
 
-const lazy = {};
-ChromeUtils.defineESModuleGetters(lazy, {
-  AppConstants: "resource://gre/modules/AppConstants.sys.mjs",
-});
-
 export const HTTPS_UPGRADES_MDN_DOCS =
   "https://developer.mozilla.org/docs/Web/Security/HTTPS-Only_Mode";
 export const COOP_MDN_DOCS =
@@ -323,23 +318,21 @@ export const NET_ERRORS = [
     id: "blockedByPolicy",
     errorCode: "blockedByPolicy",
     category: "blocked",
-    bodyTitleL10nId: "neterror-blocked-by-policy-page-title",
+    bodyTitleL10nId: "blocked-by-policy-title-enterprise",
     introContent: {
       dataL10nId: "fp-neterror-offline-intro",
       dataL10nArgs: { hostname: null },
     },
-    descriptionParts: lazy.AppConstants.MOZ_ENTERPRISE
-      ? [
-          [
-            [
-              {
-                tag: "p",
-                dataL10nId: "neterror-blocked-by-policy-contact-admin",
-              },
-            ],
-          ],
-        ]
-      : [],
+    descriptionParts: [
+      {
+        tag: "p",
+        dataL10nId: "neterror-blocked-by-policy-contact-admin",
+      },
+    ],
+    customNetError: {
+      titleL10nId: "blocked-by-policy-title-enterprise",
+      whatCanYouDoL10nId: "neterror-blocked-by-policy-contact-admin",
+    },
     buttons: {
       showTryAgain: false,
       showGoBack: false,

--- a/toolkit/content/net-error-card.mjs
+++ b/toolkit/content/net-error-card.mjs
@@ -172,7 +172,7 @@ export class NetErrorCard extends MozLitElement {
 
     const titles = {
       net: "neterror-page-title",
-      blocked: "neterror-blocked-by-policy-page-title",
+      blocked: "neterror-blocked-by-policy-page-title-enterprise",
     };
     document.l10n.setAttributes(
       document.querySelector("title"),

--- a/toolkit/locales/en-US/toolkit/neterror/netError.ftl
+++ b/toolkit/locales/en-US/toolkit/neterror/netError.ftl
@@ -7,6 +7,7 @@
 neterror-page-title = Problem loading page
 certerror-page-title = Warning: Potential Security Risk Ahead
 certerror-sts-page-title = Did Not Connect: Potential Security Issue
+neterror-blocked-by-policy-page-title = Blocked Page
 neterror-captive-portal-page-title = Log in to network
 neterror-dns-not-found-title = Server Not Found
 neterror-malformed-uri-page-title = Invalid URL


### PR DESCRIPTION
@Mossop Which way would you put these changes behind an enterprise flag?

So far I tried these two ways:
- import `AppConstants` with `ChromeUtils` but `ChromeUtils` isn't accessible from the content file `net-error.mjs`.
- import it statically but eslint warns that I can't import system modules from non-system modules see [eslint rule](https://firefox-source-docs.mozilla.org/code-quality/lint/linters/eslint-plugin-mozilla/rules/reject-import-system-module-from-non-system.html).