### PR TITLE
Bug 2017135: close FF and prompt login when token fails refresh (401)

### DIFF
--- a/browser/components/enterprise/modules/ConsoleClient.sys.mjs
+++ b/browser/components/enterprise/modules/ConsoleClient.sys.mjs
@@ -404,7 +404,7 @@ export const ConsoleClient = {
     }
 
     if ((res.status === 403 || res.status === 401) && !_didRefresh) {
-      await this._refreshSession();
+      await this.handleSessionRefresh();
       return this._fetch(path, method, { _didRefresh: true, jsonBody });
     }
 
@@ -447,15 +447,8 @@ export const ConsoleClient = {
   async getAccessToken() {
     let accessToken = Services.felt.getAccessTokenIfValid();
     if (!accessToken) {
-      await this._refreshSession();
+      await this.handleSessionRefresh();
       accessToken = Services.felt.getAccessTokenIfValid();
-    }
-    if (!accessToken) {
-      // We're not handling reauthentication just yet.
-      throw new InvalidAuthError(
-        "Unhandled reauthentication",
-        "UNHANDLED_REAUTHENTICATION"
-      );
     }
     return accessToken;
   },
@@ -486,10 +479,28 @@ export const ConsoleClient = {
   },
 
   /**
+   * Wraps _refreshSession(), handling ReauthRequiredError by notifying Felt and re-throwing.
+   *
+   * @throws {ReauthRequiredError|InvalidAuthError}
+   * @returns {Promise<void>}
+   */
+  async handleSessionRefresh() {
+    try {
+      await this._refreshSession();
+    } catch (e) {
+      lazy.log.error("handleSessionRefresh: session refresh failed", e);
+      if (e instanceof ReauthRequiredError) {
+        this.consoleForcedLogout();
+      }
+      throw e;
+    }
+  },
+
+  /**
    * Refreshes the session using a refresh token.
    * Serializes concurrent refreshes via an internal promise.
    *
-   * @throws {InvalidAuthError} If unable to refresh session
+   * @throws {ReauthRequiredError|InvalidAuthError} If unable to refresh session
    * @returns {Promise<void>}
    */
   async _refreshSession() {
@@ -510,13 +521,10 @@ export const ConsoleClient = {
     this._refreshPromise = (async () => {
       let refreshToken = Services.felt.getRefreshToken();
       if (!refreshToken) {
-        const e = new ReauthRequiredError(
+        throw new ReauthRequiredError(
           "No refresh token available",
           "MISSING_REFRESH_TOKEN"
         );
-        console.error(e);
-        this.promptForReauthentication();
-        return;
       }
       let res;
       try {
@@ -541,14 +549,11 @@ export const ConsoleClient = {
       }
 
       if (res.status === 401 || res.status === 403) {
-        const e = new ReauthRequiredError(
+        throw new ReauthRequiredError(
           "Invalid refresh token",
           "INVALID_REFRESH_TOKEN",
           { status: res.status }
         );
-        console.error(e);
-        this.promptForReauthentication();
-        return;
       }
 
       // TODO: Handle network issues, offline support, etc.
@@ -629,12 +634,46 @@ export const ConsoleClient = {
   },
 
   /**
-   * If unable to refresh the session, prompt for user reauthentication
-   * to obtain a valid set of access and refresh token.
+   * Shared logout implementation. Guards against double calls, signals FELT to
+   * take over as a background process, then invokes the provided logout
+   * function to notify FELT of the logout type. Does not quit the browser;
+   * callers are responsible for that via quit().
+   *
+   * @param {Function} performXPCOMLogout - Invokes the appropriate XPCOM logout call.
    */
-  promptForReauthentication() {
-    this.clearTokenData();
-    // TODO: Handle Re-authentication
+  _logout(performXPCOMLogout) {
+    // Only the FELT-managed browser should trigger a quit and logout.
+    // _isLogoutInProgress guards against double calls from concurrent requests.
+    if (!Services.felt.isFeltBrowser() || this._isLogoutInProgress) {
+      return;
+    }
+    this._isLogoutInProgress = true;
+    // Make sure we signal early enough to the system that FELT should take
+    // over. Relevant at least for macOS dock icon. Not having this would
+    // at least intermittently result in missing dock icon for FELT after
+    // signout.
+    Services.felt.makeBackgroundProcess(true);
+    // Notify FELT of the logout type so it can handle shutdown appropriately.
+    performXPCOMLogout();
+  },
+
+  quit() {
+    if (!this._isLogoutInProgress) {
+      return;
+    }
+    Services.startup.quit(Ci.nsIAppStartup.eForceQuit);
+  },
+
+  normalLogout({ withQuit = true } = {}) {
+    this._logout(() => Services.felt.performNormalLogout());
+    if (withQuit) {
+      this.quit();
+    }
+  },
+
+  consoleForcedLogout() {
+    this._logout(() => Services.felt.performConsoleForcedLogout());
+    this.quit();
   },
 
   /**
@@ -664,18 +703,8 @@ export const ConsoleClient = {
     const res = await this._post(this._paths.SIGNOUT);
     // Server should maybe return better JSON?
     if (res == null) {
-      // After successful server-side logout clear local state and notify FELT.
-      this.clearTokenData();
-
-      // Make sure we signal early enough to the system that FELT should take
-      // over. Relevant at least for macOS dock icon. Not having this would
-      // at least intermittently result in missing dock icon for FELT after
-      // signout.
-      Services.felt.makeBackgroundProcess(true);
-
-      // Notify FELT that we are logging out so the shutdown is a normal one
-      // that should not be followed by restarting the process.
-      Services.felt.performSignout();
+      // Quit is called from outside (e.g. by the caller after signout).
+      this.normalLogout({ withQuit: false });
       return;
     }
 
@@ -692,6 +721,11 @@ export const ConsoleClient = {
       lazy.AsyncShutdown.appShutdownConfirmed.addBlocker(
         `ConsoleClient: Sending back tokens to felt on shutdown`,
         () => {
+          // Do not send tokens back to Felt on logout — the session is
+          // being intentionally terminated and should not be restored.
+          if (this._isLogoutInProgress) {
+            return;
+          }
           try {
             Services.felt.sendTokens();
           } catch (ex) {

--- a/browser/extensions/felt/api.js
+++ b/browser/extensions/felt/api.js
@@ -8,6 +8,8 @@
 
 const lazy = {};
 
+// Maps logout types (from nsIFelt) to the CSS class applied to the FELT window
+// to display the appropriate message to the user after logout.
 ChromeUtils.defineLazyGetter(
   lazy,
   "logoutTypeMessageClass",

--- a/browser/extensions/felt/api.js
+++ b/browser/extensions/felt/api.js
@@ -8,6 +8,18 @@
 
 const lazy = {};
 
+ChromeUtils.defineLazyGetter(
+  lazy,
+  "logoutTypeMessageClass",
+  () =>
+    new Map([
+      [
+        Services.felt.logoutTypeConsoleForcedLogout,
+        "felt-browser-info-console-forced-logout",
+      ],
+    ])
+);
+
 ChromeUtils.defineESModuleGetters(lazy, {
   UpdateListener: "resource://gre/modules/UpdateListener.sys.mjs",
   FELT_OPEN_WINDOW_DISPOSITION: "resource:///modules/FeltURLHandler.sys.mjs",
@@ -267,7 +279,9 @@ this.felt = class extends ExtensionAPI {
       case "FeltParent:FirefoxLogoutExit": {
         const success = Services.felt.makeBackgroundProcess(false);
         console.debug(`FeltExtension: makeBackgroundProcess? ${success}`);
-        this.showWindow();
+        this.showWindow(
+          lazy.logoutTypeMessageClass.get(message.data.logoutType) ?? ""
+        );
         break;
       }
 

--- a/browser/extensions/felt/content/FeltProcessParent.sys.mjs
+++ b/browser/extensions/felt/content/FeltProcessParent.sys.mjs
@@ -239,7 +239,7 @@ export class FeltProcessParent extends JSProcessActorParent {
           }
 
           case "felt-firefox-logout":
-            gFeltProcessParentInstance.logoutFirefox();
+            gFeltProcessParentInstance.logoutFirefox(aData);
             break;
 
           case "felt-firefox-tokens": {
@@ -592,15 +592,17 @@ export class FeltProcessParent extends JSProcessActorParent {
   }
 
   /**
-   * Perform all the logout operations on FELT side
+   * Perform all the logout operations on FELT side.
+   *
+   * @param {string} logoutType - One of the logout type payload strings from the IPC message.
    */
-  logoutFirefox() {
+  logoutFirefox(logoutType) {
     if (!Services.felt.isFeltUI()) {
       throw new Error("Logout handling should only happen on FELT side.");
     }
 
     console.debug(
-      `FeltExtension: Logout, waiting on ${gFeltProcessParentInstance.proc.pid}`
+      `FeltExtension: Logout (${logoutType}), waiting on ${gFeltProcessParentInstance.proc.pid}`
     );
     gFeltProcessParentInstance.logoutReported = true;
     lazy.ConsoleClient.clearTokenData();
@@ -612,7 +614,9 @@ export class FeltProcessParent extends JSProcessActorParent {
     }
 
     gFeltProcessParentInstance.proc.exitPromise.then(_ => {
-      Services.cpmm.sendAsyncMessage("FeltParent:FirefoxLogoutExit", {});
+      Services.cpmm.sendAsyncMessage("FeltParent:FirefoxLogoutExit", {
+        logoutType,
+      });
     });
   }
 

--- a/browser/extensions/felt/content/felt.xhtml
+++ b/browser/extensions/felt/content/felt.xhtml
@@ -216,6 +216,12 @@
           >
             <span slot="message" class="felt-browser-error-details"></span>
           </moz-message-bar>
+          <moz-message-bar
+            class="felt-browser-info-console-forced-logout is-hidden"
+            data-l10n-id="felt-browser-info-console-forced-logout"
+            type="info"
+            dismissable="true"
+          ></moz-message-bar>
         </div>
         <span
           class="felt-powered-by text-deemphasized"

--- a/browser/extensions/felt/rust/nsIFelt.idl
+++ b/browser/extensions/felt/rust/nsIFelt.idl
@@ -76,5 +76,12 @@ interface nsIFelt : nsISupports {
   ACString getConsoleUrl();
 
   [must_use]
-  void performSignout();
+  void performNormalLogout();
+
+  [must_use]
+  void performConsoleForcedLogout();
+
+  readonly attribute ACString logoutTypeNormal;
+  readonly attribute ACString logoutTypeConsoleForcedLogout;
+  readonly attribute ACString logoutTypeUnknown;
 };

--- a/browser/extensions/felt/rust/src/client.rs
+++ b/browser/extensions/felt/rust/src/client.rs
@@ -12,7 +12,7 @@ use xpcom::RefPtr;
 
 use log::trace;
 
-use crate::message::{nsICookieWrapper, FeltMessage, FELT_IPC_VERSION};
+use crate::message::{nsICookieWrapper, FeltMessage, LogoutType, FELT_IPC_VERSION};
 use crate::utils::{self, Tokens, TOKENS};
 
 #[derive(Default)]
@@ -76,9 +76,9 @@ impl FeltIpcClient {
         }
     }
 
-    pub fn notify_signout(&self) {
+    pub fn notify_signout(&self, logout_type: LogoutType) {
         trace!("FeltIpcClient::notify_signout()");
-        let msg = FeltMessage::LogoutShutdown;
+        let msg = FeltMessage::Logout(logout_type);
         if let Some(tx) = &self.tx {
             match tx.send(msg) {
                 Ok(()) => trace!("FeltIpcClient::notify_signout() SENT"),
@@ -486,10 +486,10 @@ impl FeltClientThread {
         client.send_extension_ready();
     }
 
-    pub fn notify_signout(&self) {
+    pub fn notify_signout(&self, logout_type: LogoutType) {
         trace!("FeltClientThread::notify_signout()");
         let client = self.ipc_client.borrow();
-        client.notify_signout();
+        client.notify_signout(logout_type);
     }
 
     pub fn send_back_tokens(&self) -> nserror::nsresult {

--- a/browser/extensions/felt/rust/src/components.rs
+++ b/browser/extensions/felt/rust/src/components.rs
@@ -303,34 +303,30 @@ impl FeltXPCOM {
         NS_OK
     }
 
-    fn PerformNormalLogout(&self) -> nserror::nsresult {
-        trace!("FeltXPCOM::PerformNormalLogout");
+    fn perform_logout(&self, logout_type: LogoutType) -> nserror::nsresult {
+        trace!("FeltXPCOM::perform_logout");
         let guard = crate::FELT_CLIENT.lock().expect("Could not get lock");
         match &*guard {
             Some(client) => {
-                trace!("firefox_felt_send_extension_ready(): sending message");
-                client.notify_signout(LogoutType::Normal);
+                trace!("FeltXPCOM::perform_logout(): sending message");
+                client.notify_signout(logout_type);
+                NS_OK
             }
             None => {
-                trace!("firefox_felt_send_extension_ready(): missing client");
+                trace!("FeltXPCOM::perform_logout(): missing client");
+                NS_ERROR_FAILURE
             }
         }
-        NS_OK
+    }
+
+    fn PerformNormalLogout(&self) -> nserror::nsresult {
+        trace!("FeltXPCOM::PerformNormalLogout");
+        self.perform_logout(LogoutType::Normal)
     }
 
     fn PerformConsoleForcedLogout(&self) -> nserror::nsresult {
         trace!("FeltXPCOM::PerformConsoleForcedLogout");
-        let guard = crate::FELT_CLIENT.lock().expect("Could not get lock");
-        match &*guard {
-            Some(client) => {
-                trace!("firefox_felt_send_extension_ready(): sending message");
-                client.notify_signout(LogoutType::ConsoleForcedLogout);
-            }
-            None => {
-                trace!("firefox_felt_send_extension_ready(): missing client");
-            }
-        }
-        NS_OK
+        self.perform_logout(LogoutType::ConsoleForcedLogout)
     }
 
     fn IpcChannel(&self) -> nserror::nsresult {

--- a/browser/extensions/felt/rust/src/components.rs
+++ b/browser/extensions/felt/rust/src/components.rs
@@ -17,7 +17,7 @@ use xpcom::RefPtr;
 
 use log::{error, trace};
 
-use crate::message::{FeltMessage, FELT_IPC_VERSION};
+use crate::message::{FeltMessage, LogoutType, FELT_IPC_VERSION};
 #[cfg(target_os = "linux")]
 use crate::utils;
 use crate::utils::{Tokens, CONSOLE_URL, TOKENS, TOKEN_EXPIRY_SKEW};
@@ -288,14 +288,43 @@ impl FeltXPCOM {
         }
     }
 
-    // Firefox to FELT to notify of logout
-    fn PerformSignout(&self) -> nserror::nsresult {
-        trace!("FeltXPCOM::PerformSignout");
+    fn GetLogoutTypeNormal(&self, value: *mut nsACString) -> nserror::nsresult {
+        unsafe { (*value).assign(LogoutType::Normal.as_str()) };
+        NS_OK
+    }
+
+    fn GetLogoutTypeConsoleForcedLogout(&self, value: *mut nsACString) -> nserror::nsresult {
+        unsafe { (*value).assign(LogoutType::ConsoleForcedLogout.as_str()) };
+        NS_OK
+    }
+
+    fn GetLogoutTypeUnknown(&self, value: *mut nsACString) -> nserror::nsresult {
+        unsafe { (*value).assign(LogoutType::Unknown.as_str()) };
+        NS_OK
+    }
+
+    fn PerformNormalLogout(&self) -> nserror::nsresult {
+        trace!("FeltXPCOM::PerformNormalLogout");
         let guard = crate::FELT_CLIENT.lock().expect("Could not get lock");
         match &*guard {
             Some(client) => {
                 trace!("firefox_felt_send_extension_ready(): sending message");
-                client.notify_signout();
+                client.notify_signout(LogoutType::Normal);
+            }
+            None => {
+                trace!("firefox_felt_send_extension_ready(): missing client");
+            }
+        }
+        NS_OK
+    }
+
+    fn PerformConsoleForcedLogout(&self) -> nserror::nsresult {
+        trace!("FeltXPCOM::PerformConsoleForcedLogout");
+        let guard = crate::FELT_CLIENT.lock().expect("Could not get lock");
+        match &*guard {
+            Some(client) => {
+                trace!("firefox_felt_send_extension_ready(): sending message");
+                client.notify_signout(LogoutType::ConsoleForcedLogout);
             }
             None => {
                 trace!("firefox_felt_send_extension_ready(): missing client");
@@ -387,9 +416,9 @@ impl FeltXPCOM {
                                 trace!("FeltServerThread::felt_server::ipc_loop(): ExtensionReady");
                                 crate::utils::notify_observers("felt-extension-ready".to_string());
                             },
-                            Ok(FeltMessage::LogoutShutdown) => {
-                                trace!("FeltServerThread::felt_server::ipc_loop(): Shutdown for logout");
-                                crate::utils::notify_observers("felt-firefox-logout".to_string());
+                            Ok(FeltMessage::Logout(logout_type)) => {
+                                trace!("FeltServerThread::felt_server::ipc_loop(): Logout {:?}", logout_type);
+                                crate::utils::notify_observers_with_payload("felt-firefox-logout".to_string(), Some(logout_type.as_str().to_string()));
                             },
                             Ok(FeltMessage::Tokens((access_token, refresh_token, expires_at))) => {
                                 trace!("FeltServerThread::felt_server::ipc_loop(): Update tokens from browser");

--- a/browser/extensions/felt/rust/src/message.rs
+++ b/browser/extensions/felt/rust/src/message.rs
@@ -45,6 +45,33 @@ impl nsICookieWrapper {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+pub enum LogoutType {
+    Normal = 0,
+    ConsoleForcedLogout = 1,
+    Unknown = 255,
+}
+
+impl LogoutType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            LogoutType::Normal => "normal",
+            LogoutType::ConsoleForcedLogout => "console-forced-logout",
+            LogoutType::Unknown => "unknown",
+        }
+    }
+}
+
+impl From<i32> for LogoutType {
+    fn from(value: i32) -> Self {
+        match value {
+            0 => LogoutType::Normal,
+            1 => LogoutType::ConsoleForcedLogout,
+            _ => LogoutType::Unknown,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 pub enum FeltMessage {
     VersionProbe(u32),
     VersionValidated(bool),
@@ -59,7 +86,7 @@ pub enum FeltMessage {
     OpenURL((String, i32, Option<FocusHint>)),
     RestartForced,
     Restarting,
-    LogoutShutdown,
+    Logout(LogoutType),
     Exiting,
     UpdateReady,
 }
@@ -70,4 +97,4 @@ pub enum FocusHint {
     Timestamp(u32),
 }
 
-pub const FELT_IPC_VERSION: u32 = 7;
+pub const FELT_IPC_VERSION: u32 = 8;

--- a/browser/locales/en-US/browser/enterprise/felt.ftl
+++ b/browser/locales/en-US/browser/enterprise/felt.ftl
@@ -28,6 +28,12 @@ felt-browser-error-sso-timeout2 =
 felt-browser-error-multiple-crashes2 =
     .heading = { -brand-short-name } crashed multiple times
 
+## Logout messages
+
+felt-browser-info-console-forced-logout =
+    .heading = You’ve been signed out
+    .message = An administrator signed you out as part of routine account management. If you have any questions, please contact your administrator directly.
+
 ## Network error headings
 
 felt-browser-error-connection2 =

--- a/testing/enterprise/base_test.py
+++ b/testing/enterprise/base_test.py
@@ -10,6 +10,7 @@ import time
 from copy import deepcopy
 from enum import Enum
 
+from marionette_driver import errors
 from marionette_driver.marionette import Marionette
 from marionette_driver.wait import Wait
 from marionette_harness import MarionetteTestCase
@@ -189,6 +190,21 @@ class EnterpriseTestsBase(MarionetteTestCase):
         self._logger.info(f"Verifying user is signed out in {env.name}.")
 
         result = self.get_logged_in_user_info(env)
-        assert result["_error"] == "InvalidAuthError: Unhandled reauthentication", (
-            "Unexpected state after signout"
-        )
+        assert result["_error"] in (
+            "ReauthRequiredError: No refresh token available",
+            "ReauthRequiredError: Invalid refresh token",
+            "InvalidAuthError: Token refresh request blocked in Felt.",
+        ), "Unexpected state after signout"
+
+    def assert_child_browser_closed(self):
+        self._logger.info("Verifying child browser is closed.")
+        try:
+            self._child_driver.get_url()
+            assert False, "Expected child browser to be closed"
+        except (
+            errors.InvalidSessionIdException,
+            errors.NoSuchWindowException,
+            errors.TimeoutException,
+            OSError,
+        ):
+            pass

--- a/testing/enterprise/felt_tests.py
+++ b/testing/enterprise/felt_tests.py
@@ -515,6 +515,76 @@ def serve(
     )
 
 
+class FeltLogoutChecker:
+    """Context manager that asserts a FELT-managed Firefox browser logout of a specific type occurred.
+
+    Must be instantiated while the FELT window is open (i.e. in setup()), since it
+    registers a "felt-firefox-logout" observer in the FELT window via execute_script at
+    construction time. Use assert_browser_logouts_with() to set the expected logout type,
+    then wrap the action that triggers the logout in a with block.
+    """
+
+    def __init__(self, test):
+        self._test = test
+        self._expected_type = None
+        self._saved_window_handle = None
+
+        with test._driver.using_context("chrome"):
+            test._driver.execute_script(
+                """
+                Services.prefs.clearUserPref("enterprise._test.logout_type");
+                Services.obs.addObserver({
+                    observe(subject, topic, data) {
+                        Services.prefs.setStringPref("enterprise._test.logout_type", data);
+                    }
+                }, "felt-firefox-logout", false);
+                """
+            )
+
+    def assert_browser_logouts_with(self, expected_type):
+        self._expected_type = expected_type
+        return self
+
+    def __enter__(self):
+        try:
+            self._saved_window_handle = self._test._driver.current_chrome_window_handle
+        except Exception:
+            # If the parent browser window was closed, there is nothing to restore.
+            self._saved_window_handle = None
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if exc_type is not None:
+            return False
+
+        handles = self._test._wait.until(
+            lambda mn: self._test._driver.chrome_window_handles
+        )
+        # switch_to_window resets Marionette's internal curBrowser pointer to the new
+        # window; without it, execute_script would throw "browsing context has been
+        # discarded" because it still references the old closed window.
+        self._test._driver.switch_to_window(handles[0])
+        with self._test._driver.using_context("chrome"):
+            logout_type = self._test._wait.until(
+                lambda mn: mn.execute_script(
+                    'return Services.prefs.getStringPref("enterprise._test.logout_type", "") || null;'
+                )
+            )
+        assert logout_type == self._expected_type, (
+            f"Unexpected logout type: {logout_type}"
+        )
+
+        try:
+            parent_handles = self._test._driver.chrome_window_handles
+            if self._saved_window_handle in parent_handles:
+                self._test._driver.switch_to_window(self._saved_window_handle)
+        except Exception:
+            # If the parent browser window was closed, there is nothing to restore.
+            pass
+
+        return False
+
+
 class FeltTestsBase(EnterpriseTestsBase):
     EXTRA_ENV = {}
 

--- a/testing/enterprise/manifest.toml
+++ b/testing/enterprise/manifest.toml
@@ -46,6 +46,8 @@ run-if = [
 
 ["test_felt_browser_signout.py"]
 
+["test_felt_browser_token_refresh.py"]
+
 ["test_felt_browser_signout_verify.py"]
 
 ["test_felt_browser_starts.py"]

--- a/testing/enterprise/test_felt_browser_token_refresh.py
+++ b/testing/enterprise/test_felt_browser_token_refresh.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import os
+import sys
+
+sys.path.append(os.path.dirname(__file__))
+
+from base_test import Environment
+from felt_tests import FeltLogoutChecker, FeltTests
+from marionette_driver.by import By
+
+
+class BrowserTokenRefresh(FeltTests):
+    def setup(self):
+        super().setup()
+        self.felt_logout_checker = FeltLogoutChecker(self)
+
+    def _setup_beforeunload_tab(self):
+        # Creates a dirty tab with a beforeunload handler that will show a popup when closed.
+        self._child_driver.navigate("about:blank")
+        self._child_driver.execute_script(
+            'document.body.innerHTML = \'<input placeholder="type something"><a href="about:blank#">leave</a>\';'
+            "window.addEventListener('beforeunload', e => { e.preventDefault(); e.returnValue = ''; });"
+        )
+        input_el = self._child_driver.find_element(By.TAG_NAME, "input")
+        input_el.click()
+        input_el.send_keys("dirty")
+        new_handle = self._child_driver.open(type="tab")
+        self._child_driver.switch_to_window(new_handle["handle"])
+
+    def assert_browser_closes_on_401(self):
+        old_access_token = self.policy_access_token.value
+        old_refresh_token = self.policy_refresh_token.value
+        self.policy_access_token.value = ""
+        self.policy_refresh_token.value = ""
+
+        # Trigger an auth request with invalid tokens, expecting a forced logout.
+        with self.felt_logout_checker.assert_browser_logouts_with(
+            "console-forced-logout"
+        ):
+            self.get_logged_in_user_info(env=Environment.FIREFOX)
+        self._manually_closed_child = True
+        self.assert_child_browser_closed()
+
+        self.await_felt_auth_window()
+        self.force_window()
+        self.assert_user_signed_out(env=Environment.FELT)
+
+        self.policy_access_token.value = old_access_token
+        self.policy_refresh_token.value = old_refresh_token
+
+    def test_transparent_token_refresh(self):
+        super().run_felt_base()
+        self.connect_child_browser()
+        self.assert_user_signed_in(env=Environment.FIREFOX)
+
+        old_access_token = self.policy_access_token.value
+        self.policy_access_token.value = ""
+
+        self.assert_user_signed_in(env=Environment.FIREFOX)
+
+        self.policy_access_token.value = old_access_token
+
+    def test_forced_signout_on_401(self):
+        super().run_felt_base()
+        self.connect_child_browser()
+        self.assert_user_signed_in(env=Environment.FIREFOX)
+        self.assert_browser_closes_on_401()
+
+    def test_beforeunload_is_closed_on_401(self):
+        super().run_felt_base()
+        self.connect_child_browser()
+        self._setup_beforeunload_tab()
+        self.assert_user_signed_in(env=Environment.FIREFOX)
+
+        # trigger onbeforeunload popup in a nonblocking way
+        self._child_driver.set_context("chrome")
+        self._child_driver.execute_script(
+            "setTimeout(() => Services.startup.quit(Ci.nsIAppStartup.eAttemptQuit), 0);"
+        )
+        self._child_driver.set_context("content")
+
+        self._child_wait.until(lambda d: d.switch_to_alert())
+        self.assert_browser_closes_on_401()

--- a/testing/enterprise/test_felt_browser_token_refresh.py
+++ b/testing/enterprise/test_felt_browser_token_refresh.py
@@ -88,7 +88,7 @@ class BrowserTokenRefresh(FeltTests):
         self._driver.set_context("chrome")
         info_bar = self.get_elem(".felt-browser-info-console-forced-logout")
         heading = info_bar.get_attribute("heading").strip()
-        assert "You've been signed out" in heading, (
+        assert "You’ve been signed out" in heading, (
             f"Unexpected info bar heading: {heading}"
         )
         self._driver.set_context("content")

--- a/testing/enterprise/test_felt_browser_token_refresh.py
+++ b/testing/enterprise/test_felt_browser_token_refresh.py
@@ -85,3 +85,10 @@ class BrowserTokenRefresh(FeltTests):
 
         self._child_wait.until(lambda d: d.switch_to_alert())
         self.assert_browser_closes_on_401()
+        self._driver.set_context("chrome")
+        info_bar = self.get_elem(".felt-browser-info-console-forced-logout")
+        heading = info_bar.get_attribute("heading").strip()
+        assert "You've been signed out" in heading, (
+            f"Unexpected info bar heading: {heading}"
+        )
+        self._driver.set_context("content")


### PR DESCRIPTION
This patch implements promptForReauthentication() to force-quit the Firefox browser and trigger a sign-out, so FELT can take over and show the auth window again.