### PR TITLE
Set and lock fxa endpoints in EnterpriseEndpoints.sys.mjs

### DIFF
--- a/browser/components/enterprise/EnterpriseEndpoints.sys.mjs
+++ b/browser/components/enterprise/EnterpriseEndpoints.sys.mjs
@@ -22,6 +22,15 @@ ChromeUtils.defineLazyGetter(lazy, "log", () => {
 // We are replacing some here. But we need to take a look at the missing ones to avoid breakage.
 
 export const RELATIVE_CONSOLE_ENDPOINT_PREFS = [
+  { pref: "identity.fxaccounts.remote.oauth.uri", path: "api/fxa/oauth/v1" },
+  {
+    pref: "identity.fxaccounts.remote.profile.uri",
+    path: "api/fxa/profile/v1",
+  },
+  {
+    pref: "identity.fxaccounts.auth.uri",
+    path: "api/fxa/api/v1",
+  },
   {
     pref: "security.certerrors.mitm.priming.endpoint",
     path: "api/misc/mitm/",

--- a/browser/components/enterprise/modules/ConsoleClient.sys.mjs
+++ b/browser/components/enterprise/modules/ConsoleClient.sys.mjs
@@ -176,33 +176,6 @@ export const ConsoleClient = {
   },
 
   /**
-   * Get the FxAccounts OAuth endpoint of the console
-   *
-   * returns {string} URI of the endpoint
-   */
-  get fxAccountsOAuth() {
-    return this.constructURI(this._paths.FXACCOUNTS_OAUTH);
-  },
-
-  /**
-   * Get the FxAccounts Profile endpoint of the console
-   *
-   * returns {string} URI of the endpoint
-   */
-  get fxAccountsProfile() {
-    return this.constructURI(this._paths.FXACCOUNTS_PROFILE);
-  },
-
-  /**
-   * Get the FxAccounts Auth endpoint of the console
-   *
-   * returns {string} URI of the endpoint
-   */
-  get fxAccountsAuth() {
-    return this.constructURI(this._paths.FXACCOUNTS_AUTH);
-  },
-
-  /**
    * SSO callback uri that we match to create Felt actors on
    *
    * @returns {string}

--- a/browser/extensions/felt/content/FeltProcessParent.sys.mjs
+++ b/browser/extensions/felt/content/FeltProcessParent.sys.mjs
@@ -266,20 +266,6 @@ export class FeltProcessParent extends JSProcessActorParent {
       lazy.ConsoleClient.consoleBaseURI
     );
 
-    // Sets fxa endpoints in Firefox
-    Services.felt.sendStringPreference(
-      "identity.fxaccounts.remote.oauth.uri",
-      lazy.ConsoleClient.fxAccountsOAuth
-    );
-    Services.felt.sendStringPreference(
-      "identity.fxaccounts.remote.profile.uri",
-      lazy.ConsoleClient.fxAccountsProfile
-    );
-    Services.felt.sendStringPreference(
-      "identity.fxaccounts.auth.uri",
-      lazy.ConsoleClient.fxAccountsAuth
-    );
-
     // Enables remote policy polling
     Services.felt.sendBoolPreference(
       "browser.policies.live_polling.enabled",

--- a/testing/enterprise/test_felt_browser_fxa.py
+++ b/testing/enterprise/test_felt_browser_fxa.py
@@ -20,7 +20,6 @@ class BrowserFxAccount(FeltTests):
         super().run_felt_base()
         self.run_felt_no_fxa_toolbar_button()
         self.run_felt_no_fxa_item_in_toolbar_menu()
-        self.run_felt_fxa_endpoints_set()
 
     def run_felt_no_fxa_toolbar_button(self):
         self.connect_child_browser()
@@ -56,39 +55,5 @@ class BrowserFxAccount(FeltTests):
         assert is_restricted_for_enterprise, (
             "App menu main view should have the attribute restricted-enterprise-view to hide fxa status and separator"
         )
-
-    def run_felt_fxa_endpoints_set(self):
-        self._child_driver.set_context("chrome")
-        [
-            fxaccounts_remote_oauth,
-            fxaccounts_remote_profile,
-            fxaccounts_auth,
-            sync_token_server,
-        ] = self._child_driver.execute_script(
-            """
-            return [
-                Services.prefs.getStringPref("identity.fxaccounts.remote.oauth.uri"),
-                Services.prefs.getStringPref("identity.fxaccounts.remote.profile.uri"),
-                Services.prefs.getStringPref("identity.fxaccounts.auth.uri"),
-                Services.prefs.getStringPref("identity.sync.tokenserver.uri"),
-            ];
-            """,
-        )
-        self._child_driver.set_context("content")
-
-        console_addr = f"http://localhost:{self.console_port}"
-        assert fxaccounts_remote_oauth == f"{console_addr}/api/fxa/oauth/v1", (
-            f"FxAccount remote auth URI correct: {fxaccounts_remote_oauth}"
-        )
-        assert fxaccounts_remote_profile == f"{console_addr}/api/fxa/profile/v1", (
-            f"FxAccount remote profile URI correct: {fxaccounts_remote_profile}"
-        )
-        assert fxaccounts_auth == f"{console_addr}/api/fxa/api/v1", (
-            f"FxAccount auth URI correct: {fxaccounts_auth}"
-        )
-        assert (
-            sync_token_server
-            == "https://ent-dev-tokenserver.sync.nonprod.webservices.mozgcp.net/1.0/sync/1.5"
-        ), f"Sync TokenServer URI correct: {sync_token_server}"
 
     # More tests to follow once fxa and sync test endpoints are setup


### PR DESCRIPTION
- Sets and locks fxa endpoints derived from the console address in `EnterpriseEndpoints.sys.mjs`. 
- Test coverage in `browser/components/enterprise/EnterpriseEndpoints.sys.mjs`