### PR TITLE
Add a lot of logspam for the SSO flow

### DIFF
--- a/browser/extensions/felt/api.js
+++ b/browser/extensions/felt/api.js
@@ -43,6 +43,9 @@ this.felt = class extends ExtensionAPI {
       "resource:///modules/enterprise/ConsoleClient.sys.mjs"
     );
     const matches = [ConsoleClient.ssoCallbackUriMatchPattern];
+    console.warn(
+      `[FeltActors] Registering FeltWindow actor, matches=${JSON.stringify(matches)}`
+    );
     ChromeUtils.registerWindowActor(this.FELT_WINDOW_ACTOR, {
       child: {
         esModuleURI: "chrome://felt/content/FeltWindowChild.sys.mjs",
@@ -54,6 +57,7 @@ this.felt = class extends ExtensionAPI {
       allFrames: true,
       matches,
     });
+    console.warn("[FeltActors] FeltWindow actor registered");
 
     // We use a much simpler version of the context menu so replace the default actor with our own.
     ChromeUtils.unregisterWindowActor("ContextMenu");

--- a/browser/extensions/felt/content/FeltProcessParent.sys.mjs
+++ b/browser/extensions/felt/content/FeltProcessParent.sys.mjs
@@ -637,8 +637,9 @@ export class FeltProcessParent extends JSProcessActorParent {
   }
 
   async receiveMessage(message) {
-    console.debug(
-      `FeltExtension: ParentProcess: Received message ${message.name} => ${message.data}`
+    console.warn(
+      `[FeltProcessParent] receiveMessage: ${message.name}, ` +
+        `data keys=${Object.keys(message.data || {})}`
     );
     switch (message.name) {
       case "FeltChild:StartFirefox":

--- a/browser/extensions/felt/content/FeltWindowChild.sys.mjs
+++ b/browser/extensions/felt/content/FeltWindowChild.sys.mjs
@@ -2,36 +2,70 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-console.debug(`FeltExtension: FeltWindowChild.sys.mjs`);
+console.warn("[FeltWindowChild] Module loaded");
 
 /**
  *
  */
 export class FeltWindowChild extends JSWindowActorChild {
   actorCreated() {
-    this.actor = ChromeUtils.domProcessChild.getActor("FeltProcess");
+    console.warn(
+      `[FeltWindowChild] actorCreated, ` +
+        `browsingContext=${this.browsingContext?.id}, ` +
+        `uri=${this.document?.documentURI}`
+    );
+    try {
+      this.actor = ChromeUtils.domProcessChild.getActor("FeltProcess");
+      console.warn(`[FeltWindowChild] Got FeltProcess actor: ${!!this.actor}`);
+    } catch (e) {
+      console.warn(`[FeltWindowChild] FAILED to get FeltProcess actor: ${e}`);
+    }
   }
 
   handleEvent(event) {
+    console.warn(
+      `[FeltWindowChild] handleEvent: type=${event.type}, ` +
+        `uri=${event.target?.documentURI || "(unknown)"}`
+    );
     if (event.type !== "DOMContentLoaded") {
-      console.error(`Unexpected event.type=${event.type}`);
       return;
     }
 
     const tokenData = event.target.querySelector("#token_data");
-    if (tokenData) {
-      console.debug("FeltWindowChild: Extracting token data");
-      const consoleTokenData = JSON.parse(tokenData.textContent);
-      if (
-        consoleTokenData &&
-        "access_token" in consoleTokenData &&
-        consoleTokenData.access_token !== ""
-      ) {
-        console.debug(
-          "FeltWindowChild: Sending token data to ConsoleClient and starting Firefox"
-        );
-        this.actor.sendAsyncMessage("FeltChild:StartFirefox", consoleTokenData);
-      }
+    if (!tokenData) {
+      console.warn(
+        `[FeltWindowChild] No #token_data on page, ` +
+          `readyState=${event.target.readyState}, ` +
+          `bodyLen=${event.target.body?.innerHTML?.length ?? "N/A"}`
+      );
+      return;
     }
+
+    console.warn(
+      `[FeltWindowChild] Found #token_data, ` +
+        `length=${tokenData.textContent?.length}`
+    );
+    const consoleTokenData = JSON.parse(tokenData.textContent);
+    if (
+      consoleTokenData &&
+      "access_token" in consoleTokenData &&
+      consoleTokenData.access_token !== ""
+    ) {
+      console.warn("[FeltWindowChild] Sending FeltChild:StartFirefox");
+      this.actor.sendAsyncMessage("FeltChild:StartFirefox", consoleTokenData);
+      console.warn("[FeltWindowChild] Message sent");
+    } else {
+      console.warn(
+        `[FeltWindowChild] Token data invalid: ` +
+          `keys=${Object.keys(consoleTokenData || {})}`
+      );
+    }
+  }
+
+  didDestroy() {
+    console.warn(
+      `[FeltWindowChild] didDestroy, ` +
+        `browsingContext=${this.browsingContext?.id}`
+    );
   }
 }

--- a/browser/extensions/felt/content/window.js
+++ b/browser/extensions/felt/content/window.js
@@ -145,6 +145,78 @@ async function connectToConsole(email) {
     triggeringPrincipal: contentPrincipal,
   });
 
+  // Diagnostic: log all navigation events to stderr to trace the SSO
+  // redirect chain, process switches, and actor instantiation.
+  const debugListener = {
+    QueryInterface: ChromeUtils.generateQI([
+      "nsIWebProgressListener",
+      "nsISupportsWeakReference",
+    ]),
+    onStateChange(webProgress, request, stateFlags, status) {
+      const isStart = stateFlags & Ci.nsIWebProgressListener.STATE_START;
+      const isStop = stateFlags & Ci.nsIWebProgressListener.STATE_STOP;
+      const isNetwork = stateFlags & Ci.nsIWebProgressListener.STATE_IS_NETWORK;
+      const isDocument =
+        stateFlags & Ci.nsIWebProgressListener.STATE_IS_DOCUMENT;
+      if (!isNetwork && !isDocument) {
+        return;
+      }
+      const wg = webProgress.browsingContext?.currentWindowGlobal;
+      const uri = wg?.documentURI?.spec || request?.name || "(unknown)";
+      const pid = wg?.osPid ?? "?";
+      const innerWindowId = wg?.innerWindowId ?? "?";
+      const flags = [];
+      if (isStart) {
+        flags.push("START");
+      }
+      if (isStop) {
+        flags.push("STOP");
+      }
+      if (isNetwork) {
+        flags.push("NETWORK");
+      }
+      if (isDocument) {
+        flags.push("DOCUMENT");
+      }
+      console.warn(
+        `[SSO-debug] onStateChange: ${flags.join("|")} ` +
+          `status=0x${status.toString(16)} pid=${pid} ` +
+          `innerWindowId=${innerWindowId} uri=${uri}`
+      );
+    },
+    onLocationChange(webProgress, request, location, flags) {
+      const wg = webProgress.browsingContext?.currentWindowGlobal;
+      const pid = wg?.osPid ?? "?";
+      const innerWindowId = wg?.innerWindowId ?? "?";
+      const flagNames = [];
+      if (flags & Ci.nsIWebProgressListener.LOCATION_CHANGE_SAME_DOCUMENT) {
+        flagNames.push("SAME_DOCUMENT");
+      }
+      if (flags & Ci.nsIWebProgressListener.LOCATION_CHANGE_ERROR_PAGE) {
+        flagNames.push("ERROR_PAGE");
+      }
+      if (flags & Ci.nsIWebProgressListener.LOCATION_CHANGE_RELOAD) {
+        flagNames.push("RELOAD");
+      }
+      console.warn(
+        `[SSO-debug] onLocationChange: pid=${pid} ` +
+          `innerWindowId=${innerWindowId} ` +
+          `flags=${flagNames.join("|") || "0"} ` +
+          `uri=${location?.spec}`
+      );
+    },
+    onProgressChange() {},
+    onSecurityChange() {},
+    onStatusChange() {},
+    onContentBlockingEvent() {},
+  };
+  browser.addProgressListener(
+    debugListener,
+    Ci.nsIWebProgress.NOTIFY_STATE_NETWORK |
+      Ci.nsIWebProgress.NOTIFY_STATE_DOCUMENT |
+      Ci.nsIWebProgress.NOTIFY_LOCATION
+  );
+
   document.querySelector(".felt-login__email-pane").classList.add("is-hidden");
   document.querySelector(".felt-login__sso").classList.remove("is-hidden");
 

--- a/dom/ipc/jsactor/JSWindowActorProtocol.cpp
+++ b/dom/ipc/jsactor/JSWindowActorProtocol.cpp
@@ -19,6 +19,33 @@
 #include "mozilla/extensions/MatchPattern.h"
 #include "nsContentUtils.h"
 
+#ifdef XP_MACOSX
+#  include <pthread/qos.h>
+#  include <sys/resource.h>
+#  include <unistd.h>
+#endif
+
+#ifdef XP_MACOSX
+static const char* QoSClassName(qos_class_t qc) {
+  switch (qc) {
+    case QOS_CLASS_USER_INTERACTIVE:
+      return "USER_INTERACTIVE";
+    case QOS_CLASS_USER_INITIATED:
+      return "USER_INITIATED";
+    case QOS_CLASS_DEFAULT:
+      return "DEFAULT";
+    case QOS_CLASS_UTILITY:
+      return "UTILITY";
+    case QOS_CLASS_BACKGROUND:
+      return "BACKGROUND";
+    case QOS_CLASS_UNSPECIFIED:
+      return "UNSPECIFIED";
+    default:
+      return "UNKNOWN";
+  }
+}
+#endif
+
 namespace mozilla::dom {
 
 NS_IMPL_CYCLE_COLLECTING_ADDREF(JSWindowActorProtocol)
@@ -151,6 +178,8 @@ JSWindowActorProtocol::FromWebIDLOptions(const nsACString& aName,
 NS_IMETHODIMP JSWindowActorProtocol::HandleEvent(Event* aEvent) {
   MOZ_ASSERT(nsContentUtils::IsSafeToRunScript());
 
+  bool isFeltWindow = mName.EqualsLiteral("FeltWindow");
+
   // Determine which inner window we're associated with, and get its
   // WindowGlobalChild actor.
   EventTarget* target = aEvent->GetOriginalTarget();
@@ -166,11 +195,44 @@ NS_IMETHODIMP JSWindowActorProtocol::HandleEvent(Event* aEvent) {
 
   RefPtr<WindowGlobalChild> wgc = inner->GetWindowGlobalChild();
   if (NS_WARN_IF(!wgc)) {
+    if (isFeltWindow) {
+      nsAutoString eventType;
+      aEvent->GetType(eventType);
+      printf_stderr(
+          "[FeltWindow] HandleEvent(%s): no WindowGlobalChild, "
+          "innerWindowId=%" PRIu64 "\n",
+          NS_ConvertUTF16toUTF8(eventType).get(), inner->WindowID());
+    }
     return NS_ERROR_FAILURE;
   }
 
   if (aEvent->ShouldIgnoreChromeEventTargetListener()) {
     return NS_OK;
+  }
+
+  if (isFeltWindow) {
+    nsAutoString eventType;
+    aEvent->GetType(eventType);
+    nsCOMPtr<nsIURI> docURI = wgc->GetDocumentURI();
+    nsAutoCString docSpec;
+    if (docURI) {
+      docURI->GetSpec(docSpec);
+    }
+#ifdef XP_MACOSX
+    qos_class_t qc = QOS_CLASS_UNSPECIFIED;
+    int relPri = 0;
+    pthread_get_qos_class_np(pthread_self(), &qc, &relPri);
+    int niceness = getpriority(PRIO_PROCESS, 0);
+    printf_stderr("[FeltWindow] HandleEvent(%s): innerWindowId=%" PRIu64
+                  " pid=%d qos=%s nice=%d uri=%s\n",
+                  NS_ConvertUTF16toUTF8(eventType).get(), inner->WindowID(),
+                  getpid(), QoSClassName(qc), niceness, docSpec.get());
+#else
+    printf_stderr("[FeltWindow] HandleEvent(%s): innerWindowId=%" PRIu64
+                  " uri=%s\n",
+                  NS_ConvertUTF16toUTF8(eventType).get(), inner->WindowID(),
+                  docSpec.get());
+#endif
   }
 
   // Ensure our actor is present.
@@ -196,7 +258,17 @@ NS_IMETHODIMP JSWindowActorProtocol::HandleEvent(Event* aEvent) {
     }
   }
   if (!actor || NS_WARN_IF(!actor->GetWrapperPreserveColor())) {
+    if (isFeltWindow) {
+      nsAutoString eventType;
+      aEvent->GetType(eventType);
+      printf_stderr("[FeltWindow] HandleEvent(%s): GetActor FAILED\n",
+                    NS_ConvertUTF16toUTF8(eventType).get());
+    }
     return NS_OK;
+  }
+
+  if (isFeltWindow) {
+    printf_stderr("[FeltWindow] HandleEvent: dispatching to actor\n");
   }
 
   // Build our event listener & call it.
@@ -360,6 +432,11 @@ bool JSWindowActorProtocol::Matches(BrowsingContext* aBrowsingContext,
           "Window protocol '%s' doesn't match uri %s", mName.get(),
           nsContentUtils::TruncatedURLForDisplay(aURI).get()));
       return false;
+    }
+    if (mName.EqualsLiteral("FeltWindow")) {
+      nsAutoCString uriSpec;
+      aURI->GetSpec(uriSpec);
+      printf_stderr("[FeltWindow] Matches: URI matched: %s\n", uriSpec.get());
     }
   }
 

--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -623,8 +623,8 @@ pref("toolkit.asyncshutdown.log", false);
 // local full builds but true in artifact builds. Without these definitions
 // here, dumping is disabled in artifact builds (see Bug 1490412).
 #ifdef MOZILLA_OFFICIAL
-  pref("browser.dom.window.dump.enabled", false, sticky);
-  pref("devtools.console.stdout.chrome", false, sticky);
+  pref("browser.dom.window.dump.enabled", true, sticky);
+  pref("devtools.console.stdout.chrome", true, sticky);
 #else
   pref("browser.dom.window.dump.enabled", true, sticky);
   pref("devtools.console.stdout.chrome", true, sticky);


### PR DESCRIPTION
Add dump()/printf_stderr logging to diagnose why FeltWindowChild's DOMContentLoaded handler intermittently fails to fire after a cross-process navigation during the SSO redirect chain.

JS-level (dump to stderr, works in release builds):
- FeltWindowChild: actor lifecycle, event handling, token extraction
- window.js: webProgress listener logging every navigation event with PID, innerWindowId, and URI
- api.js: actor registration with match patterns
- FeltProcessParent: message receipt

C++ platform-level (printf_stderr):
- JSWindowActorProtocol::HandleEvent: every event reaching the protocol handler with actor name, event type, innerWindowId, URI
- JSWindowActorProtocol::Matches: URI match successes
- JSWindowActorProtocol::RegisterListenersFor: event listener setup

This is a diagnostic-only branch, not intended for merge.