### PR TITLE
Enterprise release uplift 2026032601

### DIFF
--- a/browser/components/enterprise/modules/ConsoleClient.sys.mjs
+++ b/browser/components/enterprise/modules/ConsoleClient.sys.mjs
@@ -9,6 +9,7 @@ ChromeUtils.defineESModuleGetters(lazy, {
   EnterpriseCommon: "resource:///modules/enterprise/EnterpriseCommon.sys.mjs",
   AsyncShutdown: "resource://gre/modules/AsyncShutdown.sys.mjs",
   FeltStorage: "resource:///modules/FeltStorage.sys.mjs",
+  composeOSNames: "resource:///modules/enterprise/EnterpriseOSInfo.sys.mjs",
 });
 
 ChromeUtils.defineLazyGetter(lazy, "log", () => {
@@ -614,8 +615,17 @@ export const ConsoleClient = {
       .getService()
       .QueryInterface(Ci.nsINetworkLinkService).networkInterfaces;
 
+    const baseOs = lazy.TelemetryEnvironment.currentEnvironment.system.os;
+    const { long: os_long_name, short: os_short_name } =
+      await lazy.composeOSNames(baseOs);
+    const os = {
+      ...baseOs,
+      ...(os_long_name != null && { os_long_name }),
+      ...(os_short_name != null && { os_short_name }),
+    };
+
     const devicePosturePayload = {
-      os: lazy.TelemetryEnvironment.currentEnvironment.system.os,
+      os,
       security: lazy.TelemetryEnvironment.currentEnvironment.system.sec,
       build: lazy.TelemetryEnvironment.currentEnvironment.build,
       network: {

--- a/browser/components/enterprise/modules/EnterpriseOSInfo.sys.mjs
+++ b/browser/components/enterprise/modules/EnterpriseOSInfo.sys.mjs
@@ -1,0 +1,225 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { AppConstants } from "resource://gre/modules/AppConstants.sys.mjs";
+
+const lazy = {};
+
+ChromeUtils.defineESModuleGetters(lazy, {
+  WindowsRegistry: "resource://gre/modules/WindowsRegistry.sys.mjs",
+});
+
+const WINDOWS_CURRENT_VERSION_KEY =
+  "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion";
+
+const MACOS_SYSTEM_VERSION_PLIST =
+  "/System/Library/CoreServices/SystemVersion.plist";
+
+let gMacOSVersionPromise = null;
+
+/**
+ * Reads the macOS version from SystemVersion.plist.
+ *
+ * @returns {Promise<string|null>}
+ */
+// TODO: Once bug 2017277 is fixed, os.version can be used instead of this function.
+async function getMacOSVersion() {
+  if (gMacOSVersionPromise) {
+    return gMacOSVersionPromise;
+  }
+  gMacOSVersionPromise = (async () => {
+    try {
+      const content = await IOUtils.readUTF8(MACOS_SYSTEM_VERSION_PLIST);
+      const doc = new DOMParser().parseFromString(content, "application/xml");
+      for (const key of doc.querySelectorAll("dict > key")) {
+        if (key.textContent === "ProductVersion") {
+          return key.nextElementSibling?.textContent ?? null;
+        }
+      }
+    } catch (e) {
+      console.error("getMacOSVersion: failed to read SystemVersion.plist", e);
+    }
+    return null;
+  })();
+  return gMacOSVersionPromise;
+}
+
+/**
+ * Returns the Windows release label (e.g. "22H2", "23H2", "1909") from the
+ * registry. Prefers DisplayVersion (introduced in 20H2), falls back to
+ * ReleaseId for older versions. Returns null if unavailable or not on Windows.
+ *
+ * @returns {string|null}
+ */
+function getWindowsReleaseLabel() {
+  for (const valueName of ["DisplayVersion", "ReleaseId"]) {
+    const value = lazy.WindowsRegistry.readRegKey(
+      Ci.nsIWindowsRegKey.ROOT_KEY_LOCAL_MACHINE,
+      WINDOWS_CURRENT_VERSION_KEY,
+      valueName,
+      Ci.nsIWindowsRegKey.WOW64_64
+    );
+    if (value != null) {
+      return value;
+    }
+  }
+  return null;
+}
+
+/**
+ * Returns true if the current Windows installation is a Server edition.
+ *
+ * @returns {boolean}
+ */
+function isWindowsServer() {
+  const installationType = lazy.WindowsRegistry.readRegKey(
+    Ci.nsIWindowsRegKey.ROOT_KEY_LOCAL_MACHINE,
+    WINDOWS_CURRENT_VERSION_KEY,
+    "InstallationType",
+    Ci.nsIWindowsRegKey.WOW64_64
+  );
+  return installationType === "Server";
+}
+
+const WINDOWS_SERVER_NAMES = [
+  [26100, "2025"],
+  [20348, "2022"],
+  [17763, "2019"],
+  [14393, "2016"],
+];
+
+/**
+ * Returns the Windows Server version string (e.g. "2025", "2022") from a build
+ * number, or null if the build number is not recognized.
+ *
+ * @param {number} buildNumber
+ * @returns {string|null}
+ */
+function getWindowsServerVersion(buildNumber) {
+  const match = WINDOWS_SERVER_NAMES.find(([min]) => buildNumber >= min);
+  return match ? match[1] : null;
+}
+
+const MACOS_NAMES = [
+  ["26", "Tahoe"],
+  ["15", "Sequoia"],
+  ["14", "Sonoma"],
+  ["13", "Ventura"],
+  ["12", "Monterey"],
+  ["11", "Big Sur"],
+  ["10.16", "Big Sur"],
+  ["10.15", "Catalina"],
+];
+
+/**
+ * Returns the Windows major version string ("11", "10", or "Unsupported") from
+ * a build number.
+ *
+ * @param {number} buildNumber
+ * @returns {string}
+ */
+function getWindowsMajorVersion(buildNumber) {
+  const versions = [
+    [22000, "11"],
+    [10240, "10"],
+  ];
+  const match = versions.find(([min]) => buildNumber >= min);
+  return match ? match[1] : "Unsupported";
+}
+
+/**
+ * Composes both the long and short human-readable OS names, reading SystemVersion.plist
+ * at most once on macOS.
+ *
+ * @param {object} os - The system.os object from TelemetryEnvironment.currentEnvironment.
+ * @returns {Promise<{long: string|null, short: string|null}>}
+ */
+export async function composeOSNames(os) {
+  const [long, short] = await Promise.all([
+    composeOSName(os),
+    composeShortOSName(os),
+  ]);
+  return { long, short };
+}
+
+/**
+ * Composes a short human-readable OS name from TelemetryEnvironment's system.os object.
+ *
+ * @param {object} os - The system.os object from TelemetryEnvironment.currentEnvironment.
+ * @returns {Promise<string|null>} A short OS string (e.g. "macOS 15 (Sequoia)", "Windows 11",
+ *   "Windows Server 2025", "Ubuntu 22.04"), or null if the OS cannot be identified.
+ */
+async function composeShortOSName(os) {
+  if (AppConstants.platform === "macosx") {
+    const macosVersion = await getMacOSVersion();
+    if (!macosVersion) {
+      return null;
+    }
+    const match = MACOS_NAMES.find(([prefix]) =>
+      macosVersion.startsWith(prefix)
+    );
+    const major = macosVersion.split(".")[0];
+    return match ? `macOS ${major} (${match[1]})` : `macOS ${major}`;
+  }
+  if (os.windowsBuildNumber) {
+    if (isWindowsServer()) {
+      const serverVersion = getWindowsServerVersion(os.windowsBuildNumber);
+      return serverVersion
+        ? `Windows Server ${serverVersion}`
+        : "Windows Server";
+    }
+    return `Windows ${getWindowsMajorVersion(os.windowsBuildNumber)}`;
+  }
+  if (os.distro && os.distroVersion) {
+    return `${os.distro} ${os.distroVersion}`;
+  }
+  console.error("composeShortOSName: unable to identify OS from", os);
+  return null;
+}
+
+/**
+ * Composes a human-readable OS name from TelemetryEnvironment's system.os object.
+ * On macOS, the version is read directly from SystemVersion.plist.
+ * On Windows, the installation type and release label are read from the registry.
+ *
+ * @param {object} os - The system.os object from TelemetryEnvironment.currentEnvironment.
+ * @returns {Promise<string|null>} A human-readable OS string (e.g. "macOS 15.3 (Sequoia)",
+ *   "Windows 11 22H2 (build 22621)", "Windows Server 2025 (build 26100)",
+ *   "Ubuntu 22.04 (5.15.0)"), or null if the OS cannot be identified.
+ */
+async function composeOSName(os) {
+  if (AppConstants.platform === "macosx") {
+    const macosVersion = await getMacOSVersion();
+    if (!macosVersion) {
+      return null;
+    }
+    const match = MACOS_NAMES.find(([prefix]) =>
+      macosVersion.startsWith(prefix)
+    );
+    return match
+      ? `macOS ${macosVersion} (${match[1]})`
+      : `macOS ${macosVersion}`;
+  }
+  if (os.windowsBuildNumber) {
+    const releaseLabel = getWindowsReleaseLabel();
+    const releaseSuffix = releaseLabel ? ` ${releaseLabel}` : "";
+    if (isWindowsServer()) {
+      const serverVersion = getWindowsServerVersion(os.windowsBuildNumber);
+      const prefix = serverVersion
+        ? `Windows Server ${serverVersion}`
+        : "Windows Server";
+      return `${prefix}${releaseSuffix} (build ${os.windowsBuildNumber})`;
+    }
+    // Maps minimum build numbers to Windows major versions, since
+    // windowsBuildNumber is more reliable than the version string for
+    // distinguishing Windows 10 from 11.
+    const major = getWindowsMajorVersion(os.windowsBuildNumber);
+    return `Windows ${major}${releaseSuffix} (build ${os.windowsBuildNumber})`;
+  }
+  if (os.distro && os.distroVersion && os.version) {
+    return `${os.distro} ${os.distroVersion} (${os.version})`;
+  }
+  console.error("composeOSName: unable to identify OS from", os);
+  return null;
+}

--- a/browser/components/enterprise/moz.build
+++ b/browser/components/enterprise/moz.build
@@ -13,6 +13,7 @@ EXTRA_JS_MODULES.enterprise += [
     "EnterpriseHandler.sys.mjs",
     "modules/ConsoleClient.sys.mjs",
     "modules/EnterpriseAccountsStorage.sys.mjs",
+    "modules/EnterpriseOSInfo.sys.mjs",
     "modules/Updates.sys.mjs",
 ]
 

--- a/taskcluster/test_configs/variants.yml
+++ b/taskcluster/test_configs/variants.yml
@@ -512,8 +512,9 @@ msix:
                         "asan" in task["test-platform"]
                         || "ccov" in task["test-platform"]
                         || "devedition" in task["test-platform"]
+                        || "enterprise" in task["test-platform"]
                     )
-                '
+                '  # Bug 2026135 - re-enable msix tests when msix installer exists
     replace:
         mozharness:
             extra-options:

--- a/testing/enterprise/test_felt_device_posture.py
+++ b/testing/enterprise/test_felt_device_posture.py
@@ -4,6 +4,8 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 import os
+import platform
+import re
 import sys
 import time
 
@@ -49,6 +51,84 @@ class FeltDevicePosture(FeltTests):
             "Device posture reports proper applicationName"
         )
         assert "secureBootEnabled" in device_posture
+
+        os_long_name = device_posture["os"].get("os_long_name")
+
+        assert os_long_name and len(os_long_name) > 0, (
+            "Device posture reports os_long_name"
+        )
+        if sys.platform == "darwin":
+            # e.g. "macOS 15.3.1 (Sequoia)"
+            assert re.match(r"^macOS \d+(\.\d+)+( \(\w[\w ]*\))?$", os_long_name), (
+                f"os_long_name '{os_long_name}' does not match expected macOS format"
+            )
+            actual_version = platform.mac_ver()[0]
+            assert actual_version in os_long_name, (
+                f"os_long_name '{os_long_name}' should contain macOS version '{actual_version}'"
+            )
+        elif sys.platform == "win32":
+            actual_build = platform.win32_ver()[1].split(".")[-1]
+            # e.g. "Windows 11 22H2 (build 22621)", "Windows 10 (build 19045)",
+            # or "Windows Server 2025 24H2 (build 26100)"
+            assert re.match(
+                r"^Windows( Server)? \d+( \w+)? \(build \d+\)$", os_long_name
+            ), f"os_long_name '{os_long_name}' does not match expected Windows format"
+            assert actual_build in os_long_name, (
+                f"os_long_name '{os_long_name}' should contain build number '{actual_build}'"
+            )
+        elif sys.platform == "linux":
+            os_release = platform.freedesktop_os_release()
+            pretty_name = os_release.get("NAME", "")
+            if pretty_name == "Ubuntu":
+                version_id = os_release.get("VERSION_ID", "")
+                assert pretty_name in os_long_name, (
+                    f"os_long_name '{os_long_name}' should contain NAME '{pretty_name}'"
+                )
+                assert version_id in os_long_name, (
+                    f"os_long_name '{os_long_name}' should contain VERSION_ID '{version_id}'"
+                )
+                # e.g. "Ubuntu 22.04 (5.15.0-91-generic)"
+                assert re.match(
+                    rf"^{re.escape(pretty_name)} \d+(\.\d+)+ \(\S+\)$", os_long_name
+                ), f"os_long_name '{os_long_name}' does not match expected Linux format"
+
+        os_short_name = device_posture["os"].get("os_short_name")
+
+        assert os_short_name and len(os_short_name) > 0, (
+            "Device posture reports os_short_name"
+        )
+        if sys.platform == "darwin":
+            # e.g. "macOS 15 (Sequoia)"
+            assert re.match(r"^macOS \d+( \(\w[\w ]*\))?$", os_short_name), (
+                f"os_short_name '{os_short_name}' does not match expected macOS format"
+            )
+            actual_major = platform.mac_ver()[0].split(".")[0]
+            assert f"macOS {actual_major}" in os_short_name, (
+                f"os_short_name '{os_short_name}' should contain macOS major version '{actual_major}'"
+            )
+        elif sys.platform == "win32":
+            # e.g. "Windows 11", "Windows 10", or "Windows Server 2025"
+            assert re.match(r"^Windows( Server)? \d+$", os_short_name), (
+                f"os_short_name '{os_short_name}' does not match expected Windows format"
+            )
+        elif sys.platform == "linux":
+            os_release = platform.freedesktop_os_release()
+            pretty_name = os_release.get("NAME", "")
+            if pretty_name == "Ubuntu":
+                version_id = os_release.get("VERSION_ID", "")
+                assert pretty_name in os_short_name, (
+                    f"os_short_name '{os_short_name}' should contain NAME '{pretty_name}'"
+                )
+                assert version_id in os_short_name, (
+                    f"os_short_name '{os_short_name}' should contain VERSION_ID '{version_id}'"
+                )
+                # e.g. "Ubuntu 22.04"
+                assert re.match(
+                    rf"^{re.escape(pretty_name)} \d+(\.\d+)+$", os_short_name
+                ), (
+                    f"os_short_name '{os_short_name}' does not match expected Linux format"
+                )
+
         assert "mobileEquipmentId" in device_posture["network"], (
             "Device posture reports IMEI/MEID"
         )

--- a/toolkit/crashreporter/client/app/src/config.rs
+++ b/toolkit/crashreporter/client/app/src/config.rs
@@ -90,6 +90,9 @@ const DEFAULT_PRODUCT: &str = "Firefox";
 pub struct Config {
     /// Whether reports should be automatically submitted.
     pub auto_submit: bool,
+    #[cfg(feature = "enterprise")]
+    /// Whether reports should be automatically and immediately submitted by policy.
+    pub policy_auto_submit: bool,
     /// Whether all threads of the process should be dumped (versus just the crashing thread).
     pub dump_all_threads: bool,
     /// Whether to delete the dump files after submission.
@@ -146,6 +149,10 @@ impl Config {
     #[cfg_attr(mock, allow(unused))]
     pub fn read_from_environment(&mut self) {
         self.auto_submit = env_bool(ekey!("AUTO_SUBMIT"));
+        #[cfg(feature = "enterprise")]
+        {
+            self.policy_auto_submit = env_bool(ekey!("POLICY_AUTO_SUBMIT"));
+        }
         self.dump_all_threads = env_bool(ekey!("DUMP_ALL_THREADS"));
         self.delete_dump = !env_bool(ekey!("NO_DELETE_DUMP"));
         self.run_memtest = env_bool(ekey!("RUN_MEMTEST"));

--- a/toolkit/crashreporter/client/app/src/lang/langpack.rs
+++ b/toolkit/crashreporter/client/app/src/lang/langpack.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::language_info::LanguageInfo;
-use super::zip::{read_archive_file_as_string, read_zip, Archive};
+use super::zip::{read_archive_file_as_string, read_archive_files_as_string, read_zip, Archive};
 use crate::config::installation_resource_path;
 use crate::std::path::{Path, PathBuf};
 use anyhow::Context;
@@ -163,8 +163,11 @@ fn read_archive_ftl_definitions(
     langpack: &mut Archive,
     language_identifier: &str,
 ) -> anyhow::Result<String> {
-    let path = format!("localization/{language_identifier}/crashreporter/crashreporter.ftl");
-    read_archive_file_as_string(langpack, &path)
+    let mut paths = Vec::new();
+    paths.push(format!("localization/{language_identifier}/crashreporter/crashreporter.ftl"));
+    #[cfg(feature = "enterprise")]
+    paths.push(format!("localization/{language_identifier}/crashreporter/crashreporter-enterprise.ftl"));
+    read_archive_files_as_string(langpack, &paths)
 }
 
 fn read_archive_ftl_branding(

--- a/toolkit/crashreporter/client/app/src/lang/language_info.rs
+++ b/toolkit/crashreporter/client/app/src/lang/language_info.rs
@@ -7,9 +7,22 @@ use anyhow::Context;
 use fluent::{bundle::FluentBundle, FluentResource};
 use unic_langid::LanguageIdentifier;
 
-const FALLBACK_FTL_FILE: &str = include_str!(mozbuild::srcdir_path!(
-    "/toolkit/locales/en-US/crashreporter/crashreporter.ftl"
-));
+cfg_if::cfg_if! {
+    if #[cfg(feature = "enterprise")] {
+        const FALLBACK_FTL_FILE: &str = concat!(
+            include_str!(mozbuild::srcdir_path!(
+                "/toolkit/locales/en-US/crashreporter/crashreporter.ftl"
+            )),
+            include_str!(mozbuild::srcdir_path!(
+                "/toolkit/locales/en-US/crashreporter/crashreporter-enterprise.ftl"
+            ))
+        );
+    } else {
+        const FALLBACK_FTL_FILE: &str = include_str!(mozbuild::srcdir_path!(
+            "/toolkit/locales/en-US/crashreporter/crashreporter.ftl"
+        ));
+    }
+}
 const FALLBACK_BRANDING_FILE: &str = include_str!(mozbuild::srcdir_path!(
     "/browser/branding/official/locales/en-US/brand.ftl"
 ));

--- a/toolkit/crashreporter/client/app/src/lang/omnijar.rs
+++ b/toolkit/crashreporter/client/app/src/lang/omnijar.rs
@@ -3,7 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 use super::language_info::LanguageInfo;
-use super::zip::{read_archive_file_as_string, read_zip};
+use super::zip::{read_archive_file_as_string, read_archive_files_as_string, read_zip};
 use crate::config::installation_resource_path;
 use crate::std::io::{BufRead, BufReader};
 use anyhow::Context;
@@ -30,9 +30,13 @@ pub fn read() -> anyhow::Result<Vec<LanguageInfo>> {
     let loaded: Vec<_> = locales
         .clone()
         .filter_map(|locale| {
-            match read_archive_file_as_string(
+            let mut paths = Vec::new();
+            paths.push(format!("localization/{locale}/crashreporter/crashreporter.ftl"));
+            #[cfg(feature = "enterprise")]
+            paths.push(format!("localization/{locale}/crashreporter/crashreporter-enterprise.ftl"));
+            match read_archive_files_as_string(
                 &mut zip,
-                &format!("localization/{locale}/crashreporter/crashreporter.ftl"),
+                &paths,
             ) {
                 Ok(v) => Some((locale.to_owned(), v)),
                 Err(e) => {

--- a/toolkit/crashreporter/client/app/src/lang/zip.rs
+++ b/toolkit/crashreporter/client/app/src/lang/zip.rs
@@ -38,3 +38,10 @@ pub fn read_archive_file_as_string(archive: &mut Archive, path: &str) -> anyhow:
         .with_context(|| format!("failed to read {path} from archive"))?;
     Ok(data)
 }
+
+/// Read files from a given zip archive as a string, with each file separated by a newline
+pub fn read_archive_files_as_string(archive: &mut Archive, paths: &[String]) -> anyhow::Result<String> {
+    Ok(paths.into_iter().map(|p| read_archive_file_as_string(archive, p.as_ref()))
+        .collect::<Result<Vec<_>, _>>()?
+        .join("\n"))
+}

--- a/toolkit/crashreporter/client/app/src/logic.rs
+++ b/toolkit/crashreporter/client/app/src/logic.rs
@@ -400,6 +400,7 @@ impl ReportCrash {
     }
 
     /// Restart the program.
+    #[cfg_attr(feature = "enterprise", allow(unused))]
     fn restart_process(&self) {
         self.config.restart_process();
     }
@@ -540,6 +541,7 @@ impl ReportCrash {
     }
 
     /// Restart the application and send the crash report.
+    #[cfg_attr(feature = "enterprise", allow(unused))]
     pub fn restart(&self) {
         // Get the program restarted before sending the report.
         self.restart_process();
@@ -551,6 +553,12 @@ impl ReportCrash {
     pub fn quit(&self) {
         let result = self.try_send();
         self.close_window(result.is_some());
+    }
+
+    #[cfg(feature = "enterprise")]
+    /// Quit without sending a crash report
+    pub fn just_quit(&self) {
+        self.close_window(false);
     }
 
     fn close_window(&self, report_sent: bool) {

--- a/toolkit/crashreporter/client/app/src/net/http.rs
+++ b/toolkit/crashreporter/client/app/src/net/http.rs
@@ -59,6 +59,7 @@ pub(crate) struct BackgroundTaskAttempts {
 }
 
 impl BackgroundTaskAttempts {
+    #[cfg_attr(all(mock, not(test)), allow(unused))]
     pub const fn new(count: usize) -> Self {
         BackgroundTaskAttempts {
             remaining: AtomicUsize::new(count),

--- a/toolkit/crashreporter/client/app/src/test.rs
+++ b/toolkit/crashreporter/client/app/src/test.rs
@@ -493,6 +493,7 @@ fn error_dialog() {
     .unwrap();
 }
 
+#[cfg(not(feature = "enterprise"))]
 #[test]
 fn error_dialog_restart() {
     let mut config = Config::default();
@@ -578,6 +579,7 @@ fn auto_submit() {
     test.assert_files().submitted();
 }
 
+#[cfg(not(feature = "enterprise"))]
 #[test]
 fn restart() {
     let mut test = GuiTest::new();
@@ -602,6 +604,7 @@ fn restart() {
     ran_process.assert_one();
 }
 
+#[cfg(not(feature = "enterprise"))]
 #[test]
 fn no_restart_with_windows_error_reporting() {
     let mut test = GuiTest::new();

--- a/toolkit/crashreporter/client/app/src/ui/mod.rs
+++ b/toolkit/crashreporter/client/app/src/ui/mod.rs
@@ -205,6 +205,9 @@ impl ReportCrashUI {
             close_window,
         } = state.borrow();
 
+        #[cfg(feature = "enterprise")]
+        let policy_auto_submit = config.policy_auto_submit;
+
         send_report.on_change(cc! { (logic) move |v| {
             let v = *v;
             logic.push(move |s| s.settings.borrow_mut().submit_report = v);
@@ -218,13 +221,36 @@ impl ReportCrashUI {
             logic.push(move |s| s.settings.borrow_mut().test_hardware = v);
         }});
 
-        let input_enabled = submit_state.mapped(|s| s == &SubmitState::Initial);
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "enterprise")] {
+                let input_enabled = if policy_auto_submit {
+                    data::Synchronized::new(false)
+                } else {
+                    submit_state.mapped(|s| s == &SubmitState::Initial)
+                };
+            } else {
+                let input_enabled = submit_state.mapped(|s| s == &SubmitState::Initial);
+            }
+        }
         let send_report_and_input_enabled =
             data::Synchronized::join(send_report, &input_enabled, |s, e| *s && *e);
+        #[cfg(feature = "enterprise")]
+        let close_enabled = if policy_auto_submit {
+            data::Synchronized::new(true)
+        } else {
+            submit_state.mapped(|s| s == &SubmitState::Initial)
+        };
 
         let submit_status_text = submit_state.mapped(cc! { (config) move |s| {
             config.string(match s {
+                #[cfg(not(feature = "enterprise"))]
                 SubmitState::Initial => "crashreporter-submit-status",
+                #[cfg(feature = "enterprise")]
+                SubmitState::Initial => if policy_auto_submit {
+                    "crashreporter-submit-status-policy"
+                } else {
+                    "crashreporter-submit-status-enterprise"
+                },
                 SubmitState::WaitingHardwareTests => "crashreporter-submit-waiting-hardware-tests",
                 SubmitState::InProgress => "crashreporter-submit-in-progress",
                 SubmitState::Success => "crashreporter-submit-success",
@@ -259,6 +285,9 @@ impl ReportCrashUI {
                 VBox margin(10) spacing(10) halign(Alignment::Fill) valign(Alignment::Fill) {
                     Label text(config.string("crashreporter-apology")) bold(true),
                     Label text(config.string("crashreporter-crashed-and-restore")),
+                    #[cfg(feature = "enterprise")]
+                    Label text(config.string(if policy_auto_submit {"crashreporter-policy-explanation"} else {"crashreporter-plea"})),
+                    #[cfg(not(feature = "enterprise"))]
                     Label text(config.string("crashreporter-plea")),
                     Checkbox["test-hardware"] checked(test_hardware)
                         label(config.string("crashreporter-checkbox-test-hardware"))
@@ -291,17 +320,31 @@ impl ReportCrashUI {
                     },
                     HBox valign(Alignment::End) halign(Alignment::End) spacing(10) affirmative_order(true)
                     {
+                        #[cfg(not(feature = "enterprise"))]
                         Button["restart"] visible(config.restart_command.is_some())
                             on_click(cc! { (logic) move || logic.push(|s| s.restart()) })
                             enabled(&input_enabled) hsize(160)
                         {
                             Label text(config.string("crashreporter-button-restart"))
                         },
+                        #[cfg(not(feature = "enterprise"))]
                         Button["quit"] on_click(cc! { (logic) move || logic.push(|s| s.quit()) })
                             enabled(&input_enabled) hsize(160)
                         {
                             Label text(config.string("crashreporter-button-quit"))
-                        }
+                        },
+                        #[cfg(feature = "enterprise")]
+                        Button["quit"] on_click(cc! { (logic) move || {
+                                if policy_auto_submit {
+                                    logic.push(|s| s.just_quit());
+                                } else {
+                                    logic.push(|s| s.quit());
+                                }
+                            } })
+                            enabled(&close_enabled) hsize(160)
+                        {
+                            Label text(config.string("crashreporter-button-ok"))
+                        },
                     }
                 }
             }

--- a/toolkit/crashreporter/client/app/src/ui/model/mod.rs
+++ b/toolkit/crashreporter/client/app/src/ui/model/mod.rs
@@ -300,32 +300,91 @@ pub struct Margin {
 ///
 /// For testing, a string identifier can be set on any element with a `["my_identifier"]` following
 /// the element type.
+///
+/// You may add attributes before child element items (which will be applied to the
+/// `add_child()` method call).
+///
+/// You can use a closure form rather than the braced body to manually interact with the
+/// `ElementBuilder`:
+/// ```
+/// ElementTypeName some_method(arg1, arg2) other_method() |builder| {
+///     // Do things with `builder: ElementBuilder<ElementTypeName>`
+/// }
+/// ```
 macro_rules! ui {
-    ( $el:ident
-        $([ $id:literal ])?
-        $( $method:ident $methodargs:tt )*
-        $({ $($contents:tt)* })?
-    ) => {
-        {
-            #[allow(unused_imports)]
-            use $crate::ui::model::*;
-            let mut el: ElementBuilder<$el> = Default::default();
-            $( el.id($id); )?
-            $( el.$method $methodargs ; )*
-            $( ui! { @children (el) $($contents)* } )?
-            el.into()
-        }
-    };
-    ( @children ($parent:expr) ) => {};
-    ( @children ($parent:expr)
+    /* The @elements forms parse a comma-separated list of elements and pass to a continuation. */
+    // Rewrite braces as a @children expansion (passing to the next case).
+    ( @elements $continuation:tt $els:tt
+      $(#[$attr:meta])*
       $el:ident
         $([ $id:literal ])?
         $( $method:ident $methodargs:tt )*
         $({ $($contents:tt)* })?
       $(, $($rest:tt)* )?
     ) => {
-        $parent.add_child(ui!( $el $([$id])? $( $method $methodargs )* $({ $($contents)* })? ));
-        $(ui!( @children ($parent) $($rest)* ))?
+        ui!(@elements $continuation $els
+            $(#[$attr])* $el $([$id])? $($method $methodargs)* |el| {$(ui!(@elements (@children (el)) [] $($contents)*))?}
+        $(, $($rest)*)?)
+    };
+    // Consume an element and append it to the list.
+    ( @elements $continuation:tt [$($els:tt)*]
+      $(#[$attr:meta])*
+      $el:ident
+        $([ $id:literal ])?
+        $( $method:ident $methodargs:tt )*
+        |$builder:ident| $body:expr
+      $(, $($rest:tt)* )?
+    ) => {
+        ui!(@elements $continuation [$($els)* {
+            attr $(#[$attr])*;
+            el $el;
+            id $($id)?;
+            methods $( $method $methodargs )*;
+            builder $builder;
+            body $body
+        }] $($($rest)*)?)
+    };
+    // All elements consumed: send to continuation.
+    ( @elements ($($continuation:tt)*) $els:tt ) => {
+        ui!($($continuation)* $els)
+    };
+    // Create a single element.
+    ( @create {
+        el $el:ident;
+        id $($id:literal)?;
+        methods $( $method:ident $methodargs:tt )*;
+        builder $builder:ident;
+        body $body:expr
+    } ) => {
+        {
+            #[allow(unused_imports)]
+            use $crate::ui::model::*;
+            let mut $builder: ElementBuilder<$el> = Default::default();
+            $( $builder.id($id); )?
+            $( $builder.$method $methodargs ; )*
+            $body;
+            $builder.into()
+        }
+    };
+    // Create a series of elements and call $parent.add_child() on each.
+    ( @children ($parent:expr) [$({ attr $(#[$attr:meta])*; $($rest:tt)* })*] ) => {
+        {$(
+            $(#[$attr])*
+            $parent.add_child(ui!(@create { $($rest)* }));
+        )*}
+    };
+    // Parse the top-level element (there must be exactly one).
+    ( @toplevel [{attr $(#[$attr:meta])*; $($rest:tt)*}] ) => {
+        $(#[$attr])*
+        ui!(@create {$($rest)*})
+    };
+    // Error when we don't have one top-level element.
+    ( @toplevel $other:tt ) => {
+        compile_error!("Exactly one top-level element must be specified");
+    };
+    // Default to parsing a sequence of elements at the top level.
+    ( $($s:tt)* ) => {
+        ui!(@elements (@toplevel) [] $($s)*)
     };
 }
 

--- a/toolkit/locales/en-US/crashreporter/crashreporter-enterprise.ftl
+++ b/toolkit/locales/en-US/crashreporter/crashreporter-enterprise.ftl
@@ -1,0 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+crashreporter-policy-explanation = Your administrator has configured { -brand-short-name } to send crash reports automatically. Crash reports help diagnose problems and make { -brand-short-name } better.
+crashreporter-submit-status-enterprise = Your crash report will be submitted when you click OK.
+crashreporter-submit-status-policy = Your crash report will automatically be submitted.


### PR DESCRIPTION
7801a5e096bf Bug 2021010 - Support attributes and imperative code in crashreporter client ui macro r=gsvelto
~~b1b3a92808fc Update enterprise-l10n-changesets.json from main~~
49ff419c8a25 Bug 2023530: add field to devicePosture os_long_name and os_short_name (#527)
~~1494cc82a9b4 Fix merge conflict leftover~~
b0bafd3efd08 Bug 2026132 - Enterprise: do not run MSIx variant of tests on Enterprise
~~76bfbd08beab Bug 2026142 - Enterprise: avoid duplicated 'checks' routes~~ 
~~351449f9652f Update enterprise-l10n-changesets.json from main~~
10f1f01ccabf Bug 2019055, Bug 2019267 - Customize CrashReporter UI for policy autosubmits