### PR TITLE
Don't fetch sponsored Top Sites from Mozilla Tiles Service

### DIFF
--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -1867,10 +1867,11 @@ pref("browser.topsites.component.enabled", false);
 
 pref("browser.topsites.useRemoteSetting", true);
 // Fetch sponsored Top Sites from Mozilla Tiles Service (Contile)
-pref("browser.topsites.contile.enabled", true);
 #ifdef MOZ_ENTERPRISE
+pref("browser.topsites.contile.enabled", false);
 pref("browser.topsites.contile.endpoint", "");
 #else
+pref("browser.topsites.contile.enabled", true);
 pref("browser.topsites.contile.endpoint", "https://contile.services.mozilla.com/v1/tiles");
 #endif
 


### PR DESCRIPTION
Disable fetching top sites from Mozilla Tile Service since we have nulled the endpoint.

Regressed by: Bug 2012667 - Null out prefs that reference Mozilla servers (https://github.com/mozilla/enterprise-firefox/pull/467)