### PR TITLE
Bug 2026537: Set dom.push.serverURL on test setup

### DIFF
--- a/testing/profiles/mochitest/user.js
+++ b/testing/profiles/mochitest/user.js
@@ -36,3 +36,7 @@ user_pref("places.history.floodingPrevention.enabled", false);
 // permission, and we can open it and wait for the user to give permission, then
 // don't do that.
 user_pref("geo.prompt.open_system_prefs", false);
+
+// Set a dummy push server URL for mochitest runs. In enterprise builds the
+// default is an empty string, but push tests need a non-empty value.
+user_pref("dom.push.serverURL", "wss://push.services.mozilla.com/");


### PR DESCRIPTION
The test expects  [](https://searchfox.org/enterprise-main/rev/73669e504b64c8ebe02576c85458600499166b03/dom/push/PushService.sys.mjs#389) a url in there. 

I resetted the pref on the mochi setup.