### PR TITLE
Bug 2019063 - Tab crash logic to auto send crash report if policy enabled

### DIFF
--- a/browser/components/enterprisepolicies/Policies.sys.mjs
+++ b/browser/components/enterprisepolicies/Policies.sys.mjs
@@ -1066,6 +1066,26 @@ export var Policies = {
     },
   },
 
+  CrashReportsAutoSubmit: {
+    onBeforeAddons(_manager, param) {
+      if (param) {
+        setAndLockPref("browser.crashReports.unsubmittedCheck.enabled", true);
+        setAndLockPref(
+          "browser.crashReports.unsubmittedCheck.autoSubmit2",
+          true
+        );
+        setAndLockPref("browser.tabs.crashReporting.sendReport", true);
+        setAndLockPref("browser.tabs.crashReporting.includeURL", true);
+      }
+    },
+    onRemove(_manager, _oldParam) {
+      unsetAndUnlockPref("browser.crashReports.unsubmittedCheck.enabled");
+      unsetAndUnlockPref("browser.crashReports.unsubmittedCheck.autoSubmit2");
+      unsetAndUnlockPref("browser.tabs.crashReporting.sendReport");
+      unsetAndUnlockPref("browser.tabs.crashReporting.includeURL");
+    },
+  },
+
   DefaultDownloadDirectory: {
     onBeforeAddons(manager, param) {
       PoliciesUtils.setDefaultPref(

--- a/browser/components/enterprisepolicies/Policies.sys.mjs
+++ b/browser/components/enterprisepolicies/Policies.sys.mjs
@@ -1066,9 +1066,9 @@ export var Policies = {
     },
   },
 
-  CrashReportsAutoSubmit: {
+  CrashReportsSubmit: {
     onBeforeAddons(_manager, param) {
-      if (param) {
+      if (param.ForceAutoSubmit) {
         setAndLockPref("browser.crashReports.unsubmittedCheck.enabled", true);
         setAndLockPref(
           "browser.crashReports.unsubmittedCheck.autoSubmit2",

--- a/browser/components/enterprisepolicies/schemas/policies-schema.json
+++ b/browser/components/enterprisepolicies/schemas/policies-schema.json
@@ -542,8 +542,13 @@
       }
     },
 
-    "CrashReportsAutoSubmit": {
-      "type": "boolean"
+    "CrashReportsSubmit": {
+      "type": "object",
+      "properties": {
+        "ForceAutoSubmit": {
+          "type": "boolean"
+        }
+      }
     },
 
     "DefaultDownloadDirectory": {

--- a/browser/components/enterprisepolicies/schemas/policies-schema.json
+++ b/browser/components/enterprisepolicies/schemas/policies-schema.json
@@ -542,6 +542,10 @@
       }
     },
 
+    "CrashReportsAutoSubmit": {
+      "type": "boolean"
+    },
+
     "DefaultDownloadDirectory": {
       "type": "string"
     },

--- a/browser/locales/en-US/browser/enterprise/enterprise-policies-descriptions.ftl
+++ b/browser/locales/en-US/browser/enterprise/enterprise-policies-descriptions.ftl
@@ -7,4 +7,4 @@ policy-DownloadTelemetry = Enable and configure security logging/telemetry when 
 policy-EnterpriseStorageEncryption = Enable enterprise-managed primary password for encrypted storage.
 policy-PrintPageTelemetry = Enable and configure security logging/telemetry when a page is printed.
 policy-Sync = Enable or disable sync and define which data to include.
-policy-CrashReportsAutoSubmit = Enable or disable automatically sending crash reports.
+policy-CrashReportsSubmit = Configure crash report submission settings.

--- a/browser/locales/en-US/browser/enterprise/enterprise-policies-descriptions.ftl
+++ b/browser/locales/en-US/browser/enterprise/enterprise-policies-descriptions.ftl
@@ -7,3 +7,4 @@ policy-DownloadTelemetry = Enable and configure security logging/telemetry when 
 policy-EnterpriseStorageEncryption = Enable enterprise-managed primary password for encrypted storage.
 policy-PrintPageTelemetry = Enable and configure security logging/telemetry when a page is printed.
 policy-Sync = Enable or disable sync and define which data to include.
+policy-CrashReportsAutoSubmit = Enable or disable automatically sending crash reports.

--- a/browser/modules/ContentCrashHandlers.sys.mjs
+++ b/browser/modules/ContentCrashHandlers.sys.mjs
@@ -531,6 +531,15 @@ export var TabCrashHandler = {
    *        The browser that has recently crashed.
    */
   sendToTabCrashedPage(browser) {
+    if (Services.policies.getActivePolicies()?.CrashReportsAutoSubmit) {
+      let dumpID = this.getDumpID(browser);
+      if (dumpID) {
+        lazy.CrashSubmit.submit(dumpID, lazy.CrashSubmit.SUBMITTED_FROM_AUTO);
+        let childID = this.browserMap.get(browser);
+        this.childMap.set(childID, null); // Avoid resubmission from about:tabcrashed.
+      }
+    }
+
     let title = browser.contentTitle;
     let uri = browser.currentURI;
     let gBrowser = browser.getTabBrowser();

--- a/browser/modules/ContentCrashHandlers.sys.mjs
+++ b/browser/modules/ContentCrashHandlers.sys.mjs
@@ -531,7 +531,9 @@ export var TabCrashHandler = {
    *        The browser that has recently crashed.
    */
   sendToTabCrashedPage(browser) {
-    if (Services.policies.getActivePolicies()?.CrashReportsAutoSubmit) {
+    if (
+      Services.policies.getActivePolicies()?.CrashReportsSubmit?.ForceAutoSubmit
+    ) {
       let dumpID = this.getDumpID(browser);
       if (dumpID) {
         lazy.CrashSubmit.submit(dumpID, lazy.CrashSubmit.SUBMITTED_FROM_AUTO);

--- a/browser/modules/ContentCrashHandlers.sys.mjs
+++ b/browser/modules/ContentCrashHandlers.sys.mjs
@@ -532,6 +532,7 @@ export var TabCrashHandler = {
    */
   sendToTabCrashedPage(browser) {
     if (
+      AppConstants.MOZ_CRASHREPORTER &&
       Services.policies.getActivePolicies()?.CrashReportsSubmit?.ForceAutoSubmit
     ) {
       let dumpID = this.getDumpID(browser);


### PR DESCRIPTION
## Summary

This PR adds the logic to automatically submit the tab crash report when the policy is enabled and the user is presented with the Tab Crash page. PR #531 adds the custom UI.

- [Bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=2019063)

## Related Issues and Pull Requests

- https://github.com/mozilla/enterprise-firefox/pull/531
- https://github.com/mozilla/enterprise-admin-reference/pull/86