### PR TITLE
Return null for FxAccounts config uris

### DIFF
--- a/services/fxaccounts/FxAccountsConfig.sys.mjs
+++ b/services/fxaccounts/FxAccountsConfig.sys.mjs
@@ -24,6 +24,8 @@ ChromeUtils.defineESModuleGetters(lazy, {
     "resource://gre/modules/FxAccountsWebChannel.sys.mjs",
 });
 
+import { AppConstants } from "resource://gre/modules/AppConstants.sys.mjs";
+
 XPCOMUtils.defineLazyPreferenceGetter(
   lazy,
   "ROOT_URL",
@@ -159,6 +161,9 @@ export var FxAccountsConfig = {
       addAccountIdentifiers = false,
     }
   ) {
+    if (AppConstants.MOZ_ENTERPRISE) {
+      return null;
+    }
     await this.ensureConfigured();
     const url = new URL(path, lazy.ROOT_URL);
     this.ensureHTTPS(url.protocol);


### PR DESCRIPTION
Returning null early since the nulled out uris pointing to external servers won't pass subsequent uri checks

Regressed by: Bug 2012667 - Null out prefs that reference Mozilla servers (#467)