### PR TITLE
Bug 2013840  - Attempt to fix SSO callback token extraction failing after cross-process navigation

### DIFF
--- a/browser/extensions/felt/api.js
+++ b/browser/extensions/felt/api.js
@@ -185,6 +185,10 @@ this.felt = class extends ExtensionAPI {
   async onStartup() {
     if (Services.felt.isFeltUI()) {
       Services.prefs.setBoolPref("identity.fxaccounts.enabled", false);
+      // Disable QoS thread priority demotion: background content processes get
+      // their main thread demoted to low-priority QoS, which can starve the
+      // SSO callback's DOMContentLoaded event and prevent token extraction.
+      Services.prefs.setBoolPref("threads.use_low_power.enabled", false);
       this.registerChrome();
       this.registerActors();
       await lazy.FeltStorage.init();

--- a/browser/extensions/felt/api.js
+++ b/browser/extensions/felt/api.js
@@ -44,6 +44,9 @@ this.felt = class extends ExtensionAPI {
     );
     const matches = [ConsoleClient.ssoCallbackUriMatchPattern];
     ChromeUtils.registerWindowActor(this.FELT_WINDOW_ACTOR, {
+      parent: {
+        esModuleURI: "chrome://felt/content/FeltWindowParent.sys.mjs",
+      },
       child: {
         esModuleURI: "chrome://felt/content/FeltWindowChild.sys.mjs",
         events: {

--- a/browser/extensions/felt/content/FeltWindowChild.sys.mjs
+++ b/browser/extensions/felt/content/FeltWindowChild.sys.mjs
@@ -8,30 +8,51 @@ console.debug(`FeltExtension: FeltWindowChild.sys.mjs`);
  *
  */
 export class FeltWindowChild extends JSWindowActorChild {
+  #tokensSent = false;
+
   actorCreated() {
-    this.actor = ChromeUtils.domProcessChild.getActor("FeltProcess");
+    this.processActor = ChromeUtils.domProcessChild.getActor("FeltProcess");
   }
 
   handleEvent(event) {
     if (event.type !== "DOMContentLoaded") {
-      console.error(`Unexpected event.type=${event.type}`);
       return;
     }
+    this.#extractAndSendTokens(event.target);
+  }
 
-    const tokenData = event.target.querySelector("#token_data");
-    if (tokenData) {
-      console.debug("FeltWindowChild: Extracting token data");
-      const consoleTokenData = JSON.parse(tokenData.textContent);
-      if (
-        consoleTokenData &&
-        "access_token" in consoleTokenData &&
-        consoleTokenData.access_token !== ""
-      ) {
-        console.debug(
-          "FeltWindowChild: Sending token data to ConsoleClient and starting Firefox"
-        );
-        this.actor.sendAsyncMessage("FeltChild:StartFirefox", consoleTokenData);
-      }
+  receiveMessage(message) {
+    if (message.name === "ExtractTokens") {
+      return this.#extractAndSendTokens(this.document);
     }
+    return false;
+  }
+
+  #extractAndSendTokens(doc) {
+    if (this.#tokensSent) {
+      return true;
+    }
+
+    const tokenData = doc.querySelector("#token_data");
+    if (!tokenData) {
+      return false;
+    }
+
+    console.debug("FeltWindowChild: Extracting token data");
+    const consoleTokenData = JSON.parse(tokenData.textContent);
+    if (
+      consoleTokenData &&
+      "access_token" in consoleTokenData &&
+      consoleTokenData.access_token !== ""
+    ) {
+      console.debug("FeltWindowChild: Sending token data to start Firefox");
+      this.#tokensSent = true;
+      this.processActor.sendAsyncMessage(
+        "FeltChild:StartFirefox",
+        consoleTokenData
+      );
+      return true;
+    }
+    return false;
   }
 }

--- a/browser/extensions/felt/content/FeltWindowParent.sys.mjs
+++ b/browser/extensions/felt/content/FeltWindowParent.sys.mjs
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Parent-side actor for the SSO callback page.
+ *
+ * WindowGlobalParent.getActor() requires a parent class to be registered.
+ * The webProgress fallback in window.js calls
+ *   windowGlobal.getActor("FeltWindow").sendQuery("ExtractTokens")
+ * which force-creates the actor pair (parent + child) and delivers the
+ * message to the child process. Without this class, getActor() would fail
+ * because no parent module is registered for the "FeltWindow" actor.
+ *
+ * See the webProgress fallback in window.js for details. A cross-process
+ * navigation during the SSO redirect chain can cause the child-side
+ * DOMContentLoaded event to never reach the FeltWindowChild actor.
+ */
+export class FeltWindowParent extends JSWindowActorParent {}

--- a/browser/extensions/felt/content/felt.xhtml
+++ b/browser/extensions/felt/content/felt.xhtml
@@ -188,6 +188,10 @@
             <span data-l10n-id="felt-browser-error-connection"></span>
             <span class="felt-browser-error-details"></span>
           </div>
+          <div
+            class="felt-browser-error-sso-timeout is-hidden"
+            data-l10n-id="felt-browser-error-sso-timeout"
+          ></div>
           <div class="felt-updates-error-messages is-hidden">
             <span data-l10n-id="felt-updates-error-messages"></span>
             <span class="felt-browser-error-details"></span>

--- a/browser/extensions/felt/content/window.js
+++ b/browser/extensions/felt/content/window.js
@@ -150,8 +150,9 @@ async function connectToConsole(email) {
   // DOMContentLoaded handler to never fire. Monitor the navigation from the
   // parent process and explicitly trigger token extraction when the callback
   // page finishes loading.
-  const callbackPath = lazy.ConsoleClient._paths.SSO_CALLBACK;
-  const callbackHost = lazy.ConsoleClient.consoleBaseURI.host;
+  const callbackPattern = new MatchPattern(
+    lazy.ConsoleClient.ssoCallbackUriMatchPattern
+  );
   const progressListener = {
     QueryInterface: ChromeUtils.generateQI([
       "nsIWebProgressListener",
@@ -167,7 +168,7 @@ async function connectToConsole(email) {
       }
 
       const uri = webProgress.browsingContext?.currentWindowGlobal?.documentURI;
-      if (!uri || uri.host !== callbackHost || uri.filePath !== callbackPath) {
+      if (!uri || !callbackPattern.matches(uri.spec)) {
         return;
       }
 

--- a/browser/extensions/felt/content/window.js
+++ b/browser/extensions/felt/content/window.js
@@ -159,7 +159,7 @@ async function connectToConsole(email) {
       "nsISupportsWeakReference",
     ]),
 
-    onStateChange(webProgress, _request, stateFlags, _status) {
+    onStateChange(webProgress, _request, stateFlags, status) {
       if (
         !(stateFlags & Ci.nsIWebProgressListener.STATE_STOP) ||
         !(stateFlags & Ci.nsIWebProgressListener.STATE_IS_NETWORK)
@@ -174,8 +174,22 @@ async function connectToConsole(email) {
 
       browser.removeProgressListener(progressListener);
 
+      if (!Components.isSuccessCode(status)) {
+        console.error(
+          `FeltExtension: SSO callback page failed to load: 0x${status.toString(16)}`
+        );
+        ErrorReport.update(
+          "felt-browser-error-connection",
+          lazy.ConsoleClient._getErrorNameForStatus(status),
+          { host: uri.host }
+        );
+        return;
+      }
+
       const windowGlobal = browser.browsingContext?.currentWindowGlobal;
       if (!windowGlobal) {
+        console.error("FeltExtension: No WindowGlobal for SSO callback page");
+        ErrorReport.update("felt-browser-error-connection");
         return;
       }
 
@@ -191,21 +205,30 @@ async function connectToConsole(email) {
               console.error(
                 "FeltExtension: Fallback token extraction found no token data"
               );
+              ErrorReport.update("felt-browser-error-connection");
             }
           })
           .catch(err => {
             console.error(
               `FeltExtension: Fallback token extraction failed: ${err}`
             );
+            ErrorReport.update("felt-browser-error-connection");
           });
       } catch (err) {
         console.error(
           `FeltExtension: Could not reach FeltWindow actor: ${err}`
         );
+        ErrorReport.update("felt-browser-error-connection");
       }
     },
 
-    onLocationChange() {},
+    onLocationChange(_webProgress, _request, _location, flags) {
+      if (flags & Ci.nsIWebProgressListener.LOCATION_CHANGE_ERROR_PAGE) {
+        browser.removeProgressListener(progressListener);
+        ErrorReport.update("felt-browser-error-connection");
+      }
+    },
+
     onProgressChange() {},
     onSecurityChange() {},
     onStatusChange() {},
@@ -213,7 +236,7 @@ async function connectToConsole(email) {
   };
   browser.addProgressListener(
     progressListener,
-    Ci.nsIWebProgress.NOTIFY_STATE_NETWORK
+    Ci.nsIWebProgress.NOTIFY_STATE_NETWORK | Ci.nsIWebProgress.NOTIFY_LOCATION
   );
 
   document.querySelector(".felt-login__email-pane").classList.add("is-hidden");

--- a/browser/extensions/felt/content/window.js
+++ b/browser/extensions/felt/content/window.js
@@ -145,6 +145,76 @@ async function connectToConsole(email) {
     triggeringPrincipal: contentPrincipal,
   });
 
+  // Fallback for token extraction: a cross-process navigation during the SSO
+  // redirect chain can cause the FeltWindowChild JSWindowActor's
+  // DOMContentLoaded handler to never fire. Monitor the navigation from the
+  // parent process and explicitly trigger token extraction when the callback
+  // page finishes loading.
+  const callbackPath = lazy.ConsoleClient._paths.SSO_CALLBACK;
+  const callbackHost = lazy.ConsoleClient.consoleBaseURI.host;
+  const progressListener = {
+    QueryInterface: ChromeUtils.generateQI([
+      "nsIWebProgressListener",
+      "nsISupportsWeakReference",
+    ]),
+
+    onStateChange(webProgress, _request, stateFlags, _status) {
+      if (
+        !(stateFlags & Ci.nsIWebProgressListener.STATE_STOP) ||
+        !(stateFlags & Ci.nsIWebProgressListener.STATE_IS_NETWORK)
+      ) {
+        return;
+      }
+
+      const uri = webProgress.browsingContext?.currentWindowGlobal?.documentURI;
+      if (!uri || uri.host !== callbackHost || uri.filePath !== callbackPath) {
+        return;
+      }
+
+      browser.removeProgressListener(progressListener);
+
+      const windowGlobal = browser.browsingContext?.currentWindowGlobal;
+      if (!windowGlobal) {
+        return;
+      }
+
+      // getActor() forces actor instantiation, and sendQuery() delivers the
+      // message to the child process regardless of whether DOMContentLoaded
+      // triggered actor creation.
+      try {
+        windowGlobal
+          .getActor("FeltWindow")
+          .sendQuery("ExtractTokens")
+          .then(sent => {
+            if (!sent) {
+              console.error(
+                "FeltExtension: Fallback token extraction found no token data"
+              );
+            }
+          })
+          .catch(err => {
+            console.error(
+              `FeltExtension: Fallback token extraction failed: ${err}`
+            );
+          });
+      } catch (err) {
+        console.error(
+          `FeltExtension: Could not reach FeltWindow actor: ${err}`
+        );
+      }
+    },
+
+    onLocationChange() {},
+    onProgressChange() {},
+    onSecurityChange() {},
+    onStatusChange() {},
+    onContentBlockingEvent() {},
+  };
+  browser.addProgressListener(
+    progressListener,
+    Ci.nsIWebProgress.NOTIFY_STATE_NETWORK
+  );
+
   document.querySelector(".felt-login__email-pane").classList.add("is-hidden");
   document.querySelector(".felt-login__sso").classList.remove("is-hidden");
 

--- a/browser/extensions/felt/content/window.js
+++ b/browser/extensions/felt/content/window.js
@@ -150,9 +150,36 @@ async function connectToConsole(email) {
   // DOMContentLoaded handler to never fire. Monitor the navigation from the
   // parent process and explicitly trigger token extraction when the callback
   // page finishes loading.
+  const SSO_TIMEOUT_MS = Services.prefs.getIntPref(
+    "enterprise.sso.timeout_ms",
+    60000
+  );
   const callbackPattern = new MatchPattern(
     lazy.ConsoleClient.ssoCallbackUriMatchPattern
   );
+
+  let ssoCompleted = false;
+
+  function resetToLoginPage(errorType, details = null, cause = null) {
+    if (ssoCompleted) {
+      return;
+    }
+    ssoCompleted = true;
+    try {
+      browser.removeProgressListener(progressListener);
+    } catch (_) {}
+    document.querySelector(".felt-login__sso").classList.add("is-hidden");
+    document
+      .querySelector(".felt-login__email-pane")
+      .classList.remove("is-hidden");
+    ErrorReport.update(errorType, details, cause);
+  }
+
+  let ssoTimeout = setTimeout(() => {
+    console.error("FeltExtension: SSO login timed out");
+    resetToLoginPage("felt-browser-error-sso-timeout");
+  }, SSO_TIMEOUT_MS);
+
   const progressListener = {
     QueryInterface: ChromeUtils.generateQI([
       "nsIWebProgressListener",
@@ -172,13 +199,15 @@ async function connectToConsole(email) {
         return;
       }
 
+      clearTimeout(ssoTimeout);
       browser.removeProgressListener(progressListener);
+      ssoCompleted = true;
 
       if (!Components.isSuccessCode(status)) {
         console.error(
           `FeltExtension: SSO callback page failed to load: 0x${status.toString(16)}`
         );
-        ErrorReport.update(
+        resetToLoginPage(
           "felt-browser-error-connection",
           lazy.ConsoleClient._getErrorNameForStatus(status),
           { host: uri.host }
@@ -189,7 +218,7 @@ async function connectToConsole(email) {
       const windowGlobal = browser.browsingContext?.currentWindowGlobal;
       if (!windowGlobal) {
         console.error("FeltExtension: No WindowGlobal for SSO callback page");
-        ErrorReport.update("felt-browser-error-connection");
+        resetToLoginPage("felt-browser-error-connection");
         return;
       }
 
@@ -205,34 +234,38 @@ async function connectToConsole(email) {
               console.error(
                 "FeltExtension: Fallback token extraction found no token data"
               );
-              ErrorReport.update("felt-browser-error-connection");
+              resetToLoginPage("felt-browser-error-connection");
             }
           })
           .catch(err => {
             console.error(
               `FeltExtension: Fallback token extraction failed: ${err}`
             );
-            ErrorReport.update("felt-browser-error-connection");
+            resetToLoginPage("felt-browser-error-connection");
           });
       } catch (err) {
         console.error(
           `FeltExtension: Could not reach FeltWindow actor: ${err}`
         );
-        ErrorReport.update("felt-browser-error-connection");
+        resetToLoginPage("felt-browser-error-connection");
       }
     },
 
     onLocationChange(_webProgress, _request, _location, flags) {
       if (flags & Ci.nsIWebProgressListener.LOCATION_CHANGE_ERROR_PAGE) {
-        browser.removeProgressListener(progressListener);
-        ErrorReport.update("felt-browser-error-connection");
+        clearTimeout(ssoTimeout);
+        resetToLoginPage("felt-browser-error-connection");
+        return;
       }
+      // Reset the timeout on each navigation so the limit applies per-page
+      // rather than to the entire SSO flow (which may involve slow networks,
+      // MFA prompts, etc.).
+      clearTimeout(ssoTimeout);
+      ssoTimeout = setTimeout(() => {
+        console.error("FeltExtension: SSO login timed out");
+        resetToLoginPage("felt-browser-error-sso-timeout");
+      }, SSO_TIMEOUT_MS);
     },
-
-    onProgressChange() {},
-    onSecurityChange() {},
-    onStatusChange() {},
-    onContentBlockingEvent() {},
   };
   browser.addProgressListener(
     progressListener,

--- a/browser/locales/en-US/browser/enterprise/felt.ftl
+++ b/browser/locales/en-US/browser/enterprise/felt.ftl
@@ -24,6 +24,7 @@ felt-version =
 
 felt-browser-error-multiple-crashes = { -brand-short-name } crashed multiple times.
 felt-browser-error-connection = Unable to connect to the console. Please contact your administrator.
+felt-browser-error-sso-timeout = Sign-in timed out. Please try again, or contact your administrator if the problem persists.
 
 ## Network error details.
 


### PR DESCRIPTION
A cross-process navigation during the SSO redirect chain (IdP -> MFA -> callback) can cause the FeltWindowChild JSWindowActor's DOMContentLoaded handler to never fire in the destination content process. When this happens, no tokens are extracted, Firefox is never launched, and the user sees an empty page in Felt.

Add a webProgress listener in the Felt parent process as a fallback. When the callback page finishes loading (STATE_STOP), it explicitly creates the FeltWindow actor pair via getActor() and sends an ExtractTokens query to the child process. This bypasses the flaky event-based actor instantiation. A dedup flag in FeltWindowChild prevents double-processing when both paths succeed.