### PR TITLE
Fix intermittent failure of testing/enterprise/test_felt_browser_context_menu.py

### DIFF
--- a/testing/enterprise/felt_tests.py
+++ b/testing/enterprise/felt_tests.py
@@ -681,7 +681,7 @@ class FeltTestsBase(EnterpriseTestsBase):
 
     def run_felt_base(self):
         self.run_felt_chrome_on_email_submit()
-        self.run_felt_load_sso()
+        self.run_wait_until_sso_loaded()
         self.run_felt_perform_sso_auth()
 
     def submit_email(self, email_address="random@mozilla.com"):
@@ -726,7 +726,7 @@ class FeltTests(FeltTestsBase):
         )
         self._driver.set_context("content")
 
-    def run_felt_load_sso(self):
+    def run_wait_until_sso_loaded(self):
         self._logger.info("Checking SSO page")
         self._driver.set_context("content")
         self._wait.until(lambda mn: mn.get_url().endswith("/sso_url"))

--- a/testing/enterprise/test_felt_browser_context_menu.py
+++ b/testing/enterprise/test_felt_browser_context_menu.py
@@ -51,7 +51,8 @@ class BrowserContextMenu(FeltTests):
         self.run_email_context_menu_select_all()
         self.run_email_context_menu_delete()
         self.run_email_context_menu_undo_redo()
-        self.run_email_z_submit()
+        self.run_felt_chrome_on_email_submit()
+        self.run_wait_until_sso_loaded()
         self.run_login_context_menu_cut()
         self.run_login_context_menu_copy()
         self.run_login_context_menu_paste()
@@ -352,20 +353,8 @@ class BrowserContextMenu(FeltTests):
         )
         assert email_value == test_text, "Text was redone"
 
-    def run_email_z_submit(self):
-        self.submit_email("random@mozilla.com")
-
-        self._driver.set_context("chrome")
-        self._logger.info("Email submitted and SSO browser displayed")
-        sso_content_ready = self.get_elem(".felt-login__sso")
-        assert sso_content_ready, "The SSO content is displayed"
-
-        self._driver.set_context("content")
-
     @close_context_menu
     def run_login_context_menu_cut(self):
-        self._driver.set_context("chrome")
-
         self._driver.set_context("content")
         self._logger.info("Testing cut operation on login input in SSO form")
 

--- a/testing/enterprise/test_felt_browser_signout.py
+++ b/testing/enterprise/test_felt_browser_signout.py
@@ -112,7 +112,7 @@ class BaseBrowserSignout(FeltTests):
 
     def run_load_sso(self):
         self.force_window()
-        self.run_felt_load_sso()
+        self.run_wait_until_sso_loaded()
 
     def run_perform_sso_auth(self):
         self.force_window()

--- a/testing/enterprise/test_felt_browser_updates_basic.py
+++ b/testing/enterprise/test_felt_browser_updates_basic.py
@@ -16,7 +16,7 @@ class FeltUpdatesBasicChecks(FeltTests):
     def test_felt_updates_basic_checks(self):
         self.run_felt_chrome_on_email_submit()
         self.run_verify_felt_app_update_url()
-        self.run_felt_load_sso()
+        self.run_wait_until_sso_loaded()
         self.run_felt_perform_sso_auth()
         self.connect_child_browser()
         self.run_verify_browser_app_update_url()


### PR DESCRIPTION
The `testing/enterprise/test_felt_browser_context_menu.py` failed intermittently in `run_login_context_menu_cut` (locally on macos almost every second test run failed, on TaskCluster the test failure rate is less). It's the first test that gets run after submitting the email which starts loading the sso site.

**Changes:**
- Rename `run_felt_load_sso` to `run_wait_until_sso_loaded` for clarity.
- Add a check to ensure SSO page has finished loading before resuming context menu tests.

**Verify:**
`./mach marionette-test testing/enterprise/test_felt_browser_context_menu.py --repeat 10`