### PR TITLE
Add activateApplication API and macOS activation

### DIFF
--- a/browser/extensions/felt/api.js
+++ b/browser/extensions/felt/api.js
@@ -254,6 +254,7 @@ this.felt = class extends ExtensionAPI {
         const success = Services.felt.makeBackgroundProcess(false);
         console.debug(`FeltExtension: makeBackgroundProcess? ${success}`);
         this.showWindow();
+        Services.felt.activateApplication();
         break;
       }
 

--- a/browser/extensions/felt/rust/nsIFelt.idl
+++ b/browser/extensions/felt/rust/nsIFelt.idl
@@ -77,4 +77,7 @@ interface nsIFelt : nsISupports {
 
   [must_use]
   void performSignout();
+
+  [must_use]
+  void activateApplication();
 };

--- a/browser/extensions/felt/rust/src/client.rs
+++ b/browser/extensions/felt/rust/src/client.rs
@@ -101,7 +101,7 @@ impl FeltIpcClient {
                         Ok(()) => {
                             trace!("FeltIpcClient::send_back_tokens() SENT");
                             NS_OK
-                        },
+                        }
                         Err(err) => {
                             trace!("FeltIpcClient::send_back_tokens() TX ERROR: {}", err);
                             NS_ERROR_FAILURE
@@ -255,7 +255,7 @@ impl FeltClientThread {
                                     if let Err(err) = tx.send(FeltMessage::Restarting) {
                                         trace!("FeltClientThread::start_thread::observe() failed to send restart: {:?}", err);
                                     }
-                                },
+                                }
                                 "shutdown" => {
                                     trace!("FeltClientThread::start_thread::observe() quit-application: shutdown");
                                     if let Err(err) = tx.send(FeltMessage::Exiting) {

--- a/browser/extensions/felt/rust/src/components.rs
+++ b/browser/extensions/felt/rust/src/components.rs
@@ -272,7 +272,12 @@ impl FeltXPCOM {
         let focus_hint = utils::get_focus_hint();
         #[cfg(not(target_os = "linux"))]
         let focus_hint = None;
-        trace!("FeltXPCOM::OpenURL: {} {} {:?}", url_s, disposition, focus_hint);
+        trace!(
+            "FeltXPCOM::OpenURL: {} {} {:?}",
+            url_s,
+            disposition,
+            focus_hint
+        );
         self.send(FeltMessage::OpenURL((url_s, disposition, focus_hint)))
     }
 
@@ -286,6 +291,41 @@ impl FeltXPCOM {
             trace!("FeltXPCOM::GetConsoleUrl called before initialized");
             NS_ERROR_FAILURE
         }
+    }
+
+    // Active the application on macOS (bring it to the foreground)
+    #[allow(unused_variables)]
+    pub fn ActivateApplication(&self) -> nserror::nsresult {
+        trace!("FeltXPCOM: ActivateApplication");
+        #[cfg(target_os = "macos")]
+        {
+            type Id = *mut std::ffi::c_void;
+            type Sel = *const std::ffi::c_void;
+
+            unsafe extern "C" {
+                fn objc_getClass(name: *const std::ffi::c_char) -> Id;
+                fn sel_registerName(name: *const std::ffi::c_char) -> Sel;
+                fn objc_msgSend();
+            }
+
+            unsafe {
+                let cls = objc_getClass(c"NSApplication".as_ptr());
+                let shared_app_sel = sel_registerName(c"sharedApplication".as_ptr());
+                let activate_sel = sel_registerName(c"activateIgnoringOtherApps:".as_ptr());
+                type MsgSendIdSel = unsafe extern "C" fn(Id, Sel) -> Id;
+                type MsgSendVoidBool = unsafe extern "C" fn(Id, Sel, bool);
+                let app = std::mem::transmute::<unsafe extern "C" fn(), MsgSendIdSel>(objc_msgSend)(
+                    cls,
+                    shared_app_sel,
+                );
+                std::mem::transmute::<unsafe extern "C" fn(), MsgSendVoidBool>(objc_msgSend)(
+                    app,
+                    activate_sel,
+                    true,
+                );
+            }
+        }
+        NS_OK
     }
 
     // Firefox to FELT to notify of logout


### PR DESCRIPTION
- Add activateApplication to the FELT API and implement macOS activation to bring FELT to front
- Expose activateApplication() in nsIFelt.idl and call it from the extension UI
- Implement macOS activation in Rust (FeltXPCOM) using NSApplication activateIgnoringOtherApps: to bring the app to the foreground
- Minor formatting fixes in client.rs and improved OpenURL tracing in components.rs