### PR TITLE
Bug 2023485 - Enterprise: check for consecutive updates failures

### DIFF
--- a/browser/components/enterprise/modules/Updates.sys.mjs
+++ b/browser/components/enterprise/modules/Updates.sys.mjs
@@ -23,6 +23,8 @@ export const Updates = {
     this._errorReporter = errorReporter;
 
     this.maybeShowUpdateSuccess();
+    // Check this early to avoid re-downloading updates when it would fail
+    await this.updateCheckingAllowed();
 
     if (this._initialized) {
       this.displayLoginState();
@@ -38,7 +40,9 @@ export const Updates = {
 
     this._checkingTimeout = null;
     this._receivedStaging = false;
-    this.displayUpdateState();
+    if (this._canDoUpdateChecking) {
+      this.displayUpdateState();
+    }
 
     if (lazy.isUpdatesTesting()) {
       // on Windows at least, during testing, make sure we let time for the UI to show up
@@ -52,6 +56,14 @@ export const Updates = {
     this.forceUpdateCheck();
 
     this._initialized = true;
+  },
+
+  uninit() {
+    this.unobserve();
+    this.cancelDelayedUpdateCheckUI();
+    this._document = undefined;
+    this._errorReporter = undefined;
+    this._initialized = false;
   },
 
   maybeShowUpdateSuccess() {
@@ -73,6 +85,44 @@ export const Updates = {
     );
   },
 
+  async updateCheckingAllowed() {
+    const UM = Cc["@mozilla.org/updates/update-manager;1"].getService(
+      Ci.nsIUpdateManager
+    );
+    // History is limited to 10 items, each install attempt should report a failure
+    const history = await UM.getHistory().catch(ex => {
+      console.error(`FeltUpdates: updateCheckingAllowed failed`, ex);
+      return null;
+    });
+    if (history) {
+      // The UpdaterManager history's capped at 10 max.
+      const maxConsecutiveUpdateFailures = Math.min(
+        Services.prefs.getIntPref(
+          "enterprise.felt.max_consecutive_update_failure",
+          3
+        ),
+        10
+      );
+      const firstNonFailed = history.findIndex(
+        update => update.state !== "failed"
+      );
+      const consecutiveUpdateFailures =
+        firstNonFailed === -1 ? history.length : firstNonFailed;
+      console.warn(
+        `FeltUpdates: updateCheckingAllowed: ${consecutiveUpdateFailures}, max ${maxConsecutiveUpdateFailures}`
+      );
+      if (consecutiveUpdateFailures > maxConsecutiveUpdateFailures) {
+        console.warn(
+          `FeltUpdates: updateCheckingAllowed: skip startup update check because consecutive update failures: ${consecutiveUpdateFailures}, max ${maxConsecutiveUpdateFailures}`
+        );
+        this._canDoUpdateChecking = false;
+        return;
+      }
+    }
+
+    this._canDoUpdateChecking = true;
+  },
+
   prepareUpdateCheck() {
     this._appUpdater = new lazy.AppUpdater();
     this._updaterCallback = this.appUpdaterCallback.bind(this);
@@ -83,10 +133,21 @@ export const Updates = {
   },
 
   forceUpdateCheck() {
+    if (this._canDoUpdateChecking !== true) {
+      console.warn(
+        `FeltUpdates: forceUpdateCheck(): skip because previous updates failures`
+      );
+      this.displayLoginStateWithUpdateError("contact-admin");
+      return;
+    }
+
     this._appUpdater
       .check()
       .catch(err => {
-        console.error(`AppUpdater failure: ${err}`, err);
+        console.error(
+          `Felt: forceUpdateCheck(): AppUpdater failure: ${err}`,
+          err
+        );
         this.displayLoginStateWithUpdateError("contact-admin");
       })
       .finally(() => {
@@ -276,6 +337,13 @@ export const Updates = {
       });
   },
 
+  unobserve() {
+    Services.obs.removeObserver(this, "update-staged");
+    Services.obs.removeObserver(this, "update-downloaded");
+    Services.obs.removeObserver(this, "update-error");
+    Services.obs.removeObserver(this, "xpcom-shutdown");
+  },
+
   observe(subject, topic, state) {
     // We would coerce subject
     //   update = subject && subject.QueryInterface(Ci.nsIUpdate);
@@ -284,10 +352,7 @@ export const Updates = {
     console.warn(`FeltUpdates: observer: topic:${topic} state:${state}`);
     switch (topic) {
       case "xpcom-shutdown":
-        Services.obs.removeObserver(this, "update-staged");
-        Services.obs.removeObserver(this, "update-downloaded");
-        Services.obs.removeObserver(this, "update-error");
-        Services.obs.removeObserver(this, "xpcom-shutdown");
+        this.unobserve();
         break;
       case "update-staged":
       case "update-downloaded":

--- a/testing/enterprise/base_test.py
+++ b/testing/enterprise/base_test.py
@@ -37,7 +37,7 @@ class EnterpriseTestsBase(MarionetteTestCase):
             self.marionette.instance.app_args += self._extra_cli_args
 
         self.marionette.quit(in_app=False, clean=True)
-        self.marionette.start_session()
+        self.marionette.start_session(timeout=60)
 
         if hasattr(self, "_extra_prefs"):
             self.marionette.enforce_gecko_prefs(self._extra_prefs)
@@ -137,7 +137,7 @@ class EnterpriseTestsBase(MarionetteTestCase):
         assert marionette_port != 2828, "Marionette port should not be default value"
 
         self._child_driver = Marionette(host="127.0.0.1", port=new_marionette_port)
-        self._child_driver.start_session(capabilities)
+        self._child_driver.start_session(capabilities, timeout=60)
 
     def get_driver(self, env):
         return self._driver if env == Environment.FELT else self._child_driver

--- a/testing/enterprise/felt_tests.py
+++ b/testing/enterprise/felt_tests.py
@@ -215,20 +215,18 @@ class ConsoleHttpHandler(LocalHttpRequestHandler):
             })
             contentType = "application/json"
 
+        elif path == "/api/browser/forced_updates_count":
+            """
+            This is a test only endpoint to verify how many updates were served
+            """
+
+            m = json.dumps({
+                "serve_forced_updates_count": self.server.serve_forced_updates_count
+            })
+            contentType = "application/json"
+
         # /api/browser/updates/FirefoxEnterprise/149.0a1/20260218134117/Linux_x86_64-gcc3/en-US/default/Linux%25206.17.0-8-generic%2520(GTK%25203.24.50%252Clibpulse%252017.0.0)/ISET%3ASSE4_2%2CMEM%3A85823/default/default/update.xml?force=1"
         elif path.startswith("/api/browser/updates"):
-            # Versions are important, they need to be equal or higher than the
-            # curernt binary otherwise no update will be downloaded
-            display_version = self.server.serve_updates_version["application_version"][
-                0
-            ]
-            app_version = self.server.serve_updates_version["application_version"][0]
-            platform_version = self.server.serve_updates_version["platform_version"][0]
-            # BuildID also needs to be different, fake it as newer
-            build_id = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
-            # Hash is not verified client side? At least we can put what we want
-            hash_value = "ecee0f4b9f0af06cfa3a89c328e4cbb7dd075a0d411ef1b968a072a7995a0753dd96d3d541f0781ab95fdb61e3df7252a9379fc620f2b660ecaed582f2c5246d"
-
             # Producing this requires:
             # $ mach build && mach package
             # then extract the tar somewhere, you have firefox/
@@ -239,6 +237,22 @@ class ConsoleHttpHandler(LocalHttpRequestHandler):
                 os.path.dirname(__file__), os.path.basename("complete.mar")
             )
             if self.server.serve_updates and os.path.isfile(complete_mar):
+                # Versions are important, they need to be equal or higher than the
+                # curernt binary otherwise no update will be downloaded
+                display_version = self.server.serve_updates_version[
+                    "application_version"
+                ][0]
+                app_version = self.server.serve_updates_version["application_version"][
+                    0
+                ]
+                platform_version = self.server.serve_updates_version[
+                    "platform_version"
+                ][0]
+                # BuildID also needs to be different, fake it as newer
+                build_id = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
+                # Hash is not verified client side? At least we can put what we want
+                hash_value = "ecee0f4b9f0af06cfa3a89c328e4cbb7dd075a0d411ef1b968a072a7995a0753dd96d3d541f0781ab95fdb61e3df7252a9379fc620f2b660ecaed582f2c5246d"
+
                 size = os.stat(complete_mar).st_size
                 m = f"""<?xml version="1.0"?>
 <updates>
@@ -248,6 +262,9 @@ class ConsoleHttpHandler(LocalHttpRequestHandler):
 </updates>"""
             else:
                 m = """<?xml version="1.0"?><updates></updates>"""
+
+            if "?force=1" in self.path:
+                self.server.serve_forced_updates_count += 1
 
             contentType = "text/xml"
 
@@ -382,6 +399,14 @@ class ConsoleHttpHandler(LocalHttpRequestHandler):
             self.check_auth()
             m = json.dumps(None)
 
+        elif path == "/api/browser/forced_updates_count":
+            """
+            This is a test only endpoint to reset how many updates were served
+            """
+
+            self.server.serve_forced_updates_count = 0
+            m = json.dumps(None)
+
         elif path.startswith("/api/browser/updates"):
             self.server.serve_updates = not self.server.serve_updates
             payload = self.rfile.read(int(self.headers.get("Content-Length"))).decode(
@@ -450,6 +475,7 @@ def serve(
         httpd.policy_refresh_token = policy_refresh_token
     httpd.serve_updates = False
     httpd.serve_updates_version = ""
+    httpd.serve_forced_updates_count = 0
     """
     TODO: Behavior is not yet clearly defined
     if device_posture_reply_forbidden is not None:

--- a/testing/enterprise/felt_updater_errors.py
+++ b/testing/enterprise/felt_updater_errors.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import os
+import sys
+
+import requests
+
+sys.path.append(os.path.dirname(__file__))
+
+from felt_tests import FeltTests
+
+
+class FeltUpdaterErrorsBase(FeltTests):
+    def get_update_config_file_path(self):
+        self._driver.set_context("chrome")
+        rv = self._driver.execute_script(
+            """
+            const { UpdateUtils } = ChromeUtils.importESModule("resource://gre/modules/UpdateUtils.sys.mjs");
+            return UpdateUtils.getConfigFilePath();
+            """
+        )
+        self._driver.set_context("content")
+        return rv
+
+    def reload_chrome_window(self):
+        self._driver.set_context("chrome")
+        self._driver.execute_async_script(
+            """
+            const callback = arguments[arguments.length - 1];
+            const UM = Cc["@mozilla.org/updates/update-manager;1"].getService(Ci.nsIUpdateManager);
+            UM.internal.reload(false).then(() => {
+              const { Updates } = ChromeUtils.importESModule("resource:///modules/enterprise/Updates.sys.mjs");
+              Updates.uninit();
+              window.location.reload();
+            }).finally(() => callback());
+            """
+        )
+        self._driver.set_context("content")
+
+    def get_updates_served(self):
+        return requests.get(
+            f"http://localhost:{self.console_port}/api/browser/forced_updates_count"
+        ).json()["serve_forced_updates_count"]
+
+    def assert_updates_served(self, amount):
+        served = self.get_updates_served()
+        self._logger.info(f"Checking updates served: {amount} vs {served}")
+        self._wait.until(lambda mn: self.get_updates_served() == amount)
+        served = self.get_updates_served()
+        assert served == amount, (
+            f"There should have been {amount} update served but {served}"
+        )
+
+    def assert_updates_check_allowed(self, allowed):
+        self._driver.set_context("chrome")
+        rv = self._driver.execute_async_script(
+            """
+            const callback = arguments[arguments.length - 1];
+            const UM = Cc["@mozilla.org/updates/update-manager;1"].getService(Ci.nsIUpdateManager);
+            UM.internal.reload(false).then(() => {
+              const { Updates } = ChromeUtils.importESModule("resource:///modules/enterprise/Updates.sys.mjs");
+              Updates.updateCheckingAllowed().then(() => callback(Updates._canDoUpdateChecking));
+            });
+            """
+        )
+        self._driver.set_context("content")
+        print(f"assert_updates_check_allowed: {rv}")
+        assert rv == allowed, f"Update checks are {rv} but expected {allowed}"
+
+    def assert_error_displayed(self):
+        self._driver.set_context("chrome")
+
+        browser_error = self.get_elem(".felt-browser-error")
+        assert browser_error, "Error dialog present"
+
+        error_details = self.get_elem(
+            ".felt-updates-error-messages .felt-browser-error-details"
+        )
+        error_msg = error_details.text
+
+        self._driver.set_context("content")
+
+        assert error_msg == "Please contact your administrator.", (
+            "Should display a contact your administrator error message"
+        )
+
+    def reset_updates_served(self):
+        self._logger.info("Reset updates served")
+        requests.post(
+            f"http://localhost:{self.console_port}/api/browser/forced_updates_count"
+        )
+
+    def one_xml(self, state):
+        return f"""
+<update xmlns="http://www.mozilla.org/2005/app-update" appVersion="2000.0a1" buildID="22221010555555" channel="default" detailsURL="https://www.mozilla.org/en-US/firefox/notes" displayVersion="2000.0a1" platformVersion="2000.0a1" installDate="1773852795836" isCompleteUpdate="true" name="Firefox Enterprise 2000.0a1" previousAppVersion="150.0a1" promptWaitTime="691200" serviceURL="http://localhost:8000/api/browser/updates/FirefoxEnterprise/150.0a1/20260317000000/Darwin_aarch64-gcc3/en-US/default/Darwin%252025.3.0/ISET%3ANEON%2CMEM%3A24576/default/default/update.xml?force=1" type="major" statusText="Install Pending" foregroundDownload="true">
+  <patch size="83136062" type="complete" URL="http://localhost:8000/firefox-150.0a1.en-US.mac.complete.mar" errorCode="9" finalURL="http://localhost:8000/firefox-150.0a1.en-US.mac.complete.mar?backgroundTaskMode=0" selected="true" state="{state}" internalResult="0" numTotalInstallAttempts="1"/>
+</update>
+"""
+
+    def write_updates_xml(self, updates=None):
+        self._logger.info(
+            f"Writing {len(updates)} updates failures in {self._updates_history}"
+        )
+
+        with open(self._updates_history, "w") as output_xml:
+            output_xml.write(f"""<?xml version="1.0"?>
+<updates xmlns="http://www.mozilla.org/2005/app-update">
+  {"".join(updates)}
+</updates>""")

--- a/testing/enterprise/manifest.toml
+++ b/testing/enterprise/manifest.toml
@@ -46,6 +46,8 @@ run-if = [
 
 ["test_felt_browser_starts.py"]
 
+["test_felt_browser_updater_errors.py"]
+
 ["test_felt_browser_updates_apply.py"]
 
 ["test_felt_browser_updates_basic.py"]

--- a/testing/enterprise/test_felt_browser_updater_errors.py
+++ b/testing/enterprise/test_felt_browser_updater_errors.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import os
+import sys
+
+sys.path.append(os.path.dirname(__file__))
+
+from felt_updater_errors import FeltUpdaterErrorsBase
+
+
+class FeltUpdaterErrors(FeltUpdaterErrorsBase):
+    EXTRA_PREFS = {
+        "app.update.log": True,
+        "app.update.disabledForTesting": False,
+        "app.update.BITS.enabled": False,
+        "enterprise.felt_tests.is_updates_testing": False,
+    }
+
+    def test_felt_updater_errors(self):
+        self._update_root = os.path.dirname(self.get_update_config_file_path())
+        self._updates_history = os.path.join(self._update_root, "updates.xml")
+        self._logger.info(f"Updates history {self._updates_history}")
+
+        if os.path.isfile(self._updates_history):
+            os.unlink(self._updates_history)
+            self._logger.info(f"Updates history {self._updates_history} removed.")
+
+        # Browser is not being started in this test, so there is no need to
+        # check for its proper close
+        self._manually_closed_child = True
+
+        self.reset_updates_served()
+        self.reload_chrome_window()
+        self.assert_updates_check_allowed(True)
+        self.assert_updates_served(1)
+
+        # Just one failure should not block
+        self.write_updates_xml([self.one_xml("failed")])
+        self.assert_updates_check_allowed(True)
+
+        # Three consecutive failures, we still allow
+        self.write_updates_xml([
+            self.one_xml("failed"),
+            self.one_xml("failed"),
+            self.one_xml("failed"),
+            self.one_xml("succeeded"),
+        ])
+        self.reset_updates_served()
+        self.reload_chrome_window()
+        self.assert_updates_check_allowed(True)
+        self.assert_updates_served(1)
+
+        # Four consecutive failures, we block
+        self.write_updates_xml([
+            self.one_xml("failed"),
+            self.one_xml("failed"),
+            self.one_xml("failed"),
+            self.one_xml("failed"),
+            self.one_xml("succeeded"),
+        ])
+        self.reset_updates_served()
+        self.reload_chrome_window()
+        self.assert_updates_check_allowed(False)
+        self.assert_updates_served(0)
+        self.assert_error_displayed()
+
+        # This should count as two consecutive failures, so we still allow
+        self.write_updates_xml([
+            self.one_xml("failed"),
+            self.one_xml("failed"),
+            self.one_xml("succeeded"),
+            self.one_xml("failed"),
+            self.one_xml("failed"),
+            self.one_xml("failed"),
+            self.one_xml("failed"),
+            self.one_xml("succeeded"),
+        ])
+        self.reset_updates_served()
+        self.reload_chrome_window()
+        self.assert_updates_check_allowed(True)
+        self.assert_updates_served(1)
+
+        # Four consecutive failures, but first is OK, we allow
+        self.write_updates_xml([
+            self.one_xml("succeeded"),
+            self.one_xml("failed"),
+            self.one_xml("failed"),
+            self.one_xml("failed"),
+            self.one_xml("failed"),
+            self.one_xml("succeeded"),
+        ])
+        self.reset_updates_served()
+        self.reload_chrome_window()
+        self.assert_updates_check_allowed(True)
+        self.assert_updates_served(1)
+
+        assert os.path.isfile(self._updates_history), (
+            f"Updates history is present at {self._updates_history}"
+        )
+        os.unlink(self._updates_history)


### PR DESCRIPTION
If for some reason some updates are failing to apply, our force checking, download and restart at the start of Felt may end up in infinite loop. Check the update history to verify for previous app updates failures and report and error in case it makes sense.