### PR TITLE
Bug 2012082 - Enterprise: Add custom enterprise logo on toolbar

### DIFF
--- a/browser/components/enterprise/EnterpriseHandler.sys.mjs
+++ b/browser/components/enterprise/EnterpriseHandler.sys.mjs
@@ -245,28 +245,33 @@ export const EnterpriseHandler = {
     const logoUrl = Services.prefs.getStringPref(LOGO_URL, "");
 
     if (!logoUrl) {
-      console.error(`Skipping logo update, ${LOGO_URL} pref is not set.`);
+      console.warn(`${LOGO_URL} pref is not set, skipping logo update`);
       return;
     }
 
-    // allow https: URLs and data: URIs for common image formats with base64 encoding only.
-    const logoUrlPattern =
-      /^(https:\/\/|data:image\/(?:png|jpeg|gif|webp|svg\+xml);base64,)/;
-    if (!logoUrlPattern.test(logoUrl)) {
-      console.error(`Invalid logo URL in pref: ${logoUrl}`);
-      return;
-    }
-
+    let validLogoUrl;
     try {
-      const validLogoUrl = new URL(logoUrl).href;
+      validLogoUrl = new URL(logoUrl);
+    } catch {
+      throw new Error(`Invalid logo URL in pref: ${logoUrl}`);
+    }
 
-      const toolbarLogo = window.document.querySelector(
-        "#enterprise-company-logo__wrapper > image"
-      );
-      toolbarLogo.style.setProperty(
-        "list-style-image",
-        `url("${validLogoUrl}")`
-      );
-    } catch {}
+    if (validLogoUrl.protocol === "https:") {
+      if (validLogoUrl.origin !== lazy.ConsoleClient.consoleBaseURI.origin) {
+        throw new Error(`Logo URL must be hosted from the console: ${logoUrl}`);
+      }
+    } else if (
+      !/^data:image\/(?:png|jpeg|gif|webp|svg\+xml);base64,/.test(logoUrl)
+    ) {
+      throw new Error(`Invalid logo URL in pref: ${logoUrl}`);
+    }
+
+    const toolbarLogo = window.document.querySelector(
+      "#enterprise-company-logo__wrapper > image"
+    );
+    toolbarLogo.style.setProperty(
+      "list-style-image",
+      `url("${validLogoUrl.href}")`
+    );
   },
 };

