### PR TITLE
Bug 2026578 - Hide uptodate message on sso load

### DIFF
--- a/browser/extensions/felt/content/window.js
+++ b/browser/extensions/felt/content/window.js
@@ -290,6 +290,7 @@ async function connectToConsole(email) {
   );
 
   ErrorReport.reset();
+  document.querySelector(".felt-updates-message").classList.add("is-hidden");
   document.querySelector(".felt-login__email-pane").classList.add("is-hidden");
   document.querySelector(".felt-login__sso").classList.remove("is-hidden");
 


### PR DESCRIPTION
**Bug:** The "Firefox Enterprise is up to date" message overlays the loaded `browser` element (see screenshot)
<img width="731" height="781" alt="Screenshot 2026-03-26 at 12 05 21" src="https://github.com/user-attachments/assets/66cf6ae6-1aae-4658-8565-95e36ca1c0e3" />


**Fix:** Hide the message once we load the browser element.