### PR TITLE
Bug 2024613 - Closing Firefox logs out the user from Firefox Enterprise UX

### DIFF
--- a/browser/components/BrowserGlue.sys.mjs
+++ b/browser/components/BrowserGlue.sys.mjs
@@ -137,6 +137,13 @@ ChromeUtils.defineLazyGetter(lazy, "gBrowserBundle", function () {
   );
 });
 
+ChromeUtils.defineLazyGetter(lazy, "enterpriseLocalization", () => {
+  return new Localization(
+    ["browser/enterprise/enterprise.ftl", "branding/brand.ftl"],
+    true
+  );
+});
+
 // Seconds of idle time before the late idle tasks will be scheduled.
 const LATE_TASKS_IDLE_TIME_SEC = 20;
 // Time after we stop tracking startup crashes.
@@ -1661,7 +1668,7 @@ BrowserGlue.prototype = {
       checkboxLabelId = "tabbrowser-ask-close-tabs-checkbox";
     }
 
-    const [title, quitButtonLabel, checkboxLabel] =
+    let [title, quitButtonLabel, checkboxLabel] =
       win.gBrowser.tabLocalization.formatMessagesSync([
         titleId,
         quitButtonLabelId,
@@ -1674,6 +1681,23 @@ BrowserGlue.prototype = {
       [closeTabButtonLabel] = win.gBrowser.tabLocalization.formatMessagesSync([
         closeTabButtonLabelId,
       ]);
+    }
+
+    let message = null;
+
+    if (AppConstants.MOZ_ENTERPRISE && shouldWarnForShortcut) {
+      const titleStringId = showCloseCurrentTabOption
+        ? "enterprise-quit-shortcut-prompt-title-with-tabs"
+        : "enterprise-quit-shortcut-prompt-title";
+      const [entTitle, entMessage, entQuitButtonLabel] =
+        lazy.enterpriseLocalization.formatValuesSync([
+          titleStringId,
+          "enterprise-quit-shortcut-prompt-message",
+          "enterprise-quit-shortcut-prompt-primary-btn-label",
+        ]);
+      title = { value: entTitle };
+      message = entMessage;
+      quitButtonLabel = { value: entQuitButtonLabel };
     }
 
     let warnOnClose = { value: true };
@@ -1700,7 +1724,7 @@ BrowserGlue.prototype = {
     let buttonPressed = Services.prompt.confirmEx(
       win,
       title.value,
-      null,
+      message,
       flags,
       quitButtonLabel.value,
       null,

--- a/browser/components/BrowserGlue.sys.mjs
+++ b/browser/components/BrowserGlue.sys.mjs
@@ -1564,7 +1564,6 @@ BrowserGlue.prototype = {
         aCancelQuit.QueryInterface(Ci.nsISupportsPRBool).data = true;
         this._quitSource = "unknown";
       }
-      return;
     }
 
     // browser.warnOnQuit is a hidden global boolean to override all quit prompts.

--- a/browser/components/BrowserGlue.sys.mjs
+++ b/browser/components/BrowserGlue.sys.mjs
@@ -137,13 +137,6 @@ ChromeUtils.defineLazyGetter(lazy, "gBrowserBundle", function () {
   );
 });
 
-ChromeUtils.defineLazyGetter(lazy, "enterpriseLocalization", () => {
-  return new Localization(
-    ["browser/enterprise/enterprise.ftl", "branding/brand.ftl"],
-    true
-  );
-});
-
 // Seconds of idle time before the late idle tasks will be scheduled.
 const LATE_TASKS_IDLE_TIME_SEC = 20;
 // Time after we stop tracking startup crashes.
@@ -1566,6 +1559,7 @@ BrowserGlue.prototype = {
       }
       if (lazy.EnterpriseHandler.shouldShowClosePrompt()) {
         aCancelQuit.QueryInterface(Ci.nsISupportsPRBool).data = true;
+        this._quitSource = "unknown";
         const promptWindow = lazy.BrowserWindowTracker.getTopWindow({
           allowFromInactiveWorkspace: true,
         });
@@ -1692,15 +1686,19 @@ BrowserGlue.prototype = {
     let message = null;
 
     if (AppConstants.MOZ_ENTERPRISE && shouldWarnForShortcut) {
-      const [entTitle, entMessage, entQuitButtonLabel] =
-        lazy.enterpriseLocalization.formatValuesSync([
-          {
-            id: "enterprise-quit-shortcut-prompt-title",
-            args: { withTabs: showCloseCurrentTabOption ? "true" : "false" },
-          },
-          "enterprise-quit-shortcut-prompt-message",
-          "enterprise-quit-shortcut-prompt-primary-btn-label",
-        ]);
+      const l10n = new Localization(
+        ["browser/enterprise/enterprise.ftl", "branding/brand.ftl"],
+        true
+      );
+
+      const [entTitle, entMessage, entQuitButtonLabel] = l10n.formatValuesSync([
+        {
+          id: "enterprise-quit-shortcut-prompt-title",
+          args: { withTabs: showCloseCurrentTabOption ? "true" : "false" },
+        },
+        "enterprise-quit-shortcut-prompt-message",
+        "enterprise-quit-shortcut-prompt-primary-btn-label",
+      ]);
       title = { value: entTitle };
       message = entMessage;
       quitButtonLabel = { value: entQuitButtonLabel };

--- a/browser/components/BrowserGlue.sys.mjs
+++ b/browser/components/BrowserGlue.sys.mjs
@@ -1559,17 +1559,26 @@ BrowserGlue.prototype = {
 
     // When Firefox was launched by FELT, show a signout confirmation prompt
     // instead of the standard quit dialog.
-    if (
-      AppConstants.MOZ_ENTERPRISE &&
-      Services.felt?.isFeltBrowser() &&
-      lazy.EnterpriseHandler.isSignoutPromptEnabled()
-    ) {
-      const promptWindow = lazy.BrowserWindowTracker.getTopWindow({
-        allowFromInactiveWorkspace: true,
-      });
-      if (!lazy.EnterpriseHandler.showSignoutPrompt(promptWindow)) {
+    if (AppConstants.MOZ_ENTERPRISE && Services.felt?.isFeltBrowser()) {
+      if (lazy.EnterpriseHandler._skipSignoutPrompt) {
+        lazy.EnterpriseHandler._skipSignoutPrompt = false;
+        return;
+      }
+      if (
+        Services.prefs.getBoolPref("enterprise.prompt_on_signout", true) ||
+        Services.prefs.getBoolPref("browser.tabs.warnOnClose", false)
+      ) {
         aCancelQuit.QueryInterface(Ci.nsISupportsPRBool).data = true;
-        this._quitSource = "unknown";
+        const promptWindow = lazy.BrowserWindowTracker.getTopWindow({
+          allowFromInactiveWorkspace: true,
+        });
+        lazy.EnterpriseHandler.showSignoutPrompt(promptWindow).then(proceed => {
+          if (proceed) {
+            lazy.EnterpriseHandler._skipSignoutPrompt = true;
+            Services.startup.quit(Ci.nsIAppStartup.eAttemptQuit);
+          }
+        });
+        return;
       }
     }
 

--- a/browser/components/BrowserGlue.sys.mjs
+++ b/browser/components/BrowserGlue.sys.mjs
@@ -1564,21 +1564,7 @@ BrowserGlue.prototype = {
         lazy.EnterpriseHandler._skipSignoutPrompt = false;
         return;
       }
-      const warnOnSignout = Services.prefs.getBoolPref(
-        "enterprise.prompt_on_signout",
-        true
-      );
-      const warnOnCloseWithTabs = Services.prefs.getBoolPref(
-        "browser.tabs.warnOnClose",
-        false
-      );
-      let tabCount = 0;
-      for (let win of lazy.BrowserWindowTracker.orderedWindows) {
-        if (!win.closed && win.gBrowser) {
-          tabCount += win.gBrowser.openTabs.length;
-        }
-      }
-      if (warnOnSignout || (tabCount > 1 && warnOnCloseWithTabs)) {
+      if (lazy.EnterpriseHandler.shouldShowClosePrompt()) {
         aCancelQuit.QueryInterface(Ci.nsISupportsPRBool).data = true;
         const promptWindow = lazy.BrowserWindowTracker.getTopWindow({
           allowFromInactiveWorkspace: true,

--- a/browser/components/BrowserGlue.sys.mjs
+++ b/browser/components/BrowserGlue.sys.mjs
@@ -125,6 +125,15 @@ if (AppConstants.MOZ_CRASHREPORTER) {
   });
 }
 
+if (AppConstants.MOZ_ENTERPRISE) {
+  ChromeUtils.defineLazyGetter(lazy, "localization", () => {
+    return new Localization(
+      ["browser/enterprise/enterprise.ftl", "branding/brand.ftl"],
+      true
+    );
+  });
+}
+
 ChromeUtils.defineLazyGetter(lazy, "gBrandBundle", function () {
   return Services.strings.createBundle(
     "chrome://branding/locale/brand.properties"
@@ -1559,11 +1568,16 @@ BrowserGlue.prototype = {
         const promptWindow = lazy.BrowserWindowTracker.getTopWindow({
           allowFromInactiveWorkspace: true,
         });
-        lazy.EnterpriseHandler.showSignoutPrompt(promptWindow).then(proceed => {
-          if (proceed) {
-            Services.startup.quit(Ci.nsIAppStartup.eAttemptQuit);
-          }
-        });
+        lazy.EnterpriseHandler.showSignoutPrompt(promptWindow)
+          .then(proceed => {
+            if (proceed) {
+              Services.startup.quit(Ci.nsIAppStartup.eAttemptQuit);
+            }
+          })
+          .catch(e => {
+            console.error("Enterprise signout prompt failed, quitting:", e);
+            Services.startup.quit(Ci.nsIAppStartup.eForceQuit);
+          });
         return;
       }
     }
@@ -1681,19 +1695,15 @@ BrowserGlue.prototype = {
     let message = null;
 
     if (AppConstants.MOZ_ENTERPRISE && shouldWarnForShortcut) {
-      const l10n = new Localization(
-        ["browser/enterprise/enterprise.ftl", "branding/brand.ftl"],
-        true
-      );
-
-      const [entTitle, entMessage, entQuitButtonLabel] = l10n.formatValuesSync([
-        {
-          id: "enterprise-quit-shortcut-prompt-title",
-          args: { withTabs: showCloseCurrentTabOption ? "true" : "false" },
-        },
-        "enterprise-quit-shortcut-prompt-message",
-        "enterprise-quit-shortcut-prompt-primary-btn-label",
-      ]);
+      const [entTitle, entMessage, entQuitButtonLabel] =
+        lazy.localization.formatValuesSync([
+          {
+            id: "enterprise-quit-shortcut-prompt-title",
+            args: { withTabs: showCloseCurrentTabOption ? "true" : "false" },
+          },
+          "enterprise-quit-shortcut-prompt-message",
+          "enterprise-quit-shortcut-prompt-primary-btn-label",
+        ]);
       title = { value: entTitle };
       message = entMessage;
       quitButtonLabel = { value: entQuitButtonLabel };

--- a/browser/components/BrowserGlue.sys.mjs
+++ b/browser/components/BrowserGlue.sys.mjs
@@ -1553,10 +1553,6 @@ BrowserGlue.prototype = {
     // When Firefox was launched by FELT, show a signout confirmation prompt
     // instead of the standard quit dialog.
     if (AppConstants.MOZ_ENTERPRISE && Services.felt?.isFeltBrowser()) {
-      if (lazy.EnterpriseHandler._skipSignoutPrompt) {
-        lazy.EnterpriseHandler._skipSignoutPrompt = false;
-        return;
-      }
       if (lazy.EnterpriseHandler.shouldShowClosePrompt()) {
         aCancelQuit.QueryInterface(Ci.nsISupportsPRBool).data = true;
         this._quitSource = "unknown";
@@ -1565,7 +1561,6 @@ BrowserGlue.prototype = {
         });
         lazy.EnterpriseHandler.showSignoutPrompt(promptWindow).then(proceed => {
           if (proceed) {
-            lazy.EnterpriseHandler._skipSignoutPrompt = true;
             Services.startup.quit(Ci.nsIAppStartup.eAttemptQuit);
           }
         });

--- a/browser/components/BrowserGlue.sys.mjs
+++ b/browser/components/BrowserGlue.sys.mjs
@@ -1686,12 +1686,12 @@ BrowserGlue.prototype = {
     let message = null;
 
     if (AppConstants.MOZ_ENTERPRISE && shouldWarnForShortcut) {
-      const titleStringId = showCloseCurrentTabOption
-        ? "enterprise-quit-shortcut-prompt-title-with-tabs"
-        : "enterprise-quit-shortcut-prompt-title";
       const [entTitle, entMessage, entQuitButtonLabel] =
         lazy.enterpriseLocalization.formatValuesSync([
-          titleStringId,
+          {
+            id: "enterprise-quit-shortcut-prompt-title",
+            args: { withTabs: showCloseCurrentTabOption ? "true" : "false" },
+          },
           "enterprise-quit-shortcut-prompt-message",
           "enterprise-quit-shortcut-prompt-primary-btn-label",
         ]);

--- a/browser/components/BrowserGlue.sys.mjs
+++ b/browser/components/BrowserGlue.sys.mjs
@@ -1564,10 +1564,21 @@ BrowserGlue.prototype = {
         lazy.EnterpriseHandler._skipSignoutPrompt = false;
         return;
       }
-      if (
-        Services.prefs.getBoolPref("enterprise.prompt_on_signout", true) ||
-        Services.prefs.getBoolPref("browser.tabs.warnOnClose", false)
-      ) {
+      const warnOnSignout = Services.prefs.getBoolPref(
+        "enterprise.prompt_on_signout",
+        true
+      );
+      const warnOnCloseWithTabs = Services.prefs.getBoolPref(
+        "browser.tabs.warnOnClose",
+        false
+      );
+      let tabCount = 0;
+      for (let win of lazy.BrowserWindowTracker.orderedWindows) {
+        if (!win.closed && win.gBrowser) {
+          tabCount += win.gBrowser.openTabs.length;
+        }
+      }
+      if (warnOnSignout || (tabCount > 1 && warnOnCloseWithTabs)) {
         aCancelQuit.QueryInterface(Ci.nsISupportsPRBool).data = true;
         const promptWindow = lazy.BrowserWindowTracker.getTopWindow({
           allowFromInactiveWorkspace: true,

--- a/browser/components/enterprise/EnterpriseHandler.sys.mjs
+++ b/browser/components/enterprise/EnterpriseHandler.sys.mjs
@@ -117,6 +117,12 @@ export const EnterpriseHandler = {
   _skipSignoutPrompt: false,
 
   /**
+   * Cached count of open tabs used when showing the close prompt to avoid recounting
+   * tabs multiple times during the prompt flow. Resets to null after use.
+   */
+  _tabCount: null,
+
+  /**
    * Handles the enterprise state for each new browser window.
    * On first call:
    *    - Make a request to the console to retrieve the user information of the signed in user.
@@ -407,13 +413,13 @@ export const EnterpriseHandler = {
       this._skipSignoutPrompt = false;
       return false;
     }
-    if (Services.prefs.getBoolPref(PROMPT_ON_SIGNOUT_PREF, true)) {
-      return true;
-    }
-    if (!Services.prefs.getBoolPref(WARN_ON_CLOSE_PREF, false)) {
+    const warnOnSignout = Services.prefs.getBoolPref(PROMPT_ON_SIGNOUT_PREF, true);
+    const warnOnCloseWithTabs = Services.prefs.getBoolPref(WARN_ON_CLOSE_PREF, false);
+    if (!warnOnSignout && !warnOnCloseWithTabs) {
       return false;
     }
-    return this._countOpenTabs() > 1;
+    this._tabCount = this._countOpenTabs();
+    return warnOnSignout || this._tabCount > 1;
   },
 
   /**
@@ -432,18 +438,19 @@ export const EnterpriseHandler = {
       false
     );
 
-    const tabCount = this._countOpenTabs();
-    const hasMultipleTabs = tabCount > 1;
+    this._tabCount ??= this._countOpenTabs();
 
-    if (!warnOnSignout && (!hasMultipleTabs || !warnOnCloseWithTabs)) {
+    if (!warnOnSignout && (this._tabCount <= 1 || !warnOnCloseWithTabs)) {
+      this._tabCount = null;
       return true;
     }
 
     const params = this._getSignoutPromptParams({
-      tabCount,
+      tabCount: this._tabCount,
       warnOnSignout,
       warnOnCloseWithTabs,
     });
+    this._tabCount = null;
 
     if (!window) {
       params.wrappedJSObject = params;

--- a/browser/components/enterprise/EnterpriseHandler.sys.mjs
+++ b/browser/components/enterprise/EnterpriseHandler.sys.mjs
@@ -401,8 +401,24 @@ export const EnterpriseHandler = {
     return true;
   },
 
-  isSignoutPromptEnabled() {
-    return Services.prefs.getBoolPref(PROMPT_ON_SIGNOUT_PREF, true);
+  _countOpenTabs() {
+    let tabCount = 0;
+    for (let win of Services.wm.getEnumerator("navigator:browser")) {
+      if (!win.closed && win.gBrowser) {
+        tabCount += win.gBrowser.openTabs.length;
+      }
+    }
+    return tabCount;
+  },
+
+  shouldShowClosePrompt() {
+    if (Services.prefs.getBoolPref(PROMPT_ON_SIGNOUT_PREF, true)) {
+      return true;
+    }
+    if (!Services.prefs.getBoolPref(WARN_ON_CLOSE_PREF, false)) {
+      return false;
+    }
+    return this._countOpenTabs() > 1;
   },
 
   /**
@@ -421,16 +437,10 @@ export const EnterpriseHandler = {
       false
     );
 
-    let tabCount = 0;
-    for (let win of Services.wm.getEnumerator("navigator:browser")) {
-      if (!win.closed && win.gBrowser) {
-        tabCount += win.gBrowser.openTabs.length;
-      }
-    }
-
+    const tabCount = this._countOpenTabs();
     const hasMultipleTabs = tabCount > 1;
 
-    if (!this.isSignoutPromptEnabled() && (!hasMultipleTabs || !warnOnCloseWithTabs)) {
+    if (!warnOnSignout && (!hasMultipleTabs || !warnOnCloseWithTabs)) {
       return true;
     }
 

--- a/browser/components/enterprise/EnterpriseHandler.sys.mjs
+++ b/browser/components/enterprise/EnterpriseHandler.sys.mjs
@@ -116,7 +116,6 @@ export const EnterpriseHandler = {
    */
   _skipSignoutPrompt: false,
 
-
   /**
    * Handles the enterprise state for each new browser window.
    * On first call:
@@ -320,7 +319,11 @@ export const EnterpriseHandler = {
     window.PanelUI.mainView.setAttribute("restricted-enterprise-view", true);
   },
 
-  _getSignoutPromptParams({ tabCount, warnOnSignout, warnOnCloseWithTabs } = {}) {
+  _getSignoutPromptParams({
+    tabCount,
+    warnOnSignout,
+    warnOnCloseWithTabs,
+  } = {}) {
     const hasMultipleTabs = tabCount > 1;
     const hasTabsWarning = hasMultipleTabs && warnOnCloseWithTabs;
 
@@ -345,15 +348,21 @@ export const EnterpriseHandler = {
       messageId = { id: "enterprise-close-prompt-message" };
     }
 
-    const [title, messageBody, acceptLabel, reauthNotice, checkLabel, tabsCheckLabel] =
-      lazy.localization.formatValuesSync([
-        titleId,
-        messageId,
-        { id: "enterprise-close-prompt-primary-btn-label" },
-        { id: "enterprise-close-prompt-message-reauth" },
-        { id: "enterprise-close-prompt-checkbox-label" },
-        { id: "enterprise-close-prompt-tabs-checkbox-label" },
-      ]);
+    const [
+      title,
+      messageBody,
+      acceptLabel,
+      reauthNotice,
+      checkLabel,
+      tabsCheckLabel,
+    ] = lazy.localization.formatValuesSync([
+      titleId,
+      messageId,
+      { id: "enterprise-close-prompt-primary-btn-label" },
+      { id: "enterprise-close-prompt-message-reauth" },
+      { id: "enterprise-close-prompt-checkbox-label" },
+      { id: "enterprise-close-prompt-tabs-checkbox-label" },
+    ]);
 
     const message = warnOnSignout
       ? `${messageBody}\n\n${reauthNotice}`
@@ -362,7 +371,13 @@ export const EnterpriseHandler = {
     const checkboxes = [
       { id: "warnOnSignout", label: checkLabel, checked: warnOnSignout },
       ...(hasMultipleTabs
-        ? [{ id: "warnOnCloseWithTabs", label: tabsCheckLabel, checked: warnOnCloseWithTabs }]
+        ? [
+            {
+              id: "warnOnCloseWithTabs",
+              label: tabsCheckLabel,
+              checked: warnOnCloseWithTabs,
+            },
+          ]
         : []),
     ];
 
@@ -372,7 +387,7 @@ export const EnterpriseHandler = {
       acceptLabel,
       checkboxes,
       accepted: false,
-    }
+    };
   },
 
   _handleSignoutPromptResult(accepted, checkboxes) {
@@ -445,7 +460,7 @@ export const EnterpriseHandler = {
    * @param {Window} window
    */
   async onSignOut(window) {
-    if (!await this.showSignoutPrompt(window)) {
+    if (!(await this.showSignoutPrompt(window))) {
       return;
     }
     await this.initiateShutdown();

--- a/browser/components/enterprise/EnterpriseHandler.sys.mjs
+++ b/browser/components/enterprise/EnterpriseHandler.sys.mjs
@@ -440,7 +440,17 @@ export const EnterpriseHandler = {
       warnOnCloseWithTabs,
     });
 
-    if (!window.gDialogBox.isOpen) {
+    if (!window) {
+      await new Promise(resolve => {
+        const dlg = Services.appShell.hiddenDOMWindow.openDialog(
+          "chrome://browser/content/enterprise/enterprise-close-dialog.xhtml",
+          "_blank",
+          "chrome,centerscreen",
+          params
+        );
+        dlg.addEventListener("unload", resolve, { once: true });
+      });
+    } else if (!window.gDialogBox.isOpen) {
       await window.gDialogBox.open(
         "chrome://browser/content/enterprise/enterprise-close-dialog.xhtml",
         params

--- a/browser/components/enterprise/EnterpriseHandler.sys.mjs
+++ b/browser/components/enterprise/EnterpriseHandler.sys.mjs
@@ -330,11 +330,17 @@ export const EnterpriseHandler = {
     const effectiveTabCount = hasTabsWarning ? tabCount : 0;
     const titleId = {
       id: "enterprise-close-prompt-title",
-      args: { tabCount: effectiveTabCount, warnSignout: warnOnSignout.toString() },
+      args: {
+        tabCount: effectiveTabCount,
+        warnSignout: warnOnSignout.toString(),
+      },
     };
     const messageId = {
       id: "enterprise-close-prompt-message",
-      args: { tabCount: effectiveTabCount, warnSignout: warnOnSignout.toString() },
+      args: {
+        tabCount: effectiveTabCount,
+        warnSignout: warnOnSignout.toString(),
+      },
     };
 
     const [
@@ -424,15 +430,15 @@ export const EnterpriseHandler = {
 
     const hasMultipleTabs = tabCount > 1;
 
+    if (!this.isSignoutPromptEnabled() && (!hasMultipleTabs || !warnOnCloseWithTabs)) {
+      return true;
+    }
+
     const params = this._getSignoutPromptParams({
       tabCount,
       warnOnSignout,
       warnOnCloseWithTabs,
     });
-
-    if (!this.isSignoutPromptEnabled() && (!hasMultipleTabs || !warnOnCloseWithTabs)) {
-      return true;
-    }
 
     await window.gDialogBox.open(
       "chrome://browser/content/enterprise/enterprise-close-dialog.xhtml",

--- a/browser/components/enterprise/EnterpriseHandler.sys.mjs
+++ b/browser/components/enterprise/EnterpriseHandler.sys.mjs
@@ -327,21 +327,15 @@ export const EnterpriseHandler = {
     const hasMultipleTabs = tabCount > 1;
     const hasTabsWarning = hasMultipleTabs && warnOnCloseWithTabs;
 
-    const effectiveTabCount = hasTabsWarning ? tabCount : 0;
-    const titleId = {
-      id: "enterprise-close-prompt-title",
-      args: {
-        tabCount: effectiveTabCount,
-        warnSignout: warnOnSignout.toString(),
-      },
-    };
-    const messageId = {
-      id: "enterprise-close-prompt-message",
-      args: {
-        tabCount: effectiveTabCount,
-        warnSignout: warnOnSignout.toString(),
-      },
-    };
+    let titleId, messageId;
+    if (hasTabsWarning) {
+      const args = { tabCount, warnSignout: warnOnSignout.toString() };
+      titleId = { id: "enterprise-close-prompt-title-with-tabcount", args };
+      messageId = { id: "enterprise-close-prompt-message-with-tabcount", args };
+    } else {
+      titleId = { id: "enterprise-close-prompt-title" };
+      messageId = { id: "enterprise-close-prompt-message" };
+    }
 
     const [
       title,
@@ -460,7 +454,7 @@ export const EnterpriseHandler = {
         "chrome,centerscreen,modal,dialog",
         params
       );
-    } else if (!window.gDialogBox.isOpen) {
+    } else {
       if (window.gDialogBox.isOpen) {
         window.gDialogBox.replaceDialogIfOpen();
       }

--- a/browser/components/enterprise/EnterpriseHandler.sys.mjs
+++ b/browser/components/enterprise/EnterpriseHandler.sys.mjs
@@ -111,8 +111,8 @@ export const EnterpriseHandler = {
   _isInitialized: false,
 
   /**
-   * Whether to skip showing the signout prompt. This used for gating the prompt on
-   * shutdown when the signout is initiated from the enterprise panel.
+   * Set to true after the user confirms the enterprise close dialog, so that the
+   * resulting re-quit skips showing it again.
    */
   _skipSignoutPrompt: false,
 
@@ -440,10 +440,12 @@ export const EnterpriseHandler = {
       warnOnCloseWithTabs,
     });
 
-    await window.gDialogBox.open(
-      "chrome://browser/content/enterprise/enterprise-close-dialog.xhtml",
-      params
-    );
+    if (!window.gDialogBox.isOpen) {
+      await window.gDialogBox.open(
+        "chrome://browser/content/enterprise/enterprise-close-dialog.xhtml",
+        params
+      );
+    }
 
     return this._handleSignoutPromptResult(params.accepted, params.checkboxes);
   },

--- a/browser/components/enterprise/EnterpriseHandler.sys.mjs
+++ b/browser/components/enterprise/EnterpriseHandler.sys.mjs
@@ -451,15 +451,14 @@ export const EnterpriseHandler = {
     });
 
     if (!window) {
-      await new Promise(resolve => {
-        const dlg = Services.appShell.hiddenDOMWindow.openDialog(
-          "chrome://browser/content/enterprise/enterprise-close-dialog.xhtml",
-          "_blank",
-          "chrome,centerscreen",
-          params
-        );
-        dlg.addEventListener("unload", resolve, { once: true });
-      });
+      params.wrappedJSObject = params;
+      Services.ww.openWindow(
+        null,
+        "chrome://browser/content/enterprise/enterprise-close-dialog.xhtml",
+        "_blank",
+        "chrome,centerscreen,modal,dialog",
+        params
+      );
     } else if (!window.gDialogBox.isOpen) {
       await window.gDialogBox.open(
         "chrome://browser/content/enterprise/enterprise-close-dialog.xhtml",

--- a/browser/components/enterprise/EnterpriseHandler.sys.mjs
+++ b/browser/components/enterprise/EnterpriseHandler.sys.mjs
@@ -345,7 +345,7 @@ export const EnterpriseHandler = {
 
     const [
       title,
-      messageBody,
+      message,
       acceptLabel,
       reauthNotice,
       checkLabel,
@@ -358,10 +358,6 @@ export const EnterpriseHandler = {
       { id: "enterprise-close-prompt-checkbox-label" },
       { id: "enterprise-close-prompt-tabs-checkbox-label" },
     ]);
-
-    const message = warnOnSignout
-      ? `${messageBody}\n\n${reauthNotice}`
-      : messageBody;
 
     const checkboxes = [
       { id: "warnOnSignout", label: checkLabel, checked: warnOnSignout },
@@ -379,6 +375,7 @@ export const EnterpriseHandler = {
     return {
       title,
       message,
+      reauthNotice: warnOnSignout ? reauthNotice : null,
       acceptLabel,
       checkboxes,
       accepted: false,
@@ -412,6 +409,10 @@ export const EnterpriseHandler = {
   },
 
   shouldShowClosePrompt() {
+    if (this._skipSignoutPrompt) {
+      this._skipSignoutPrompt = false;
+      return false;
+    }
     if (Services.prefs.getBoolPref(PROMPT_ON_SIGNOUT_PREF, true)) {
       return true;
     }
@@ -460,13 +461,23 @@ export const EnterpriseHandler = {
         params
       );
     } else if (!window.gDialogBox.isOpen) {
+      if (window.gDialogBox.isOpen) {
+        window.gDialogBox.replaceDialogIfOpen();
+      }
       await window.gDialogBox.open(
         "chrome://browser/content/enterprise/enterprise-close-dialog.xhtml",
         params
       );
     }
 
-    return this._handleSignoutPromptResult(params.accepted, params.checkboxes);
+    const accepted = this._handleSignoutPromptResult(
+      params.accepted,
+      params.checkboxes
+    );
+    if (accepted) {
+      this._skipSignoutPrompt = true;
+    }
+    return accepted;
   },
 
   /**

--- a/browser/components/enterprise/EnterpriseHandler.sys.mjs
+++ b/browser/components/enterprise/EnterpriseHandler.sys.mjs
@@ -327,26 +327,15 @@ export const EnterpriseHandler = {
     const hasMultipleTabs = tabCount > 1;
     const hasTabsWarning = hasMultipleTabs && warnOnCloseWithTabs;
 
-    let titleId, messageId;
-    if (warnOnSignout && hasTabsWarning) {
-      titleId = {
-        id: "enterprise-close-prompt-title-with-tabs",
-        args: { tabCount },
-      };
-      messageId = {
-        id: "enterprise-close-prompt-message-with-tabs",
-        args: { tabCount },
-      };
-    } else if (hasTabsWarning) {
-      titleId = {
-        id: "enterprise-close-prompt-title-tabs-only",
-        args: { tabCount },
-      };
-      messageId = { id: "enterprise-close-prompt-message-tabs-only" };
-    } else {
-      titleId = { id: "enterprise-close-prompt-title" };
-      messageId = { id: "enterprise-close-prompt-message" };
-    }
+    const effectiveTabCount = hasTabsWarning ? tabCount : 0;
+    const titleId = {
+      id: "enterprise-close-prompt-title",
+      args: { tabCount: effectiveTabCount, warnSignout: warnOnSignout.toString() },
+    };
+    const messageId = {
+      id: "enterprise-close-prompt-message",
+      args: { tabCount: effectiveTabCount, warnSignout: warnOnSignout.toString() },
+    };
 
     const [
       title,

--- a/browser/components/enterprise/EnterpriseHandler.sys.mjs
+++ b/browser/components/enterprise/EnterpriseHandler.sys.mjs
@@ -26,6 +26,7 @@ ChromeUtils.defineLazyGetter(lazy, "log", () => {
 const PROMPT_ON_SIGNOUT_PREF = "enterprise.prompt_on_signout";
 const COMPANY_LOGO_URL_PREF = "enterprise.configs.company_logo_url";
 const LEARN_MORE_URL_PREF = "enterprise.configs.learn_more_url";
+const WARN_ON_CLOSE_PREF = "browser.tabs.warnOnClose";
 
 /**
  * Parses a given url string
@@ -108,6 +109,13 @@ export const EnterpriseHandler = {
    * from the signed in user has been received from the console.
    */
   _isInitialized: false,
+
+  /**
+   * Whether to skip showing the signout prompt. This used for gating the prompt on
+   * shutdown when the signout is initiated from the enterprise panel.
+   */
+  _skipSignoutPrompt: false,
+
 
   /**
    * Handles the enterprise state for each new browser window.
@@ -312,38 +320,74 @@ export const EnterpriseHandler = {
     window.PanelUI.mainView.setAttribute("restricted-enterprise-view", true);
   },
 
-  _getSignoutPromptParams() {
-    let tabCount = 0;
-    for (let win of Services.wm.getEnumerator("navigator:browser")) {
-      if (!win.closed && win.gBrowser) {
-        tabCount += win.gBrowser.openTabs.length;
+  _getSignoutPromptParams({ tabCount, warnOnSignout, warnOnCloseWithTabs } = {}) {
+    const hasMultipleTabs = tabCount > 1;
+    const hasTabsWarning = hasMultipleTabs && warnOnCloseWithTabs;
+
+    let titleId, messageId;
+    if (warnOnSignout && hasTabsWarning) {
+      titleId = {
+        id: "enterprise-close-prompt-title-with-tabs",
+        args: { tabCount },
+      };
+      messageId = {
+        id: "enterprise-close-prompt-message-with-tabs",
+        args: { tabCount },
+      };
+    } else if (hasTabsWarning) {
+      titleId = {
+        id: "enterprise-close-prompt-title-tabs-only",
+        args: { tabCount },
+      };
+      messageId = { id: "enterprise-close-prompt-message-tabs-only" };
+    } else {
+      titleId = { id: "enterprise-close-prompt-title" };
+      messageId = { id: "enterprise-close-prompt-message" };
+    }
+
+    const [title, messageBody, acceptLabel, reauthNotice, checkLabel, tabsCheckLabel] =
+      lazy.localization.formatValuesSync([
+        titleId,
+        messageId,
+        { id: "enterprise-close-prompt-primary-btn-label" },
+        { id: "enterprise-close-prompt-message-reauth" },
+        { id: "enterprise-close-prompt-checkbox-label" },
+        { id: "enterprise-close-prompt-tabs-checkbox-label" },
+      ]);
+
+    const message = warnOnSignout
+      ? `${messageBody}\n\n${reauthNotice}`
+      : messageBody;
+
+    const checkboxes = [
+      { id: "warnOnSignout", label: checkLabel, checked: warnOnSignout },
+      ...(hasMultipleTabs
+        ? [{ id: "warnOnCloseWithTabs", label: tabsCheckLabel, checked: warnOnCloseWithTabs }]
+        : []),
+    ];
+
+    return {
+      title,
+      message,
+      acceptLabel,
+      checkboxes,
+      accepted: false,
+    }
+  },
+
+  _handleSignoutPromptResult(accepted, checkboxes) {
+    if (!accepted) {
+      return false;
+    }
+
+    for (const { id, checked } of checkboxes) {
+      if (id === "warnOnSignout") {
+        Services.prefs.setBoolPref(PROMPT_ON_SIGNOUT_PREF, checked);
+      } else if (id === "warnOnCloseWithTabs") {
+        Services.prefs.setBoolPref(WARN_ON_CLOSE_PREF, checked);
       }
     }
 
-    const titleId = {
-      id: "enterprise-signout-prompt-title2",
-      args: { tabCount },
-    };
-
-    return {
-      titleId,
-      messageId: { id: "enterprise-signout-prompt-message" },
-      checkLabelId: { id: "enterprise-signout-prompt-checkbox-label" },
-      signoutBtnLabelId: { id: "enterprise-signout-prompt-primary-btn-label" },
-      flags:
-        Services.prompt.BUTTON_TITLE_IS_STRING * Services.prompt.BUTTON_POS_0 +
-        Services.prompt.BUTTON_TITLE_CANCEL * Services.prompt.BUTTON_POS_1 +
-        Services.prompt.BUTTON_POS_0_DEFAULT,
-    };
-  },
-
-  _handleSignoutPromptResult(buttonPressed, checked) {
-    if (buttonPressed === 1) {
-      return false;
-    }
-    if (!checked) {
-      Services.prefs.setBoolPref(PROMPT_ON_SIGNOUT_PREF, false);
-    }
     return true;
   },
 
@@ -352,85 +396,58 @@ export const EnterpriseHandler = {
   },
 
   /**
-   * Synchronous signout prompt for the quit-application-requested observer,
-   * which must return a result before the quit proceeds.
+   * Shows the signout/close confirmation dialog if needed.
    *
    * @param {Window} window
-   * @returns {boolean} true if quit should proceed, false if cancelled.
+   * @returns {Promise<boolean>} true if the action should proceed, false if cancelled.
    */
-  showSignoutPrompt(window) {
-    if (!this.isSignoutPromptEnabled()) {
+  async showSignoutPrompt(window) {
+    const warnOnSignout = Services.prefs.getBoolPref(
+      PROMPT_ON_SIGNOUT_PREF,
+      true
+    );
+    const warnOnCloseWithTabs = Services.prefs.getBoolPref(
+      WARN_ON_CLOSE_PREF,
+      false
+    );
+
+    let tabCount = 0;
+    for (let win of Services.wm.getEnumerator("navigator:browser")) {
+      if (!win.closed && win.gBrowser) {
+        tabCount += win.gBrowser.openTabs.length;
+      }
+    }
+
+    const hasMultipleTabs = tabCount > 1;
+
+    const params = this._getSignoutPromptParams({
+      tabCount,
+      warnOnSignout,
+      warnOnCloseWithTabs,
+    });
+
+    if (!this.isSignoutPromptEnabled() && (!hasMultipleTabs || !warnOnCloseWithTabs)) {
       return true;
     }
 
-    const params = this._getSignoutPromptParams();
-    const [title, message, checkLabel, signoutBtnLabel] =
-      lazy.localization.formatValuesSync([
-        params.titleId,
-        params.messageId,
-        params.checkLabelId,
-        params.signoutBtnLabelId,
-      ]);
-
-    const checkState = { value: true };
-    const buttonPressed = Services.prompt.confirmEx(
-      window,
-      title,
-      message,
-      params.flags,
-      signoutBtnLabel,
-      null,
-      null,
-      checkLabel,
-      checkState
+    await window.gDialogBox.open(
+      "chrome://browser/content/enterprise/enterprise-close-dialog.xhtml",
+      params
     );
 
-    return this._handleSignoutPromptResult(buttonPressed, checkState.value);
+    return this._handleSignoutPromptResult(params.accepted, params.checkboxes);
   },
 
   /**
-   * Handles the signout button in the enterprise panel. Shows an async
-   * in-content dialog that does not block the parent process, then quits.
+   * Handles the signout button in the enterprise panel. Shows the signout
+   * confirmation dialog then performs a full signout and quits.
    *
    * @param {Window} window
    */
   async onSignOut(window) {
-    if (!Services.prefs.getBoolPref(PROMPT_ON_SIGNOUT_PREF, true)) {
-      await this.initiateShutdown();
+    if (!await this.showSignoutPrompt(window)) {
       return;
     }
-
-    const params = this._getSignoutPromptParams();
-    const [title, message, checkLabel, signoutBtnLabel] =
-      await lazy.localization.formatValues([
-        params.titleId,
-        params.messageId,
-        params.checkLabelId,
-        params.signoutBtnLabelId,
-      ]);
-
-    const result = await Services.prompt.asyncConfirmEx(
-      window.browsingContext,
-      Services.prompt.MODAL_TYPE_INTERNAL_WINDOW,
-      title,
-      message,
-      params.flags,
-      signoutBtnLabel,
-      null,
-      null,
-      checkLabel,
-      true
-    );
-
-    if (
-      !this._handleSignoutPromptResult(
-        result.get("buttonNumClicked"),
-        result.get("checked")
-      )
-    ) {
-      return;
-    }
-
     await this.initiateShutdown();
   },
 

--- a/browser/components/enterprise/EnterpriseHandler.sys.mjs
+++ b/browser/components/enterprise/EnterpriseHandler.sys.mjs
@@ -325,6 +325,15 @@ export const EnterpriseHandler = {
     window.PanelUI.mainView.setAttribute("restricted-enterprise-view", true);
   },
 
+  /**
+   * Generates the parameters for the signout/close prompt based on the current state and preferences.
+   *
+   * @param {object} options
+   * @param {number} options.tabCount - The number of open tabs across all windows.
+   * @param {boolean} options.warnOnSignout - Whether to warn on signout.
+   * @param {boolean} options.warnOnCloseWithTabs - Whether to warn on close when multiple tabs are open.
+   * @returns {object} The parameters for the signout/close prompt, including title, message, checkbox states, and more.
+   */
   _getSignoutPromptParams({
     tabCount,
     warnOnSignout,
@@ -382,6 +391,13 @@ export const EnterpriseHandler = {
     };
   },
 
+  /**
+   * Handles the result of the signout/close prompt, updating preferences based on checkbox states if accepted.
+   *
+   * @param {boolean} accepted - Whether the user accepted the prompt.
+   * @param {Array<{id: string, checked: boolean}>} checkboxes - The state of the checkboxes in the prompt.
+   * @returns {boolean} True if the action should proceed (accepted), false if cancelled.
+   */
   _handleSignoutPromptResult(accepted, checkboxes) {
     if (!accepted) {
       return false;
@@ -398,6 +414,11 @@ export const EnterpriseHandler = {
     return true;
   },
 
+  /**
+   * Counts the total number of open tabs across all browser windows.
+   *
+   * @returns {number} The total count of open tabs.
+   */
   _countOpenTabs() {
     let tabCount = 0;
     for (let win of Services.wm.getEnumerator("navigator:browser")) {
@@ -408,13 +429,24 @@ export const EnterpriseHandler = {
     return tabCount;
   },
 
+  /**
+   * Determines whether the signout/close prompt should be shown based on preferences and current state.
+   *
+   * @returns {boolean} True if the prompt should be shown, false otherwise.
+   */
   shouldShowClosePrompt() {
     if (this._skipSignoutPrompt) {
       this._skipSignoutPrompt = false;
       return false;
     }
-    const warnOnSignout = Services.prefs.getBoolPref(PROMPT_ON_SIGNOUT_PREF, true);
-    const warnOnCloseWithTabs = Services.prefs.getBoolPref(WARN_ON_CLOSE_PREF, false);
+    const warnOnSignout = Services.prefs.getBoolPref(
+      PROMPT_ON_SIGNOUT_PREF,
+      true
+    );
+    const warnOnCloseWithTabs = Services.prefs.getBoolPref(
+      WARN_ON_CLOSE_PREF,
+      false
+    );
     if (!warnOnSignout && !warnOnCloseWithTabs) {
       return false;
     }

--- a/browser/components/enterprise/EnterpriseHandler.sys.mjs
+++ b/browser/components/enterprise/EnterpriseHandler.sys.mjs
@@ -332,9 +332,9 @@ export const EnterpriseHandler = {
    * @param {number} options.tabCount - The number of open tabs across all windows.
    * @param {boolean} options.warnOnSignout - Whether to warn on signout.
    * @param {boolean} options.warnOnCloseWithTabs - Whether to warn on close when multiple tabs are open.
-   * @returns {object} The parameters for the signout/close prompt, including title, message, checkbox states, and more.
+   * @returns {Promise<object>} The parameters for the signout/close prompt, including title, message, checkbox states, and more.
    */
-  _getSignoutPromptParams({
+  async _getSignoutPromptParams({
     tabCount,
     warnOnSignout,
     warnOnCloseWithTabs,
@@ -359,7 +359,7 @@ export const EnterpriseHandler = {
       reauthNotice,
       checkLabel,
       tabsCheckLabel,
-    ] = lazy.localization.formatValuesSync([
+    ] = await lazy.localization.formatValues([
       titleId,
       messageId,
       { id: "enterprise-close-prompt-primary-btn-label" },
@@ -477,7 +477,7 @@ export const EnterpriseHandler = {
       return true;
     }
 
-    const params = this._getSignoutPromptParams({
+    const params = await this._getSignoutPromptParams({
       tabCount: this._tabCount,
       warnOnSignout,
       warnOnCloseWithTabs,

--- a/browser/components/enterprise/content/enterprise-close-dialog.css
+++ b/browser/components/enterprise/content/enterprise-close-dialog.css
@@ -11,6 +11,12 @@
   margin-block: 0;
 }
 
+#dialogGrid {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}
+
 #infoContainer {
   display: flex;
   flex-direction: column;

--- a/browser/components/enterprise/content/enterprise-close-dialog.css
+++ b/browser/components/enterprise/content/enterprise-close-dialog.css
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+:root {
+  min-width: 30em;
+}
+
+.dialogRow:not([hidden]) {
+  display: block;
+  margin-block: 0;
+}
+
+#infoContainer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-large);
+}
+
+#infoTitle,
+#infoBody {
+  margin-bottom: 0;
+}
+
+#infoTitle {
+  font-weight: var(--font-weight-bold);
+}
+
+#checkboxesList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-large);
+}
+
+#checkboxesList .checkbox-label {
+  white-space: nowrap;
+}

--- a/browser/components/enterprise/content/enterprise-close-dialog.css
+++ b/browser/components/enterprise/content/enterprise-close-dialog.css
@@ -24,7 +24,8 @@
 }
 
 #infoTitle,
-#infoBody {
+#infoBody,
+#infoReauth {
   margin-bottom: 0;
 }
 

--- a/browser/components/enterprise/content/enterprise-close-dialog.css
+++ b/browser/components/enterprise/content/enterprise-close-dialog.css
@@ -37,7 +37,3 @@
   flex-direction: column;
   gap: var(--space-large);
 }
-
-#checkboxesList .checkbox-label {
-  white-space: nowrap;
-}

--- a/browser/components/enterprise/content/enterprise-close-dialog.js
+++ b/browser/components/enterprise/content/enterprise-close-dialog.js
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const XUL_NS = "http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul";
+
+let gArgs;
+
+function onLoad() {
+  gArgs = window.arguments[0];
+
+  document.title = gArgs.title;
+  document.getElementById("infoTitle").textContent = gArgs.title;
+  document.getElementById("infoBody").textContent = gArgs.message;
+
+  const dialog = document.getElementById("enterpriseCloseDialog");
+  dialog.getButton("accept").label = gArgs.acceptLabel;
+
+  if (gArgs.checkboxes.length) {
+    createCheckboxes();
+  }
+
+  document.addEventListener("dialogaccept", onAccept, { once: true });
+  document.addEventListener("dialogcancel", onCancel, { once: true });
+
+  window.sizeToContent();
+}
+
+function createCheckboxes() {
+  const list = document.getElementById("checkboxesList");
+  for (const { id, label, checked } of gArgs.checkboxes) {
+    const checkbox = document.createElementNS(XUL_NS, "checkbox");
+    checkbox.id = id;
+    checkbox.setAttribute("label", label);
+    if (checked) {
+      checkbox.setAttribute("checked", "true");
+    }
+    list.appendChild(checkbox);
+  }
+  document.getElementById("checkboxesRow").removeAttribute("hidden");
+}
+
+function onAccept() {
+  gArgs.accepted = true;
+  for (const checkboxArgs of gArgs.checkboxes) {
+    checkboxArgs.checked = document.getElementById(checkboxArgs.id).checked;
+  }
+}
+
+function onCancel() {
+  gArgs.accepted = false;
+}
+
+document.addEventListener("DOMContentLoaded", onLoad);

--- a/browser/components/enterprise/content/enterprise-close-dialog.js
+++ b/browser/components/enterprise/content/enterprise-close-dialog.js
@@ -3,13 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 const XUL_NS = "http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul";
+const gArgs = window.arguments[0].wrappedJSObject ?? window.arguments[0];
 
 /**
  * Initializes the enterprise close dialog, called on DOMContentLoaded.
  */
 function onLoad() {
-  const gArgs = window.arguments[0].wrappedJSObject ?? window.arguments[0];
-
   document.title = gArgs.title;
   document.getElementById("infoTitle").textContent = gArgs.title;
   document.getElementById("infoBody").textContent = gArgs.message;
@@ -27,10 +26,10 @@ function onLoad() {
     createCheckboxes(gArgs.checkboxes);
   }
 
-  document.addEventListener("dialogaccept", () => onAccept(gArgs), {
+  document.addEventListener("dialogaccept", onAccept, {
     once: true,
   });
-  document.addEventListener("dialogcancel", () => onCancel(gArgs), {
+  document.addEventListener("dialogcancel", onCancel, {
     once: true,
   });
 
@@ -58,10 +57,8 @@ function createCheckboxes(checkboxes) {
 
 /**
  * Handles the accept action for the enterprise close dialog.
- *
- * @param {object} gArgs - The arguments object passed to the dialog.
  */
-function onAccept(gArgs) {
+function onAccept() {
   gArgs.accepted = true;
   for (const checkboxArgs of gArgs.checkboxes) {
     checkboxArgs.checked = document.getElementById(checkboxArgs.id).checked;
@@ -70,10 +67,8 @@ function onAccept(gArgs) {
 
 /**
  * Handles the cancel action for the enterprise close dialog.
- *
- * @param {object} gArgs - The arguments object passed to the dialog.
  */
-function onCancel(gArgs) {
+function onCancel() {
   gArgs.accepted = false;
 }
 

--- a/browser/components/enterprise/content/enterprise-close-dialog.js
+++ b/browser/components/enterprise/content/enterprise-close-dialog.js
@@ -4,10 +4,8 @@
 
 const XUL_NS = "http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul";
 
-let gArgs;
-
 function onLoad() {
-  gArgs = window.arguments[0].wrappedJSObject ?? window.arguments[0];
+  const gArgs = window.arguments[0].wrappedJSObject ?? window.arguments[0];
 
   document.title = gArgs.title;
   document.getElementById("infoTitle").textContent = gArgs.title;
@@ -23,18 +21,18 @@ function onLoad() {
   dialog.getButton("accept").label = gArgs.acceptLabel;
 
   if (gArgs.checkboxes.length) {
-    createCheckboxes();
+    createCheckboxes(gArgs.checkboxes);
   }
 
-  document.addEventListener("dialogaccept", onAccept, { once: true });
-  document.addEventListener("dialogcancel", onCancel, { once: true });
+  document.addEventListener("dialogaccept", () => onAccept(gArgs), { once: true });
+  document.addEventListener("dialogcancel", () => onCancel(gArgs), { once: true });
 
   window.sizeToContent();
 }
 
-function createCheckboxes() {
+function createCheckboxes(checkboxes) {
   const list = document.getElementById("checkboxesList");
-  for (const { id, label, checked } of gArgs.checkboxes) {
+  for (const { id, label, checked } of checkboxes) {
     const checkbox = document.createElementNS(XUL_NS, "checkbox");
     checkbox.id = id;
     checkbox.setAttribute("label", label);
@@ -46,14 +44,14 @@ function createCheckboxes() {
   document.getElementById("checkboxesRow").removeAttribute("hidden");
 }
 
-function onAccept() {
+function onAccept(gArgs) {
   gArgs.accepted = true;
   for (const checkboxArgs of gArgs.checkboxes) {
     checkboxArgs.checked = document.getElementById(checkboxArgs.id).checked;
   }
 }
 
-function onCancel() {
+function onCancel(gArgs) {
   gArgs.accepted = false;
 }
 

--- a/browser/components/enterprise/content/enterprise-close-dialog.js
+++ b/browser/components/enterprise/content/enterprise-close-dialog.js
@@ -7,7 +7,7 @@ const XUL_NS = "http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul";
 let gArgs;
 
 function onLoad() {
-  gArgs = window.arguments[0];
+  gArgs = window.arguments[0].wrappedJSObject ?? window.arguments[0];
 
   document.title = gArgs.title;
   document.getElementById("infoTitle").textContent = gArgs.title;

--- a/browser/components/enterprise/content/enterprise-close-dialog.js
+++ b/browser/components/enterprise/content/enterprise-close-dialog.js
@@ -4,6 +4,9 @@
 
 const XUL_NS = "http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul";
 
+/**
+ * Initializes the enterprise close dialog, called on DOMContentLoaded.
+ */
 function onLoad() {
   const gArgs = window.arguments[0].wrappedJSObject ?? window.arguments[0];
 
@@ -24,12 +27,21 @@ function onLoad() {
     createCheckboxes(gArgs.checkboxes);
   }
 
-  document.addEventListener("dialogaccept", () => onAccept(gArgs), { once: true });
-  document.addEventListener("dialogcancel", () => onCancel(gArgs), { once: true });
+  document.addEventListener("dialogaccept", () => onAccept(gArgs), {
+    once: true,
+  });
+  document.addEventListener("dialogcancel", () => onCancel(gArgs), {
+    once: true,
+  });
 
   window.sizeToContent();
 }
 
+/**
+ * Dynamically creates checkboxes in the enterprise close dialog based on provided configurations.
+ *
+ * @param {Array<{id: string, label: string, checked: boolean}>} checkboxes - An array of checkbox configurations, each containing an id, label, and checked state.
+ */
 function createCheckboxes(checkboxes) {
   const list = document.getElementById("checkboxesList");
   for (const { id, label, checked } of checkboxes) {
@@ -44,6 +56,11 @@ function createCheckboxes(checkboxes) {
   document.getElementById("checkboxesRow").removeAttribute("hidden");
 }
 
+/**
+ * Handles the accept action for the enterprise close dialog.
+ *
+ * @param {object} gArgs - The arguments object passed to the dialog.
+ */
 function onAccept(gArgs) {
   gArgs.accepted = true;
   for (const checkboxArgs of gArgs.checkboxes) {
@@ -51,6 +68,11 @@ function onAccept(gArgs) {
   }
 }
 
+/**
+ * Handles the cancel action for the enterprise close dialog.
+ *
+ * @param {object} gArgs - The arguments object passed to the dialog.
+ */
 function onCancel(gArgs) {
   gArgs.accepted = false;
 }

--- a/browser/components/enterprise/content/enterprise-close-dialog.js
+++ b/browser/components/enterprise/content/enterprise-close-dialog.js
@@ -13,6 +13,12 @@ function onLoad() {
   document.getElementById("infoTitle").textContent = gArgs.title;
   document.getElementById("infoBody").textContent = gArgs.message;
 
+  if (gArgs.reauthNotice) {
+    const reauthEl = document.getElementById("infoReauth");
+    reauthEl.textContent = gArgs.reauthNotice;
+    reauthEl.removeAttribute("hidden");
+  }
+
   const dialog = document.getElementById("enterpriseCloseDialog");
   dialog.getButton("accept").label = gArgs.acceptLabel;
 

--- a/browser/components/enterprise/content/enterprise-close-dialog.xhtml
+++ b/browser/components/enterprise/content/enterprise-close-dialog.xhtml
@@ -37,6 +37,7 @@
         <html:div id="infoContainer">
           <xul:description id="infoTitle" />
           <xul:description id="infoBody" />
+          <xul:description id="infoReauth" hidden="true" />
         </html:div>
       </html:div>
       <html:div class="dialogRow" id="checkboxesRow" hidden="hidden">

--- a/browser/components/enterprise/content/enterprise-close-dialog.xhtml
+++ b/browser/components/enterprise/content/enterprise-close-dialog.xhtml
@@ -12,7 +12,7 @@
   xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
   xmlns:html="http://www.w3.org/1999/xhtml"
   xmlns:xul="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
-  aria-describedby="infoBody"
+  aria-describedby="infoBody infoReauth"
   headerparent="dialogGrid"
 >
   <dialog id="enterpriseCloseDialog" buttonpack="end">

--- a/browser/components/enterprise/content/enterprise-close-dialog.xhtml
+++ b/browser/components/enterprise/content/enterprise-close-dialog.xhtml
@@ -1,0 +1,49 @@
+<?xml version="1.0"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
+
+<?csp default-src chrome:; ?>
+
+<!DOCTYPE window>
+
+<window
+  id="enterpriseCloseDialogWindow"
+  xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
+  xmlns:html="http://www.w3.org/1999/xhtml"
+  xmlns:xul="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
+  aria-describedby="infoBody"
+  headerparent="dialogGrid"
+>
+  <dialog id="enterpriseCloseDialog" buttonpack="end">
+    <linkset>
+      <html:link rel="stylesheet" href="chrome://global/skin/global.css" />
+      <html:link
+        rel="stylesheet"
+        href="chrome://global/content/commonDialog.css"
+      />
+      <html:link
+        rel="stylesheet"
+        href="chrome://global/skin/commonDialog.css"
+      />
+      <html:link
+        rel="stylesheet"
+        href="chrome://browser/content/enterprise/enterprise-close-dialog.css"
+      />
+    </linkset>
+
+    <html:div id="dialogGrid">
+      <html:div class="dialogRow" id="infoRow">
+        <html:div id="infoContainer">
+          <xul:description id="infoTitle" />
+          <xul:description id="infoBody" />
+        </html:div>
+      </html:div>
+      <html:div class="dialogRow" id="checkboxesRow" hidden="hidden">
+        <html:div id="checkboxesList" />
+      </html:div>
+    </html:div>
+
+    <script src="chrome://browser/content/enterprise/enterprise-close-dialog.js" />
+  </dialog>
+</window>

--- a/browser/components/enterprise/jar.mn
+++ b/browser/components/enterprise/jar.mn
@@ -12,6 +12,9 @@ browser.jar:
   content/browser/enterprise/enterprise-urlbar-panels.inc.xhtml (content/enterprise-urlbar-panels.inc.xhtml)
   content/browser/enterprise/lockdown-mode.svg              (content/icons/lockdown-mode.svg)
   content/browser/enterprise/user-avatar.svg                (content/icons/user-avatar.svg)
+  content/browser/enterprise/enterprise-close-dialog.xhtml  (content/enterprise-close-dialog.xhtml)
+  content/browser/enterprise/enterprise-close-dialog.js     (content/enterprise-close-dialog.js)
+  content/browser/enterprise/enterprise-close-dialog.css    (content/enterprise-close-dialog.css)
 
   content/builtin-themes/enterprise-light                   (theme/light/*.svg)
   content/builtin-themes/enterprise-light                   (theme/light/*.png)

--- a/browser/locales/en-US/browser/enterprise/enterprise.ftl
+++ b/browser/locales/en-US/browser/enterprise/enterprise.ftl
@@ -15,34 +15,42 @@ enterprise-panel-learn-more = Learn more
 enterprise-panel-sign-out-btn =
     .label = Sign out…
 
-enterprise-close-prompt-title = Close { -brand-short-name }?
 # Variables:
-#   $tabCount (Number): The number of tabs that will be closed.
-enterprise-close-prompt-title-with-tabs =
-    Close { -brand-short-name } and { $tabCount ->
-       *[other] { $tabCount } tabs
-    }?
-enterprise-close-prompt-message = You’re about to sign out of { -brand-short-name } and end your session.
+#   $tabCount (Number): The number of tabs to be closed, or 0 when the tab count warning is not shown.
+#   $warnSignout (String): "true" when the sign-out warning is shown.
+enterprise-close-prompt-title =
+    { $tabCount ->
+        [0] Close { -brand-short-name }?
+       *[other]
+            { $warnSignout ->
+                [true] Close { -brand-short-name } and { $tabCount } tabs?
+               *[false] Close { $tabCount } tabs?
+            }
+    }
 # Variables:
-#   $tabCount (Number): The number of tabs that will be closed.
-enterprise-close-prompt-message-with-tabs =
-    You’re about to sign out of { -brand-short-name } and close { $tabCount ->
-       *[other] { $tabCount } tabs
-    }.
-# Variables:
-#   $tabCount (Number): The number of tabs that will be closed.
-enterprise-close-prompt-title-tabs-only =
-    Close { $tabCount ->
-       *[other] { $tabCount } tabs
-    }?
+#   $tabCount (Number): The number of tabs to be closed, or 0 when the tab count warning is not shown.
+#   $warnSignout (String): "true" when the sign-out warning is shown.
+enterprise-close-prompt-message =
+    { $tabCount ->
+        [0] You’re about to sign out of { -brand-short-name } and end your session.
+       *[other]
+            { $warnSignout ->
+                [true] You’re about to sign out of { -brand-short-name } and close { $tabCount } tabs.
+               *[false] Closing { -brand-short-name } will also sign you out.
+            }
+    }
 enterprise-close-prompt-message-reauth = To use { -brand-short-name } again, you’ll need to reauthenticate through your organization’s SSO provider.
-enterprise-close-prompt-message-tabs-only = Closing { -brand-short-name } will also sign you out.
 enterprise-close-prompt-checkbox-label = Warn me when closing { -brand-short-name } signs me out
 enterprise-close-prompt-tabs-checkbox-label = Warn me when closing multiple tabs
 enterprise-close-prompt-primary-btn-label = Close and sign out
 
-enterprise-quit-shortcut-prompt-title = Close window and quit { -brand-short-name }?
-enterprise-quit-shortcut-prompt-title-with-tabs = Quit { -brand-short-name } or close current tab?
+# Variables:
+#   $withTabs (String): "true" when showing the option to close the current tab instead of quitting.
+enterprise-quit-shortcut-prompt-title =
+    { $withTabs ->
+        [true] Quit { -brand-short-name } or close current tab?
+       *[false] Close window and quit { -brand-short-name }?
+    }
 enterprise-quit-shortcut-prompt-message = Quitting will sign you out of your session. You’ll need to reauthenticate through your organization’s SSO provider.
 enterprise-quit-shortcut-prompt-primary-btn-label = Quit and sign out
 

--- a/browser/locales/en-US/browser/enterprise/enterprise.ftl
+++ b/browser/locales/en-US/browser/enterprise/enterprise.ftl
@@ -15,16 +15,31 @@ enterprise-panel-learn-more = Learn more
 enterprise-panel-sign-out-btn =
     .label = Sign out…
 
-# $tabCount (Number) - the number of open tabs
-enterprise-signout-prompt-title2 =
-    { $tabCount ->
-        [0] Sign out of { -brand-short-name }?
-        [one] Sign out of { -brand-short-name }?
-       *[other] Sign out and close { $tabCount } tabs?
-    }
-enterprise-signout-prompt-message = You’re signing out of your { -brand-short-name } browser. To use it again, you’ll need to re-authenticate through your company’s SSO provider.
-enterprise-signout-prompt-checkbox-label = Show this message when signing out.
-enterprise-signout-prompt-primary-btn-label = Sign out
+enterprise-close-prompt-title = Close { -brand-short-name }?
+# Variables:
+#   $tabCount (Number): The number of tabs that will be closed.
+enterprise-close-prompt-title-with-tabs =
+    Close { -brand-short-name } and { $tabCount ->
+       *[other] { $tabCount } tabs
+    }?
+enterprise-close-prompt-message = You’re about to sign out of { -brand-short-name } and end your session.
+# Variables:
+#   $tabCount (Number): The number of tabs that will be closed.
+enterprise-close-prompt-message-with-tabs =
+    You’re about to sign out of { -brand-short-name } and close { $tabCount ->
+       *[other] { $tabCount } tabs
+    }.
+# Variables:
+#   $tabCount (Number): The number of tabs that will be closed.
+enterprise-close-prompt-title-tabs-only =
+    Close { $tabCount ->
+       *[other] { $tabCount } tabs
+    }?
+enterprise-close-prompt-message-reauth = To use { -brand-short-name } again, you’ll need to reauthenticate through your organization’s SSO provider.
+enterprise-close-prompt-message-tabs-only = Closing { -brand-short-name } will also sign you out.
+enterprise-close-prompt-checkbox-label = Warn me when closing { -brand-short-name } signs me out
+enterprise-close-prompt-tabs-checkbox-label = Warn me when closing multiple tabs
+enterprise-close-prompt-primary-btn-label = Close and sign out
 
 restart-forced-title = Restart { -brand-short-name }
 restart-forced-heading = Restart to continue using { -brand-short-name }.

--- a/browser/locales/en-US/browser/enterprise/enterprise.ftl
+++ b/browser/locales/en-US/browser/enterprise/enterprise.ftl
@@ -41,6 +41,11 @@ enterprise-close-prompt-checkbox-label = Warn me when closing { -brand-short-nam
 enterprise-close-prompt-tabs-checkbox-label = Warn me when closing multiple tabs
 enterprise-close-prompt-primary-btn-label = Close and sign out
 
+enterprise-quit-shortcut-prompt-title = Close window and quit { -brand-short-name }?
+enterprise-quit-shortcut-prompt-title-with-tabs = Quit { -brand-short-name } or close current tab?
+enterprise-quit-shortcut-prompt-message = Quitting will sign you out of your session. You’ll need to reauthenticate through your organization’s SSO provider.
+enterprise-quit-shortcut-prompt-primary-btn-label = Quit and sign out
+
 restart-forced-title = Restart { -brand-short-name }
 restart-forced-heading = Restart to continue using { -brand-short-name }.
 restart-forced-intro = Company policy requires that { -brand-short-name } be restarted.

--- a/browser/locales/en-US/browser/enterprise/enterprise.ftl
+++ b/browser/locales/en-US/browser/enterprise/enterprise.ftl
@@ -15,29 +15,37 @@ enterprise-panel-learn-more = Learn more
 enterprise-panel-sign-out-btn =
     .label = Sign out…
 
+enterprise-close-prompt-title = Close { -brand-short-name }?
+
 # Variables:
-#   $tabCount (Number): The number of tabs to be closed, or 0 when the tab count warning is not shown.
+#   $tabCount (Number): The number of tabs to be closed.
 #   $warnSignout (String): "true" when the sign-out warning is shown.
-enterprise-close-prompt-title =
-    { $tabCount ->
-        [0] Close { -brand-short-name }?
-       *[other]
-            { $warnSignout ->
-                [true] Close { -brand-short-name } and { $tabCount } tabs?
-               *[false] Close { $tabCount } tabs?
+enterprise-close-prompt-title-with-tabcount =
+    { $warnSignout ->
+        [true]
+            { $tabCount ->
+                [one] Close { -brand-short-name } and { $tabCount } tab?
+               *[other] Close { -brand-short-name } and { $tabCount } tabs?
+            }
+       *[false]
+            { $tabCount ->
+                [one] Close { $tabCount } tab?
+               *[other] Close { $tabCount } tabs?
             }
     }
+enterprise-close-prompt-message = You’re about to sign out of { -brand-short-name } and end your session.
+
 # Variables:
-#   $tabCount (Number): The number of tabs to be closed, or 0 when the tab count warning is not shown.
+#   $tabCount (Number): The number of tabs to be closed.
 #   $warnSignout (String): "true" when the sign-out warning is shown.
-enterprise-close-prompt-message =
-    { $tabCount ->
-        [0] You’re about to sign out of { -brand-short-name } and end your session.
-       *[other]
-            { $warnSignout ->
-                [true] You’re about to sign out of { -brand-short-name } and close { $tabCount } tabs.
-               *[false] Closing { -brand-short-name } will also sign you out.
+enterprise-close-prompt-message-with-tabcount =
+    { $warnSignout ->
+        [true]
+            { $tabCount ->
+                [one] You’re about to sign out of { -brand-short-name } and close { $tabCount } tab.
+               *[other] You’re about to sign out of { -brand-short-name } and close { $tabCount } tabs.
             }
+       *[false] Closing { -brand-short-name } will also sign you out.
     }
 enterprise-close-prompt-message-reauth = To use { -brand-short-name } again, you’ll need to reauthenticate through your organization’s SSO provider.
 enterprise-close-prompt-checkbox-label = Warn me when closing { -brand-short-name } signs me out

--- a/testing/enterprise/manifest.toml
+++ b/testing/enterprise/manifest.toml
@@ -44,6 +44,8 @@ run-if = [
 
 ["test_felt_browser_shutdown_crash_exit.py"]
 
+["test_felt_browser_close_warning.py"]
+
 ["test_felt_browser_signout.py"]
 
 ["test_felt_browser_signout_on_exit.py"]

--- a/testing/enterprise/test_felt_browser_close_warning.py
+++ b/testing/enterprise/test_felt_browser_close_warning.py
@@ -23,20 +23,39 @@ class BrowserCloseWarning(FeltTests):
         )
         self._child_driver.set_context("content")
 
-    def _trigger_browser_closure(self):
+    def _trigger_browser_closure(self, close_all_windows=False):
         """Simulate a natural browser close by firing quit-application-requested,
         which BrowserGlue intercepts to show the Enterprise signout dialog.
-        If the quit is not cancelled, force-quit to mirror native OS behavior."""
+        If the quit is not cancelled, force-quit to mirror native OS behavior.
+
+        If close_all_windows is True, all browser windows are closed first so
+        that BrowserWindowTracker.getTopWindow() returns null, which causes
+        BrowserGlue to open a standalone dialog (the macOS no-window path).
+        """
         self._child_driver.set_context("chrome")
         self._child_driver.execute_script(
             """
-            let cancelQuit = Cc["@mozilla.org/supports-PRBool;1"]
-                .createInstance(Ci.nsISupportsPRBool);
-            Services.obs.notifyObservers(cancelQuit, "quit-application-requested", null);
-            if (!cancelQuit.data) {
-                Services.startup.quit(Ci.nsIAppStartup.eForceQuit);
+            const closeWindows = arguments[0];
+            function triggerQuit() {
+                let cancelQuit = Cc["@mozilla.org/supports-PRBool;1"]
+                    .createInstance(Ci.nsISupportsPRBool);
+                Services.obs.notifyObservers(cancelQuit, "quit-application-requested", null);
+                if (!cancelQuit.data) {
+                    Services.startup.quit(Ci.nsIAppStartup.eForceQuit);
+                }
             }
-            """
+            if (closeWindows) {
+                const wins = [...Services.wm.getEnumerator('navigator:browser')];
+                const closed = wins.map(win =>
+                    new Promise(r => win.addEventListener('unload', r, { once: true }))
+                );
+                wins.forEach(win => win.close());
+                Promise.all(closed).then(triggerQuit);
+            } else {
+                triggerQuit();
+            }
+            """,
+            [close_all_windows],
         )
         self._manually_closed_child = True
 
@@ -231,20 +250,6 @@ class BrowserCloseWarning(FeltTests):
 
         self._child_driver.set_context("chrome")
         initial_handles = set(self._child_driver.chrome_window_handles)
-
-        # showSignoutPrompt(null) is the code path hit on macOS when the user
-        # quits with no browser windows open. Verify it opens a standalone dialog.
-        # Use setTimeout to defer the call so execute_script returns before the
-        # modal dialog blocks the event loop.
-        self._child_driver.execute_script(
-            """
-            const { EnterpriseHandler } = ChromeUtils.importESModule(
-                "resource:///modules/enterprise/EnterpriseHandler.sys.mjs"
-            );
-            setTimeout(() => EnterpriseHandler.showSignoutPrompt(null), 0);
-            """
-        )
-
+        self._trigger_browser_closure(close_all_windows=True)
         self._accept_standalone_close_dialog(initial_handles)
-
         self.assert_child_browser_closed()

--- a/testing/enterprise/test_felt_browser_close_warning.py
+++ b/testing/enterprise/test_felt_browser_close_warning.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import os
+import sys
+
+sys.path.append(os.path.dirname(__file__))
+
+from base_test import Environment
+from felt_tests import FeltTests
+from marionette_driver.errors import NoSuchWindowException, UnknownException
+
+PREF_PROMPT_ON_SIGNOUT = "enterprise.promptOnSignout"
+PREF_WARN_ON_CLOSE = "browser.tabs.warnOnClose"
+
+
+class BrowserCloseWarning(FeltTests):
+    def _set_child_bool_pref(self, pref_name, value):
+        self._child_driver.set_context("chrome")
+        self._child_driver.execute_script(
+            f"Services.prefs.setBoolPref('{pref_name}', {'true' if value else 'false'});"
+        )
+        self._child_driver.set_context("content")
+
+    def _close_browser(self):
+        self._child_driver.set_context("chrome")
+        try:
+            self._child_driver.execute_script(
+                "EnterpriseHandler.warnAboutClosing(window);"
+            )
+        except (NoSuchWindowException, UnknownException):
+            pass
+        finally:
+            self._manually_closed_child = True
+
+    def _close_app(self):
+        """Simulate an OS-level app close by firing quit-application-requested,
+        which BrowserGlue intercepts to show the Enterprise signout dialog."""
+        self._child_driver.set_context("chrome")
+        self._child_driver.execute_script(
+            """
+            let cancelQuit = Cc["@mozilla.org/supports-PRBool;1"]
+                .createInstance(Ci.nsISupportsPRBool);
+            Services.obs.notifyObservers(cancelQuit, "quit-application-requested", null);
+            """
+        )
+        self._manually_closed_child = True
+
+    def _accept_close_dialog(self):
+        self._logger.info("Waiting for the custom signout dialog to open")
+        self._child_wait.until(
+            lambda _: self._child_driver.execute_script(
+                """
+                try {
+                    const dialog = document.getElementById('window-modal-dialog');
+                    return !!(dialog?.open && dialog.querySelector(".dialogFrame")
+                        ?.contentDocument
+                        ?.getElementById("enterpriseCloseDialog")
+                        ?.getButton('accept'));
+                } catch (e) {
+                    return false;
+                }
+                """
+            )
+        )
+
+        self._logger.info(
+            "Signing out the user by clicking the Signout button in the custom signout dialog"
+        )
+        self._child_driver.execute_script(
+            """
+            document.getElementById("window-modal-dialog")
+                .querySelector(".dialogFrame")
+                .contentDocument
+                .getElementById("enterpriseCloseDialog")
+                .getButton("accept")
+                .click();
+            """
+        )
+
+    def _assert_signed_out_after_close(self):
+        self.await_felt_auth_window()
+        self.force_window()
+        self.assert_user_signed_out(env=Environment.FELT)
+
+    def test_browser_window_close_default_config(self):
+        """Default config: sign-out warn on, tabs warn off, single tab - dialog shows."""
+        super().run_felt_base()
+        self.connect_child_browser()
+        self.assert_user_signed_in(env=Environment.FIREFOX)
+
+        self._close_browser()
+        self._accept_close_dialog()
+
+        self._assert_signed_out_after_close()
+
+    def test_browser_window_close_with_both_warnings(self):
+        """Sign-out warn on, tabs warn on, multiple tabs open - both warnings shown."""
+        super().run_felt_base()
+        self.connect_child_browser()
+        self.assert_user_signed_in(env=Environment.FIREFOX)
+
+        self._set_child_bool_pref(PREF_WARN_ON_CLOSE, True)
+        self.open_tab_child("about:blank")
+
+        self._close_browser()
+        self._accept_close_dialog()
+
+        self._assert_signed_out_after_close()
+
+    def test_browser_window_close_no_warnings(self):
+        """Sign-out warn off, tabs warn off - no dialog, direct shutdown."""
+        super().run_felt_base()
+        self.connect_child_browser()
+        self.assert_user_signed_in(env=Environment.FIREFOX)
+
+        self._set_child_bool_pref(PREF_PROMPT_ON_SIGNOUT, False)
+
+        self._close_browser()
+
+        self._assert_signed_out_after_close()
+
+    def test_browser_window_close_tabs_warn_only(self):
+        """Sign-out warn off, tabs warn on, multiple tabs open - tabs warning shown."""
+        super().run_felt_base()
+        self.connect_child_browser()
+        self.assert_user_signed_in(env=Environment.FIREFOX)
+
+        self._set_child_bool_pref(PREF_PROMPT_ON_SIGNOUT, False)
+        self._set_child_bool_pref(PREF_WARN_ON_CLOSE, True)
+        self.open_tab_child("about:blank")
+
+        self._close_browser()
+        self._accept_close_dialog()
+
+        self._assert_signed_out_after_close()
+
+    def test_app_close_shows_enterprise_dialog(self):
+        """App close (quit-application-requested) is intercepted by BrowserGlue and shows dialog."""
+        super().run_felt_base()
+        self.connect_child_browser()
+        self.assert_user_signed_in(env=Environment.FIREFOX)
+
+        self._close_app()
+        self._accept_close_dialog()
+
+        self._assert_signed_out_after_close()

--- a/testing/enterprise/test_felt_browser_close_warning.py
+++ b/testing/enterprise/test_felt_browser_close_warning.py
@@ -10,7 +10,6 @@ sys.path.append(os.path.dirname(__file__))
 
 from base_test import Environment
 from felt_tests import FeltTests
-from marionette_driver.errors import NoSuchWindowException, UnknownException
 
 PREF_PROMPT_ON_SIGNOUT = "enterprise.promptOnSignout"
 PREF_WARN_ON_CLOSE = "browser.tabs.warnOnClose"
@@ -25,25 +24,18 @@ class BrowserCloseWarning(FeltTests):
         self._child_driver.set_context("content")
 
     def _close_browser(self):
-        self._child_driver.set_context("chrome")
-        try:
-            self._child_driver.execute_script(
-                "EnterpriseHandler.warnAboutClosing(window);"
-            )
-        except (NoSuchWindowException, UnknownException):
-            pass
-        finally:
-            self._manually_closed_child = True
-
-    def _close_app(self):
-        """Simulate an OS-level app close by firing quit-application-requested,
-        which BrowserGlue intercepts to show the Enterprise signout dialog."""
+        """Simulate a natural browser close by firing quit-application-requested,
+        which BrowserGlue intercepts to show the Enterprise signout dialog.
+        If the quit is not cancelled, force-quit to mirror native OS behavior."""
         self._child_driver.set_context("chrome")
         self._child_driver.execute_script(
             """
             let cancelQuit = Cc["@mozilla.org/supports-PRBool;1"]
                 .createInstance(Ci.nsISupportsPRBool);
             Services.obs.notifyObservers(cancelQuit, "quit-application-requested", null);
+            if (!cancelQuit.data) {
+                Services.startup.quit(Ci.nsIAppStartup.eForceQuit);
+            }
             """
         )
         self._manually_closed_child = True
@@ -80,13 +72,8 @@ class BrowserCloseWarning(FeltTests):
             """
         )
 
-    def _assert_signed_out_after_close(self):
-        self.await_felt_auth_window()
-        self.force_window()
-        self.assert_user_signed_out(env=Environment.FELT)
-
     def test_browser_window_close_default_config(self):
-        """Default config: sign-out warn on, tabs warn off, single tab - dialog shows."""
+        """Default config: sign-out warn on, single tab - enterprise dialog shows."""
         super().run_felt_base()
         self.connect_child_browser()
         self.assert_user_signed_in(env=Environment.FIREFOX)
@@ -94,10 +81,10 @@ class BrowserCloseWarning(FeltTests):
         self._close_browser()
         self._accept_close_dialog()
 
-        self._assert_signed_out_after_close()
+        self.assert_child_browser_closed()
 
     def test_browser_window_close_with_both_warnings(self):
-        """Sign-out warn on, tabs warn on, multiple tabs open - both warnings shown."""
+        """Sign-out warn on, tabs warn on, multiple tabs open - enterprise dialog with tabs checkbox shown."""
         super().run_felt_base()
         self.connect_child_browser()
         self.assert_user_signed_in(env=Environment.FIREFOX)
@@ -108,10 +95,10 @@ class BrowserCloseWarning(FeltTests):
         self._close_browser()
         self._accept_close_dialog()
 
-        self._assert_signed_out_after_close()
+        self.assert_child_browser_closed()
 
     def test_browser_window_close_no_warnings(self):
-        """Sign-out warn off, tabs warn off - no dialog, direct shutdown."""
+        """Sign-out warn off - no dialog, quit proceeds directly."""
         super().run_felt_base()
         self.connect_child_browser()
         self.assert_user_signed_in(env=Environment.FIREFOX)
@@ -120,30 +107,4 @@ class BrowserCloseWarning(FeltTests):
 
         self._close_browser()
 
-        self._assert_signed_out_after_close()
-
-    def test_browser_window_close_tabs_warn_only(self):
-        """Sign-out warn off, tabs warn on, multiple tabs open - tabs warning shown."""
-        super().run_felt_base()
-        self.connect_child_browser()
-        self.assert_user_signed_in(env=Environment.FIREFOX)
-
-        self._set_child_bool_pref(PREF_PROMPT_ON_SIGNOUT, False)
-        self._set_child_bool_pref(PREF_WARN_ON_CLOSE, True)
-        self.open_tab_child("about:blank")
-
-        self._close_browser()
-        self._accept_close_dialog()
-
-        self._assert_signed_out_after_close()
-
-    def test_app_close_shows_enterprise_dialog(self):
-        """App close (quit-application-requested) is intercepted by BrowserGlue and shows dialog."""
-        super().run_felt_base()
-        self.connect_child_browser()
-        self.assert_user_signed_in(env=Environment.FIREFOX)
-
-        self._close_app()
-        self._accept_close_dialog()
-
-        self._assert_signed_out_after_close()
+        self.assert_child_browser_closed()

--- a/testing/enterprise/test_felt_browser_close_warning.py
+++ b/testing/enterprise/test_felt_browser_close_warning.py
@@ -106,6 +106,38 @@ class BrowserCloseWarning(FeltTests):
             """
         )
 
+    def _accept_standalone_close_dialog(self, initial_handles):
+        """Switch to and accept the standalone enterprise close dialog window,
+        then switch back to the original window.
+
+        Used for the macOS no-window case where the dialog opens outside any
+        browser window.
+        """
+        self._logger.info("Waiting for standalone enterprise close dialog window")
+
+        def get_new_handle(_):
+            current = set(self._child_driver.chrome_window_handles)
+            new = current - initial_handles
+            return new.pop() if new else None
+
+        dialog_handle = self._child_wait.until(get_new_handle)
+        self._child_driver.switch_to_window(dialog_handle)
+
+        self._child_wait.until(
+            lambda _: self._child_driver.execute_script(
+                "return !!document.getElementById('enterpriseCloseDialog')?.getButton('accept');"
+            )
+        )
+        self._logger.info("Clicking accept on standalone enterprise close dialog")
+        self._child_driver.execute_script(
+            "document.getElementById('enterpriseCloseDialog').getButton('accept').click();"
+        )
+
+        self._child_wait.until(
+            lambda _: set(self._child_driver.chrome_window_handles) == initial_handles
+        )
+        self._child_driver.switch_to_window(list(initial_handles)[0])
+
     def test_browser_window_close_default_config(self):
         """Default config: sign-out warn on, single tab - enterprise dialog shows."""
         super().run_felt_base()
@@ -188,3 +220,26 @@ class BrowserCloseWarning(FeltTests):
         self._close_browser()
 
         self.assert_child_browser_closed()
+
+    def test_browser_close_no_windows_shows_standalone_dialog(self):
+        """macOS no-window: quitting with no browser windows shows a standalone
+        enterprise dialog instead of crashing."""
+        super().run_felt_base()
+        self.connect_child_browser()
+        self.assert_user_signed_in(env=Environment.FIREFOX)
+
+        self._child_driver.set_context("chrome")
+        initial_handles = set(self._child_driver.chrome_window_handles)
+
+        # showSignoutPrompt(null) is the code path hit on macOS when the user
+        # quits with no browser windows open. Verify it opens a standalone dialog.
+        self._child_driver.execute_script(
+            """
+            const { EnterpriseHandler } = ChromeUtils.importESModule(
+                "resource:///modules/enterprise/EnterpriseHandler.sys.mjs"
+            );
+            EnterpriseHandler.showSignoutPrompt(null);
+            """
+        )
+
+        self._accept_standalone_close_dialog(initial_handles)

--- a/testing/enterprise/test_felt_browser_close_warning.py
+++ b/testing/enterprise/test_felt_browser_close_warning.py
@@ -11,7 +11,7 @@ sys.path.append(os.path.dirname(__file__))
 from base_test import Environment
 from felt_tests import FeltTests
 
-PREF_PROMPT_ON_SIGNOUT = "enterprise.promptOnSignout"
+PREF_PROMPT_ON_SIGNOUT = "enterprise.prompt_on_signout"
 PREF_WARN_ON_CLOSE = "browser.tabs.warnOnClose"
 
 
@@ -39,6 +39,40 @@ class BrowserCloseWarning(FeltTests):
             """
         )
         self._manually_closed_child = True
+
+    def _assert_close_dialog_content(self, expected_title, expected_message):
+        self._logger.info("Waiting for the custom signout dialog to assert its content")
+        self._child_wait.until(
+            lambda _: self._child_driver.execute_script(
+                """
+                try {
+                    const dialog = document.getElementById('window-modal-dialog');
+                    return !!(dialog?.open && dialog.querySelector(".dialogFrame")
+                        ?.contentDocument
+                        ?.getElementById("enterpriseCloseDialog")
+                        ?.getButton('accept'));
+                } catch (e) {
+                    return false;
+                }
+                """
+            )
+        )
+        content = self._child_driver.execute_script(
+            """
+            const doc = document.getElementById('window-modal-dialog')
+                .querySelector('.dialogFrame').contentDocument;
+            return {
+                title: doc.getElementById('infoTitle').textContent,
+                message: doc.getElementById('infoBody').textContent,
+            };
+            """
+        )
+        assert content["title"] == expected_title, (
+            f"Unexpected dialog title: {content['title']!r}"
+        )
+        assert content["message"] == expected_message, (
+            f"Unexpected dialog message: {content['message']!r}"
+        )
 
     def _accept_close_dialog(self):
         self._logger.info("Waiting for the custom signout dialog to open")
@@ -79,6 +113,13 @@ class BrowserCloseWarning(FeltTests):
         self.assert_user_signed_in(env=Environment.FIREFOX)
 
         self._close_browser()
+        self._assert_close_dialog_content(
+            expected_title="Close Firefox Enterprise?",
+            expected_message=(
+                "You’re about to sign out of Firefox Enterprise and end your session.\n\n"
+                "To use Firefox Enterprise again, you’ll need to reauthenticate through your organization’s SSO provider."
+            ),
+        )
         self._accept_close_dialog()
 
         self.assert_child_browser_closed()
@@ -93,6 +134,32 @@ class BrowserCloseWarning(FeltTests):
         self.open_tab_child("about:blank")
 
         self._close_browser()
+        self._assert_close_dialog_content(
+            expected_title="Close Firefox Enterprise and 2 tabs?",
+            expected_message=(
+                "You’re about to sign out of Firefox Enterprise and close 2 tabs.\n\n"
+                "To use Firefox Enterprise again, you’ll need to reauthenticate through your organization’s SSO provider."
+            ),
+        )
+        self._accept_close_dialog()
+
+        self.assert_child_browser_closed()
+
+    def test_browser_window_close_tabs_warning_only(self):
+        """Sign-out warn off, tabs warn on, multiple tabs - dialog shows tabs-only variant."""
+        super().run_felt_base()
+        self.connect_child_browser()
+        self.assert_user_signed_in(env=Environment.FIREFOX)
+
+        self._set_child_bool_pref(PREF_PROMPT_ON_SIGNOUT, False)
+        self._set_child_bool_pref(PREF_WARN_ON_CLOSE, True)
+        self.open_tab_child("about:blank")
+
+        self._close_browser()
+        self._assert_close_dialog_content(
+            expected_title="Close 2 tabs?",
+            expected_message="Closing Firefox will also sign you out.",
+        )
         self._accept_close_dialog()
 
         self.assert_child_browser_closed()

--- a/testing/enterprise/test_felt_browser_close_warning.py
+++ b/testing/enterprise/test_felt_browser_close_warning.py
@@ -17,6 +17,7 @@ PREF_WARN_ON_CLOSE = "browser.tabs.warnOnClose"
 
 class BrowserCloseWarning(FeltTests):
     def _set_child_bool_pref(self, pref_name, value):
+        """Set a boolean preference on the child browser via chrome context."""
         self._child_driver.set_context("chrome")
         self._child_driver.execute_script(
             f"Services.prefs.setBoolPref('{pref_name}', {'true' if value else 'false'});"
@@ -26,22 +27,25 @@ class BrowserCloseWarning(FeltTests):
     def _trigger_browser_closure(self, close_all_windows=False):
         """Simulate a natural browser close by firing quit-application-requested,
         which BrowserGlue intercepts to show the Enterprise signout dialog.
-        If the quit is not cancelled, force-quit to mirror native OS behavior.
 
         If close_all_windows is True, all browser windows are closed first so
         that BrowserWindowTracker.getTopWindow() returns null, which causes
         BrowserGlue to open a standalone dialog (the macOS no-window path).
         """
         self._child_driver.set_context("chrome")
-        self._child_driver.execute_script(
+        self._manually_closed_child = True
+        self._child_driver.execute_async_script(
             """
-            const closeWindows = arguments[0];
-            function triggerQuit() {
+            const [closeWindows, resolve] = arguments;
+            function triggerQuit(shouldResolve) {
                 let cancelQuit = Cc["@mozilla.org/supports-PRBool;1"]
                     .createInstance(Ci.nsISupportsPRBool);
                 Services.obs.notifyObservers(cancelQuit, "quit-application-requested", null);
                 if (!cancelQuit.data) {
-                    Services.startup.quit(Ci.nsIAppStartup.eForceQuit);
+                    if (shouldResolve) resolve();
+                    Services.startup.quit(Ci.nsIAppStartup.eAttemptQuit);
+                } else if (shouldResolve) {
+                    resolve();
                 }
             }
             if (closeWindows) {
@@ -50,14 +54,16 @@ class BrowserCloseWarning(FeltTests):
                     new Promise(r => win.addEventListener('unload', r, { once: true }))
                 );
                 wins.forEach(win => win.close());
-                Promise.all(closed).then(triggerQuit);
+                // callback() must fire before the document unloads, so it is
+                // called here rather than inside triggerQuit.
+                Promise.all(closed).then(() => triggerQuit(false));
+                resolve();
             } else {
-                triggerQuit();
+                triggerQuit(true);
             }
             """,
             [close_all_windows],
         )
-        self._manually_closed_child = True
 
     def _wait_for_close_dialog(self):
         """Wait for the enterprise close dialog to be ready and store a
@@ -80,6 +86,7 @@ class BrowserCloseWarning(FeltTests):
         )
 
     def _get_close_dialog_content(self):
+        """Return the title, message, and reauth text from the open close dialog."""
         return self._child_driver.execute_script(
             """
             const doc = document.getElementById('window-modal-dialog')
@@ -95,6 +102,7 @@ class BrowserCloseWarning(FeltTests):
     def _assert_close_dialog_content(
         self, expected_title, expected_message, expected_reauth=None
     ):
+        """Wait for the close dialog and assert its title, message, and optional reauth text."""
         self._logger.info("Waiting for the custom signout dialog to assert its content")
         self._wait_for_close_dialog()
         content = self._get_close_dialog_content()
@@ -109,6 +117,7 @@ class BrowserCloseWarning(FeltTests):
         )
 
     def _accept_close_dialog(self):
+        """Wait for the in-window close dialog and click its accept button."""
         self._logger.info("Waiting for the custom signout dialog to open")
         self._wait_for_close_dialog()
 
@@ -148,11 +157,24 @@ class BrowserCloseWarning(FeltTests):
                 "return !!document.getElementById('enterpriseCloseDialog')?.getButton('accept');"
             )
         )
+        self._manually_closed_child = True
         self._logger.info("Clicking accept on standalone enterprise close dialog")
         self._child_driver.execute_script(
             "document.getElementById('enterpriseCloseDialog').getButton('accept').click();"
         )
-        self._manually_closed_child = True
+
+    def _wait_for_child_browser_closed(self):
+        """Poll until the child browser has fully closed."""
+        self._logger.info("Waiting for child browser to close.")
+
+        def is_closed(_):
+            try:
+                super(BrowserCloseWarning, self).assert_child_browser_closed()
+                return True
+            except AssertionError:
+                return False
+
+        self._child_wait.until(is_closed)
 
     def test_browser_window_close_signout_warning_only(self):
         """Sign-out warn on, tabs warn off, single tab - enterprise signout dialog shows."""
@@ -171,6 +193,7 @@ class BrowserCloseWarning(FeltTests):
         )
         self._accept_close_dialog()
 
+        self._wait_for_child_browser_closed()
         self.assert_child_browser_closed()
 
     def test_browser_window_close_with_both_warnings(self):
@@ -191,6 +214,7 @@ class BrowserCloseWarning(FeltTests):
         )
         self._accept_close_dialog()
 
+        self._wait_for_child_browser_closed()
         self.assert_child_browser_closed()
 
     def test_browser_window_close_tabs_warning_only(self):
@@ -210,6 +234,7 @@ class BrowserCloseWarning(FeltTests):
         )
         self._accept_close_dialog()
 
+        self._wait_for_child_browser_closed()
         self.assert_child_browser_closed()
 
     def test_browser_window_close_no_warnings(self):
@@ -223,6 +248,7 @@ class BrowserCloseWarning(FeltTests):
 
         self._trigger_browser_closure()
 
+        self._wait_for_child_browser_closed()
         self.assert_child_browser_closed()
 
     def test_browser_window_close_no_warnings_multiple_tabs(self):
@@ -237,6 +263,7 @@ class BrowserCloseWarning(FeltTests):
 
         self._trigger_browser_closure()
 
+        self._wait_for_child_browser_closed()
         self.assert_child_browser_closed()
 
     def test_browser_close_no_windows_shows_standalone_dialog(self):
@@ -252,4 +279,5 @@ class BrowserCloseWarning(FeltTests):
         initial_handles = set(self._child_driver.chrome_window_handles)
         self._trigger_browser_closure(close_all_windows=True)
         self._accept_standalone_close_dialog(initial_handles)
+        self._wait_for_child_browser_closed()
         self.assert_child_browser_closed()

--- a/testing/enterprise/test_felt_browser_close_warning.py
+++ b/testing/enterprise/test_felt_browser_close_warning.py
@@ -158,7 +158,7 @@ class BrowserCloseWarning(FeltTests):
         self._close_browser()
         self._assert_close_dialog_content(
             expected_title="Close 2 tabs?",
-            expected_message="Closing Firefox will also sign you out.",
+            expected_message="Closing Firefox Enterprise will also sign you out.",
         )
         self._accept_close_dialog()
 
@@ -171,6 +171,19 @@ class BrowserCloseWarning(FeltTests):
         self.assert_user_signed_in(env=Environment.FIREFOX)
 
         self._set_child_bool_pref(PREF_PROMPT_ON_SIGNOUT, False)
+
+        self._close_browser()
+
+        self.assert_child_browser_closed()
+
+    def test_browser_window_close_no_warnings_multiple_tabs(self):
+        """Sign-out warn off, tabs warn off (default), multiple tabs - no dialog, quit proceeds."""
+        super().run_felt_base()
+        self.connect_child_browser()
+        self.assert_user_signed_in(env=Environment.FIREFOX)
+
+        self._set_child_bool_pref(PREF_PROMPT_ON_SIGNOUT, False)
+        self.open_tab_child("about:blank")
 
         self._close_browser()
 

--- a/testing/enterprise/test_felt_browser_close_warning.py
+++ b/testing/enterprise/test_felt_browser_close_warning.py
@@ -40,8 +40,10 @@ class BrowserCloseWarning(FeltTests):
         )
         self._manually_closed_child = True
 
-    def _assert_close_dialog_content(self, expected_title, expected_message):
-        self._logger.info("Waiting for the custom signout dialog to assert its content")
+    def _wait_for_close_dialog(self):
+        """Wait for the enterprise close dialog to be ready and store a
+        reference to it on the chrome window for follow-up scripts.
+        """
         self._child_wait.until(
             lambda _: self._child_driver.execute_script(
                 """
@@ -57,7 +59,9 @@ class BrowserCloseWarning(FeltTests):
                 """
             )
         )
-        content = self._child_driver.execute_script(
+
+    def _get_close_dialog_content(self):
+        return self._child_driver.execute_script(
             """
             const doc = document.getElementById('window-modal-dialog')
                 .querySelector('.dialogFrame').contentDocument;
@@ -67,6 +71,11 @@ class BrowserCloseWarning(FeltTests):
             };
             """
         )
+
+    def _assert_close_dialog_content(self, expected_title, expected_message):
+        self._logger.info("Waiting for the custom signout dialog to assert its content")
+        self._wait_for_close_dialog()
+        content = self._get_close_dialog_content()
         assert content["title"] == expected_title, (
             f"Unexpected dialog title: {content['title']!r}"
         )
@@ -76,21 +85,7 @@ class BrowserCloseWarning(FeltTests):
 
     def _accept_close_dialog(self):
         self._logger.info("Waiting for the custom signout dialog to open")
-        self._child_wait.until(
-            lambda _: self._child_driver.execute_script(
-                """
-                try {
-                    const dialog = document.getElementById('window-modal-dialog');
-                    return !!(dialog?.open && dialog.querySelector(".dialogFrame")
-                        ?.contentDocument
-                        ?.getElementById("enterpriseCloseDialog")
-                        ?.getButton('accept'));
-                } catch (e) {
-                    return false;
-                }
-                """
-            )
-        )
+        self._wait_for_close_dialog()
 
         self._logger.info(
             "Signing out the user by clicking the Signout button in the custom signout dialog"
@@ -138,11 +133,14 @@ class BrowserCloseWarning(FeltTests):
         )
         self._child_driver.switch_to_window(list(initial_handles)[0])
 
-    def test_browser_window_close_default_config(self):
-        """Default config: sign-out warn on, single tab - enterprise dialog shows."""
+    def test_browser_window_close_signout_warning_only(self):
+        """Sign-out warn on, tabs warn off, single tab - enterprise signout dialog shows."""
         super().run_felt_base()
         self.connect_child_browser()
         self.assert_user_signed_in(env=Environment.FIREFOX)
+
+        self._set_child_bool_pref(PREF_PROMPT_ON_SIGNOUT, True)
+        self._set_child_bool_pref(PREF_WARN_ON_CLOSE, False)
 
         self._close_browser()
         self._assert_close_dialog_content(
@@ -157,11 +155,12 @@ class BrowserCloseWarning(FeltTests):
         self.assert_child_browser_closed()
 
     def test_browser_window_close_with_both_warnings(self):
-        """Sign-out warn on, tabs warn on, multiple tabs open - enterprise dialog with tabs checkbox shown."""
+        """Sign-out warn on, tabs warn on, multiple tabs open - enterprise dialog with tabs count shown."""
         super().run_felt_base()
         self.connect_child_browser()
         self.assert_user_signed_in(env=Environment.FIREFOX)
 
+        self._set_child_bool_pref(PREF_PROMPT_ON_SIGNOUT, True)
         self._set_child_bool_pref(PREF_WARN_ON_CLOSE, True)
         self.open_tab_child("about:blank")
 
@@ -197,24 +196,26 @@ class BrowserCloseWarning(FeltTests):
         self.assert_child_browser_closed()
 
     def test_browser_window_close_no_warnings(self):
-        """Sign-out warn off - no dialog, quit proceeds directly."""
+        """Sign-out warn off, tabs warn off - no dialog, quit proceeds directly."""
         super().run_felt_base()
         self.connect_child_browser()
         self.assert_user_signed_in(env=Environment.FIREFOX)
 
         self._set_child_bool_pref(PREF_PROMPT_ON_SIGNOUT, False)
+        self._set_child_bool_pref(PREF_WARN_ON_CLOSE, False)
 
         self._close_browser()
 
         self.assert_child_browser_closed()
 
     def test_browser_window_close_no_warnings_multiple_tabs(self):
-        """Sign-out warn off, tabs warn off (default), multiple tabs - no dialog, quit proceeds."""
+        """Sign-out warn off, tabs warn off, multiple tabs - no dialog, quit proceeds."""
         super().run_felt_base()
         self.connect_child_browser()
         self.assert_user_signed_in(env=Environment.FIREFOX)
 
         self._set_child_bool_pref(PREF_PROMPT_ON_SIGNOUT, False)
+        self._set_child_bool_pref(PREF_WARN_ON_CLOSE, False)
         self.open_tab_child("about:blank")
 
         self._close_browser()
@@ -227,6 +228,8 @@ class BrowserCloseWarning(FeltTests):
         super().run_felt_base()
         self.connect_child_browser()
         self.assert_user_signed_in(env=Environment.FIREFOX)
+
+        self._set_child_bool_pref(PREF_PROMPT_ON_SIGNOUT, True)
 
         self._child_driver.set_context("chrome")
         initial_handles = set(self._child_driver.chrome_window_handles)

--- a/testing/enterprise/test_felt_browser_close_warning.py
+++ b/testing/enterprise/test_felt_browser_close_warning.py
@@ -233,12 +233,14 @@ class BrowserCloseWarning(FeltTests):
 
         # showSignoutPrompt(null) is the code path hit on macOS when the user
         # quits with no browser windows open. Verify it opens a standalone dialog.
+        # Use setTimeout to defer the call so execute_script returns before the
+        # modal dialog blocks the event loop.
         self._child_driver.execute_script(
             """
             const { EnterpriseHandler } = ChromeUtils.importESModule(
                 "resource:///modules/enterprise/EnterpriseHandler.sys.mjs"
             );
-            EnterpriseHandler.showSignoutPrompt(null);
+            setTimeout(() => EnterpriseHandler.showSignoutPrompt(null), 0);
             """
         )
 

--- a/testing/enterprise/test_felt_browser_close_warning.py
+++ b/testing/enterprise/test_felt_browser_close_warning.py
@@ -23,7 +23,7 @@ class BrowserCloseWarning(FeltTests):
         )
         self._child_driver.set_context("content")
 
-    def _close_browser(self):
+    def _trigger_browser_closure(self):
         """Simulate a natural browser close by firing quit-application-requested,
         which BrowserGlue intercepts to show the Enterprise signout dialog.
         If the quit is not cancelled, force-quit to mirror native OS behavior."""
@@ -68,11 +68,14 @@ class BrowserCloseWarning(FeltTests):
             return {
                 title: doc.getElementById('infoTitle').textContent,
                 message: doc.getElementById('infoBody').textContent,
+                reauth: doc.getElementById('infoReauth').textContent,
             };
             """
         )
 
-    def _assert_close_dialog_content(self, expected_title, expected_message):
+    def _assert_close_dialog_content(
+        self, expected_title, expected_message, expected_reauth=None
+    ):
         self._logger.info("Waiting for the custom signout dialog to assert its content")
         self._wait_for_close_dialog()
         content = self._get_close_dialog_content()
@@ -81,6 +84,9 @@ class BrowserCloseWarning(FeltTests):
         )
         assert content["message"] == expected_message, (
             f"Unexpected dialog message: {content['message']!r}"
+        )
+        assert content["reauth"] == (expected_reauth or ""), (
+            f"Unexpected dialog reauth: {content['reauth']!r}"
         )
 
     def _accept_close_dialog(self):
@@ -127,11 +133,7 @@ class BrowserCloseWarning(FeltTests):
         self._child_driver.execute_script(
             "document.getElementById('enterpriseCloseDialog').getButton('accept').click();"
         )
-
-        self._child_wait.until(
-            lambda _: set(self._child_driver.chrome_window_handles) == initial_handles
-        )
-        self._child_driver.switch_to_window(list(initial_handles)[0])
+        self._manually_closed_child = True
 
     def test_browser_window_close_signout_warning_only(self):
         """Sign-out warn on, tabs warn off, single tab - enterprise signout dialog shows."""
@@ -142,13 +144,11 @@ class BrowserCloseWarning(FeltTests):
         self._set_child_bool_pref(PREF_PROMPT_ON_SIGNOUT, True)
         self._set_child_bool_pref(PREF_WARN_ON_CLOSE, False)
 
-        self._close_browser()
+        self._trigger_browser_closure()
         self._assert_close_dialog_content(
             expected_title="Close Firefox Enterprise?",
-            expected_message=(
-                "You’re about to sign out of Firefox Enterprise and end your session.\n\n"
-                "To use Firefox Enterprise again, you’ll need to reauthenticate through your organization’s SSO provider."
-            ),
+            expected_message="You’re about to sign out of Firefox Enterprise and end your session.",
+            expected_reauth="To use Firefox Enterprise again, you’ll need to reauthenticate through your organization’s SSO provider.",
         )
         self._accept_close_dialog()
 
@@ -164,13 +164,11 @@ class BrowserCloseWarning(FeltTests):
         self._set_child_bool_pref(PREF_WARN_ON_CLOSE, True)
         self.open_tab_child("about:blank")
 
-        self._close_browser()
+        self._trigger_browser_closure()
         self._assert_close_dialog_content(
             expected_title="Close Firefox Enterprise and 2 tabs?",
-            expected_message=(
-                "You’re about to sign out of Firefox Enterprise and close 2 tabs.\n\n"
-                "To use Firefox Enterprise again, you’ll need to reauthenticate through your organization’s SSO provider."
-            ),
+            expected_message="You’re about to sign out of Firefox Enterprise and close 2 tabs.",
+            expected_reauth="To use Firefox Enterprise again, you’ll need to reauthenticate through your organization’s SSO provider.",
         )
         self._accept_close_dialog()
 
@@ -186,7 +184,7 @@ class BrowserCloseWarning(FeltTests):
         self._set_child_bool_pref(PREF_WARN_ON_CLOSE, True)
         self.open_tab_child("about:blank")
 
-        self._close_browser()
+        self._trigger_browser_closure()
         self._assert_close_dialog_content(
             expected_title="Close 2 tabs?",
             expected_message="Closing Firefox Enterprise will also sign you out.",
@@ -204,7 +202,7 @@ class BrowserCloseWarning(FeltTests):
         self._set_child_bool_pref(PREF_PROMPT_ON_SIGNOUT, False)
         self._set_child_bool_pref(PREF_WARN_ON_CLOSE, False)
 
-        self._close_browser()
+        self._trigger_browser_closure()
 
         self.assert_child_browser_closed()
 
@@ -218,7 +216,7 @@ class BrowserCloseWarning(FeltTests):
         self._set_child_bool_pref(PREF_WARN_ON_CLOSE, False)
         self.open_tab_child("about:blank")
 
-        self._close_browser()
+        self._trigger_browser_closure()
 
         self.assert_child_browser_closed()
 
@@ -248,3 +246,5 @@ class BrowserCloseWarning(FeltTests):
         )
 
         self._accept_standalone_close_dialog(initial_handles)
+
+        self.assert_child_browser_closed()

--- a/testing/enterprise/test_felt_browser_signout.py
+++ b/testing/enterprise/test_felt_browser_signout.py
@@ -11,10 +11,6 @@ sys.path.append(os.path.dirname(__file__))
 
 from base_test import Environment
 from felt_tests import FeltTests
-from marionette_driver.errors import (
-    NoAlertPresentException,
-    UnexpectedAlertOpen,
-)
 
 
 class BaseBrowserSignout(FeltTests):
@@ -51,27 +47,39 @@ class BaseBrowserSignout(FeltTests):
             == "ignore"
         ), "Driver should not auto-handle prompt"
 
-        try:
-            # This will cause an UnexpectedAlertPresentException, which is our expected signout dialog
-            self._logger.info("Clicking signout button in enterprise panel")
-            self.get_elem_child(".panelUI-enterprise__sign-out-btn").click()
-        except UnexpectedAlertOpen:
-            # Do nothing, signout dialog ("alert") is expected
-            pass
+        self._logger.info("Clicking signout button in enterprise panel")
+        self.get_elem_child(".panelUI-enterprise__sign-out-btn").click()
 
-        self._logger.info("Waiting for the signout dialog to open")
+        self._logger.info("Waiting for the custom signout dialog to open")
+        self._child_wait.until(
+            lambda _: self._child_driver.execute_script(
+                """
+                try {
+                    const dialog = document.getElementById('window-modal-dialog');
+                    return (dialog?.open && dialog.querySelector(".dialogFrame")
+                        ?.contentDocument
+                        ?.getElementById("enterpriseCloseDialog")
+                        ?.getButton('accept') !== null);
+                } catch (e) {
+                    return false;
+                }
+                """
+            )
+        )
 
-        def wait_for_and_accept_alert(driver):
-            try:
-                driver.switch_to_alert().accept()
-                self._logger.info(
-                    "Signing out the user by clicking the Signout button in the dialog"
-                )
-                return True
-            except NoAlertPresentException:
-                return False
-
-        self._waiter(self._child_driver).until(wait_for_and_accept_alert)
+        self._logger.info(
+            "Signing out the user by clicking the Signout button in the custom signout dialog"
+        )
+        self._child_driver.execute_script(
+            """
+            document.getElementById("window-modal-dialog")
+                .querySelector(".dialogFrame")
+                .contentDocument
+                .getElementById("enterpriseCloseDialog")
+                .getButton("accept")
+                .click();
+            """
+        )
 
         self._child_driver.set_context("content")
 


### PR DESCRIPTION
## Summary

Builds upon #673 by replacing the simple single-checkbox prompt with a custom multi-checkbox prompt base on tab and pref logic.

- Adds `enterprise-close-dialog.xhtml` as custom prompt with multiple checkbox support. Modeled after `commonDialog`
- Adds custom localized signout text to the default prompt when quitting using shortcut (default true on MacOS)

## Links

- [Figma](https://www.figma.com/design/xYH6L8QrDz0Q16XFvdo7We/%F0%9F%A6%8A-Client-Design?node-id=1614-2058&p=f&m=dev)
- [Bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=2024613)

## Related Issues and Pull Requests

- #674 
- #673 

## Screenshots

<img width="1004" height="560" alt="close-single-tab-both-checked" src="https://github.com/user-attachments/assets/55394a5a-d665-421c-a20e-ba86b90fb327" />

_Warn me about **both** - single tab_

<img width="1004" height="560" alt="close-multi-tab-both-checked" src="https://github.com/user-attachments/assets/23989828-e23b-4013-8353-25bd58ebf1d0" />

_Warn me about **both** - multiple tabs_

<img width="1004" height="560" alt="close-multi-tab-signOut-unchecked" src="https://github.com/user-attachments/assets/092262f5-4be7-45bc-9f3d-97d2cc558c3f" />

_Warn me when **closing multiple tabs ONLY**_

<img width="1004" height="560" alt="close-multi-tab-tabs-unchecked" src="https://github.com/user-attachments/assets/95057aa2-90a0-4552-8a43-ae7f9051421e" />

_Warn me about **signing out ONLY**_

<img width="1279" height="900" alt="ask-before-quitting" src="https://github.com/user-attachments/assets/1aac0f9e-9114-4fcb-88ba-d746e34e192e" />

_Ask before quitting with shortcut (Cmd+Q)_

<img width="1279" height="900" alt="ask-before-quitting-multi-tab" src="https://github.com/user-attachments/assets/11b5e0da-a809-45ca-aa86-a32d143596ad" />

_Ask before quitting with shortcut (Cmd+Q) with multiple tabs_

## Testing

Prefs that are toggled: 

- Signout warning: `enterprise.promptOnSignout`
- Multi tab warning: `browser.tabs.warnOnClose`
- Ask before quitting with shortcut: `browser.warnOnQuitShortcut`

1. `mach build`
2. `mach run`
3. Login with FELT
4. Verify all window close, signout paths, and pref combos display proper message and sign user out when closing
  - [ ] Close window with single tab open (both prefs checked)
  - [ ] Close window with single tab open (signout pref unchecked)
  - [ ] Close window with multiple tabs open (both prefs checked)
  - [ ] Close window with multiple tabs open (signout pref unchecked)
  - [ ] Close window with multiple tabs open (tab pref unchecked)
  - [ ] Close window with multiple tabs open (no prefs checked)
  - [ ] Signout using Enterprise Badge