--- a/browser/components/enterprise/EnterpriseHandler.sys.mjs
+++ b/browser/components/enterprise/EnterpriseHandler.sys.mjs
@@ -27,26 +27,6 @@ ChromeUtils.defineLazyGetter(lazy, "log", () => {
 const PROMPT_ON_SIGNOUT_PREF = "enterprise.promptOnSignout";
 const ENTERPRISE_TOOLBAR_LOGO_URL_PREF = "enterprise.toolbar.logoUrl";
 
-/**
- * Validate and normalize logo URL
- *
- * @param {*} logoUrl
- */
-function _resolveLogoUrl(logoUrl) {
-  // allow https: URLs and data: URIs for common image formats with base64 encoding only.
-  const logoUrlPattern =
-    /^(https:\/\/|data:image\/(?:png|jpeg|gif|webp|svg\+xml);base64,)/;
-  if (!logoUrlPattern.test(logoUrl)) {
-    return null;
-  }
-
-  try {
-    return new URL(logoUrl).href;
-  } catch {
-    return null;
-  }
-}
-
 export const EnterpriseHandler = {
   /**
    * @type {{name:string, email:string, pictureUrl:string} | null}
@@ -126,17 +106,10 @@ export const EnterpriseHandler = {
     const toolbarLogo = window.document.querySelector(
       "#enterprise-company-logo__wrapper > image"
     );
-    const logoUrl = Services.prefs.getStringPref(
-      ENTERPRISE_TOOLBAR_LOGO_URL_PREF,
-      ""
-    );
-    const validLogoUrl = logoUrl && _resolveLogoUrl(logoUrl);
+    const logoUrl = this._getLogoUrl();
 
-    if (validLogoUrl) {
-      toolbarLogo.style.setProperty(
-        "list-style-image",
-        `url("${validLogoUrl}")`
-      );
+    if (logoUrl) {
+      toolbarLogo.style.setProperty("list-style-image", `url("${logoUrl}")`);
     }
 
     if (!this._signedInUser) {
@@ -272,5 +245,53 @@ export const EnterpriseHandler = {
   uninit() {
     this._signedInUser = {};
     this._isInitialized = false;
+  },
+
+  _getLogoUrl() {
+    const logoUrl = Services.prefs.getStringPref(
+      ENTERPRISE_TOOLBAR_LOGO_URL_PREF,
+      ""
+    );
+
+    // if pref is not set, try loading from repack
+    if (!logoUrl) {
+      return this._getDistributionLogoUrl();
+    }
+
+    // allow https: URLs and data: URIs for common image formats with base64 encoding only.
+    const logoUrlPattern =
+      /^(https:\/\/|data:image\/(?:png|jpeg|gif|webp|svg\+xml);base64,)/;
+    if (!logoUrlPattern.test(logoUrl)) {
+      return null;
+    }
+
+    try {
+      return new URL(logoUrl).href;
+    } catch {
+      return null;
+    }
+  },
+
+  _getDistributionLogoUrl() {
+    const SUPPORTED_EXTENSIONS = [
+      ".svg",
+      ".png",
+      ".jpeg",
+      ".jpg",
+      ".gif",
+      ".webp",
+    ];
+    const BADGE_LOGO_NAME = "badge-logo";
+    try {
+      let distDir = Services.dirsvc.get("XREAppDist", Ci.nsIFile);
+      for (let ext of SUPPORTED_EXTENSIONS) {
+        let logoFile = distDir.clone();
+        logoFile.append(`${BADGE_LOGO_NAME}${ext}`);
+        if (logoFile.exists()) {
+          return Services.io.newFileURI(logoFile).spec;
+        }
+      }
+    } catch {}
+    return null;
   },
 };

--- a/browser/components/enterprise/EnterpriseHandler.sys.mjs
+++ b/browser/components/enterprise/EnterpriseHandler.sys.mjs
@@ -25,6 +25,27 @@ ChromeUtils.defineLazyGetter(lazy, "log", () => {
 });
 
 const PROMPT_ON_SIGNOUT_PREF = "enterprise.promptOnSignout";
+const ENTERPRISE_TOOLBAR_LOGO_URL_PREF = "enterprise.toolbar.logoUrl";
+
+/**
+ * Validate and normalize logo URL
+ *
+ * @param {*} logoUrl
+ */
+function _resolveLogoUrl(logoUrl) {
+  // allow https: URLs and data: URIs for common image formats with base64 encoding only.
+  const logoUrlPattern =
+    /^(https:\/\/|data:image\/(?:png|jpeg|gif|webp|svg\+xml);base64,)/;
+  if (!logoUrlPattern.test(logoUrl)) {
+    return null;
+  }
+
+  try {
+    return new URL(logoUrl).href;
+  } catch {
+    return null;
+  }
+}
 
 export const EnterpriseHandler = {
   /**
@@ -102,6 +123,21 @@ export const EnterpriseHandler = {
    */
   updateBadge(window) {
     const userIcon = window.document.querySelector("#enterprise-user-icon");
+    const toolbarLogo = window.document.querySelector(
+      "#enterprise-company-logo__wrapper > image"
+    );
+    const logoUrl = Services.prefs.getStringPref(
+      ENTERPRISE_TOOLBAR_LOGO_URL_PREF,
+      ""
+    );
+    const validLogoUrl = logoUrl && _resolveLogoUrl(logoUrl);
+
+    if (validLogoUrl) {
+      toolbarLogo.style.setProperty(
+        "list-style-image",
+        `url("${validLogoUrl}")`
+      );
+    }
 
     if (!this._signedInUser) {
       // Hide user icon from enterprise badge until we have user information

--- a/browser/components/enterprise/EnterpriseHandler.sys.mjs
+++ b/browser/components/enterprise/EnterpriseHandler.sys.mjs
@@ -15,6 +15,7 @@ ChromeUtils.defineESModuleGetters(lazy, {
   BrowserUtils: "resource://gre/modules/BrowserUtils.sys.mjs",
   ConsoleClient: "resource:///modules/enterprise/ConsoleClient.sys.mjs",
   EnterpriseCommon: "resource:///modules/enterprise/EnterpriseCommon.sys.mjs",
+  PREFS: "resource:///modules/enterprise/ConsoleClient.sys.mjs",
 });
 
 ChromeUtils.defineLazyGetter(lazy, "log", () => {
@@ -25,14 +26,12 @@ ChromeUtils.defineLazyGetter(lazy, "log", () => {
 });
 
 const PROMPT_ON_SIGNOUT_PREF = "enterprise.promptOnSignout";
-const ENTERPRISE_TOOLBAR_LOGO_URL_PREF = "enterprise.toolbar.logoUrl";
 
 export const EnterpriseHandler = {
   /**
    * @type {{name:string, email:string, pictureUrl:string} | null}
    */
   _signedInUser: null,
-  _logoUrl: null,
 
   /**
    * Whether the handler is initialized, meaning the user information
@@ -52,11 +51,6 @@ export const EnterpriseHandler = {
   async init(window) {
     if (!this._isInitialized) {
       lazy.log.debug("Initializing...");
-
-      if (!this._setLogoUrlFromPref() && !this._setLogoFromDistribution()) {
-        lazy.log.debug("No custom enterprise logo configured.");
-      }
-
       await this.initUser();
       this._isInitialized = true;
     }
@@ -108,16 +102,9 @@ export const EnterpriseHandler = {
    * @param {Window} window chrome window
    */
   updateBadge(window) {
+    this._setLogoUrlFromPref(window);
+
     const userIcon = window.document.querySelector("#enterprise-user-icon");
-    const toolbarLogo = window.document.querySelector(
-      "#enterprise-company-logo__wrapper > image"
-    );
-    if (this._logoUrl) {
-      toolbarLogo.style.setProperty(
-        "list-style-image",
-        `url("${this._logoUrl}")`
-      );
-    }
 
     if (!this._signedInUser) {
       // Hide user icon from enterprise badge until we have user information
@@ -251,19 +238,14 @@ export const EnterpriseHandler = {
 
   uninit() {
     this._signedInUser = {};
-    this._logoUrl = null;
     this._isInitialized = false;
   },
 
-  _setLogoUrlFromPref() {
-    const prefLogoUrl = Services.prefs.getStringPref(
-      ENTERPRISE_TOOLBAR_LOGO_URL_PREF,
-      ""
-    );
+  _setLogoUrlFromPref(window) {
+    const prefLogoUrl = Services.prefs.getStringPref(lazy.PREFS.LOGO_URL, "");
 
-    // skip if pref is not set
     if (!prefLogoUrl) {
-      return false;
+      return;
     }
 
     // allow https: URLs and data: URIs for common image formats with base64 encoding only.
@@ -271,44 +253,16 @@ export const EnterpriseHandler = {
       /^(https:\/\/|data:image\/(?:png|jpeg|gif|webp|svg\+xml);base64,)/;
     if (!logoUrlPattern.test(prefLogoUrl)) {
       console.warn(`Invalid logo URL in pref: ${prefLogoUrl}`);
-      return false;
+      return;
     }
 
     try {
-      this._logoUrl = new URL(prefLogoUrl).href;
-      return true;
-    } catch {}
-    return false;
-  },
+      const logoUrl = new URL(prefLogoUrl).href;
 
-  _setLogoFromDistribution() {
-    const SUPPORTED_EXTENSIONS = [
-      ".svg",
-      ".png",
-      ".jpeg",
-      ".jpg",
-      ".gif",
-      ".webp",
-    ];
-    const BADGE_LOGO_NAME = "badge-logo";
-    try {
-      const distDir = Services.dirsvc.get("XREAppDist", Ci.nsIFile);
-      for (const ext of SUPPORTED_EXTENSIONS) {
-        const logoFile = distDir.clone();
-        logoFile.append(`${BADGE_LOGO_NAME}${ext}`);
-        if (logoFile.exists()) {
-          const protocolHandler = Services.io
-            .getProtocolHandler("resource")
-            .QueryInterface(Ci.nsIResProtocolHandler);
-          protocolHandler.setSubstitution(
-            "enterprise-distribution",
-            Services.io.newFileURI(distDir)
-          );
-          this._logoUrl = `resource://enterprise-distribution/${BADGE_LOGO_NAME}${ext}`;
-          return true;
-        }
-      }
+      const toolbarLogo = window.document.querySelector(
+        "#enterprise-company-logo__wrapper > image"
+      );
+      toolbarLogo.style.setProperty("list-style-image", `url("${logoUrl}")`);
     } catch {}
-    return false;
   },
 };

--- a/browser/components/enterprise/EnterpriseHandler.sys.mjs
+++ b/browser/components/enterprise/EnterpriseHandler.sys.mjs
@@ -32,6 +32,7 @@ export const EnterpriseHandler = {
    * @type {{name:string, email:string, pictureUrl:string} | null}
    */
   _signedInUser: null,
+  _logoUrl: null,
 
   /**
    * Whether the handler is initialized, meaning the user information
@@ -51,6 +52,11 @@ export const EnterpriseHandler = {
   async init(window) {
     if (!this._isInitialized) {
       lazy.log.debug("Initializing...");
+
+      if (!this._setLogoUrlFromPref() && !this._setLogoFromDistribution()) {
+        lazy.log.debug("No custom enterprise logo configured.");
+      }
+
       await this.initUser();
       this._isInitialized = true;
     }
@@ -106,10 +112,11 @@ export const EnterpriseHandler = {
     const toolbarLogo = window.document.querySelector(
       "#enterprise-company-logo__wrapper > image"
     );
-    const logoUrl = this._getLogoUrl();
-
-    if (logoUrl) {
-      toolbarLogo.style.setProperty("list-style-image", `url("${logoUrl}")`);
+    if (this._logoUrl) {
+      toolbarLogo.style.setProperty(
+        "list-style-image",
+        `url("${this._logoUrl}")`
+      );
     }
 
     if (!this._signedInUser) {
@@ -244,35 +251,37 @@ export const EnterpriseHandler = {
 
   uninit() {
     this._signedInUser = {};
+    this._logoUrl = null;
     this._isInitialized = false;
   },
 
-  _getLogoUrl() {
-    const logoUrl = Services.prefs.getStringPref(
+  _setLogoUrlFromPref() {
+    const prefLogoUrl = Services.prefs.getStringPref(
       ENTERPRISE_TOOLBAR_LOGO_URL_PREF,
       ""
     );
 
-    // if pref is not set, try loading from repack
-    if (!logoUrl) {
-      return this._getDistributionLogoUrl();
+    // skip if pref is not set
+    if (!prefLogoUrl) {
+      return false;
     }
 
     // allow https: URLs and data: URIs for common image formats with base64 encoding only.
     const logoUrlPattern =
       /^(https:\/\/|data:image\/(?:png|jpeg|gif|webp|svg\+xml);base64,)/;
-    if (!logoUrlPattern.test(logoUrl)) {
-      return null;
+    if (!logoUrlPattern.test(prefLogoUrl)) {
+      console.warn(`Invalid logo URL in pref: ${prefLogoUrl}`);
+      return false;
     }
 
     try {
-      return new URL(logoUrl).href;
-    } catch {
-      return null;
-    }
+      this._logoUrl = new URL(prefLogoUrl).href;
+      return true;
+    } catch {}
+    return false;
   },
 
-  _getDistributionLogoUrl() {
+  _setLogoFromDistribution() {
     const SUPPORTED_EXTENSIONS = [
       ".svg",
       ".png",
@@ -283,15 +292,23 @@ export const EnterpriseHandler = {
     ];
     const BADGE_LOGO_NAME = "badge-logo";
     try {
-      let distDir = Services.dirsvc.get("XREAppDist", Ci.nsIFile);
-      for (let ext of SUPPORTED_EXTENSIONS) {
-        let logoFile = distDir.clone();
+      const distDir = Services.dirsvc.get("XREAppDist", Ci.nsIFile);
+      for (const ext of SUPPORTED_EXTENSIONS) {
+        const logoFile = distDir.clone();
         logoFile.append(`${BADGE_LOGO_NAME}${ext}`);
         if (logoFile.exists()) {
-          return Services.io.newFileURI(logoFile).spec;
+          const protocolHandler = Services.io
+            .getProtocolHandler("resource")
+            .QueryInterface(Ci.nsIResProtocolHandler);
+          protocolHandler.setSubstitution(
+            "enterprise-distribution",
+            Services.io.newFileURI(distDir)
+          );
+          this._logoUrl = `resource://enterprise-distribution/${BADGE_LOGO_NAME}${ext}`;
+          return true;
         }
       }
     } catch {}
-    return null;
+    return false;
   },
 };

--- a/browser/components/enterprise/EnterpriseHandler.sys.mjs
+++ b/browser/components/enterprise/EnterpriseHandler.sys.mjs
@@ -25,7 +25,7 @@ ChromeUtils.defineLazyGetter(lazy, "log", () => {
 });
 
 const PROMPT_ON_SIGNOUT_PREF = "enterprise.promptOnSignout";
-const LOGO_URL = "enterprise.logoUrl";
+const LOGO_URL = "enterprise.logo_url";
 
 export const EnterpriseHandler = {
   /**

--- a/browser/components/enterprise/EnterpriseHandler.sys.mjs
+++ b/browser/components/enterprise/EnterpriseHandler.sys.mjs
@@ -15,7 +15,6 @@ ChromeUtils.defineESModuleGetters(lazy, {
   BrowserUtils: "resource://gre/modules/BrowserUtils.sys.mjs",
   ConsoleClient: "resource:///modules/enterprise/ConsoleClient.sys.mjs",
   EnterpriseCommon: "resource:///modules/enterprise/EnterpriseCommon.sys.mjs",
-  PREFS: "resource:///modules/enterprise/ConsoleClient.sys.mjs",
 });
 
 ChromeUtils.defineLazyGetter(lazy, "log", () => {
@@ -26,6 +25,7 @@ ChromeUtils.defineLazyGetter(lazy, "log", () => {
 });
 
 const PROMPT_ON_SIGNOUT_PREF = "enterprise.promptOnSignout";
+const LOGO_URL = "enterprise.logoUrl";
 
 export const EnterpriseHandler = {
   /**
@@ -97,12 +97,12 @@ export const EnterpriseHandler = {
   },
 
   /**
-   * Updates the user icon
+   * Updates the user icon and badge logo
    *
    * @param {Window} window chrome window
    */
   updateBadge(window) {
-    this._setLogoUrlFromPref(window);
+    this._updateLogo(window);
 
     const userIcon = window.document.querySelector("#enterprise-user-icon");
 
@@ -241,28 +241,32 @@ export const EnterpriseHandler = {
     this._isInitialized = false;
   },
 
-  _setLogoUrlFromPref(window) {
-    const prefLogoUrl = Services.prefs.getStringPref(lazy.PREFS.LOGO_URL, "");
+  _updateLogo(window) {
+    const logoUrl = Services.prefs.getStringPref(LOGO_URL, "");
 
-    if (!prefLogoUrl) {
+    if (!logoUrl) {
+      console.error(`Skipping logo update, ${LOGO_URL} pref is not set.`);
       return;
     }
 
     // allow https: URLs and data: URIs for common image formats with base64 encoding only.
     const logoUrlPattern =
       /^(https:\/\/|data:image\/(?:png|jpeg|gif|webp|svg\+xml);base64,)/;
-    if (!logoUrlPattern.test(prefLogoUrl)) {
-      console.warn(`Invalid logo URL in pref: ${prefLogoUrl}`);
+    if (!logoUrlPattern.test(logoUrl)) {
+      console.error(`Invalid logo URL in pref: ${logoUrl}`);
       return;
     }
 
     try {
-      const logoUrl = new URL(prefLogoUrl).href;
+      const validLogoUrl = new URL(logoUrl).href;
 
       const toolbarLogo = window.document.querySelector(
         "#enterprise-company-logo__wrapper > image"
       );
-      toolbarLogo.style.setProperty("list-style-image", `url("${logoUrl}")`);
+      toolbarLogo.style.setProperty(
+        "list-style-image",
+        `url("${validLogoUrl}")`
+      );
     } catch {}
   },
 };

--- a/browser/components/enterprise/content/enterprise-badge.css
+++ b/browser/components/enterprise/content/enterprise-badge.css
@@ -19,6 +19,8 @@
 }
 
 #enterprise-badge-toolbar-button {
+  flex-shrink: 0;
+
   &:focus-visible {
     outline: none;
 
@@ -40,7 +42,6 @@
   padding: var(--space-xxsmall) var(--space-xsmall);
   align-items: center;
   gap: var(--space-small);
-  flex-shrink: 0;
 
   border-radius: var(--border-radius-medium);
   /* stylelint-disable-next-line stylelint-plugin-mozilla/use-design-tokens */
@@ -58,11 +59,11 @@
 
 #enterprise-company-logo__wrapper {
   /* stylelint-disable-next-line stylelint-plugin-mozilla/use-design-tokens */
+  min-width: 0;
   max-width: 80px;
-  max-height: var(--size-item-medium);
+  height: var(--size-item-medium);
   justify-content: center;
   align-items: center;
-  flex-shrink: 0;
 
   > image {
     width: 100%;

--- a/browser/components/enterprise/content/enterprise-badge.css
+++ b/browser/components/enterprise/content/enterprise-badge.css
@@ -59,8 +59,8 @@
 
 #enterprise-company-logo__wrapper {
   /* stylelint-disable-next-line stylelint-plugin-mozilla/use-design-tokens */
-  min-width: 0;
   max-width: 80px;
+  /* stylelint-disable-next-line stylelint-plugin-mozilla/use-design-tokens */
   height: var(--size-item-medium);
   justify-content: center;
   align-items: center;

--- a/browser/components/enterprise/modules/ConsoleClient.sys.mjs
+++ b/browser/components/enterprise/modules/ConsoleClient.sys.mjs
@@ -24,6 +24,7 @@ ChromeUtils.defineLazyGetter(lazy, "log", () => {
  */
 export const PREFS = {
   CONSOLE_ADDRESS: "enterprise.console.address",
+  LOGO_URL: "enterprise.logoUrl",
 };
 
 /**

--- a/browser/components/enterprise/modules/ConsoleClient.sys.mjs
+++ b/browser/components/enterprise/modules/ConsoleClient.sys.mjs
@@ -24,7 +24,6 @@ ChromeUtils.defineLazyGetter(lazy, "log", () => {
  */
 export const PREFS = {
   CONSOLE_ADDRESS: "enterprise.console.address",
-  LOGO_URL: "enterprise.logoUrl",
 };
 
 /**


### PR DESCRIPTION
## Summary

Adds support for loading the Enterprise Badge logo from `enterprise.logoUrl` using the following URL pattern: `^(https:\/\/|data:image\/(?:png|jpeg|gif|webp|svg\+xml);base64,)`

Also fixes spacing issue with Enterprise Badge on smaller displays. 

Open to trimming the icon format types down as well, for now it's just web raster formats + svg.

## Links

- [Bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=2012082)

## Related Issues and Pull Requests

## Screenshots

<img width="527" height="113" alt="badge-logo-resource" src="https://github.com/user-attachments/assets/fbf4a005-3feb-44f6-a5c9-d4785005169e" />

_Custom Enterprise Badge logo_

<img width="254" height="106" alt="badge-logo-overlap" src="https://github.com/user-attachments/assets/f923b9ab-0479-4144-996e-c11a9015ef91" />

_Enterprise Badge overlapping neighboring elements (before fix)_

## Testing

1. `mach build`
2. `mach run`
3. Set `enterprise.logoUrl` to a valid `https` or `data:base64` url
4. Close and reopen or open new window