### PR TITLE
Bug 2026576 - Fix SitePolicies Lockdown UI persisting through tabs

### DIFF
--- a/browser/components/enterprise/EnterpriseHandler.sys.mjs
+++ b/browser/components/enterprise/EnterpriseHandler.sys.mjs
@@ -79,11 +79,8 @@ export const EnterpriseHandler = {
       window.PanelUI.showSubView("panelUI-lockdown-mode", button, event);
     });
 
-    window.gBrowser.addTabsProgressListener({
-      onLocationChange(browser, _webProgress, _request, location) {
-        if (browser !== window.gBrowser.selectedBrowser) {
-          return;
-        }
+    window.gBrowser.addProgressListener({
+      onLocationChange(_webProgress, _request, location) {
         let isLockedDown = false;
         try {
           isLockedDown = !Services.policies.isAllowedForURI("jit", location);

--- a/browser/components/enterprise/EnterpriseHandler.sys.mjs
+++ b/browser/components/enterprise/EnterpriseHandler.sys.mjs
@@ -80,7 +80,10 @@ export const EnterpriseHandler = {
     });
 
     window.gBrowser.addProgressListener({
-      onLocationChange(_webProgress, _request, location) {
+      onLocationChange(webProgress, _request, location) {
+        if (!webProgress.isTopLevel) {
+          return;
+        }
         let isLockedDown = false;
         try {
           isLockedDown = !Services.policies.isAllowedForURI("jit", location);

--- a/browser/components/enterprise/tests/browser/browser_lockdown_mode_page_action.js
+++ b/browser/components/enterprise/tests/browser/browser_lockdown_mode_page_action.js
@@ -111,6 +111,37 @@ add_task(async function test_button_toggles_with_navigation() {
   });
 });
 
+add_task(async function test_button_hidden_when_switching_to_non_locked_tab() {
+  await setupWithSitePolicies();
+
+  let lockedTab = await BrowserTestUtils.openNewForegroundTab(
+    gBrowser,
+    LOCKED_URL
+  );
+  Assert.ok(
+    !getLockdownUrlbarButton().hidden,
+    "Urlbar button should be visible on a locked-down page"
+  );
+
+  let unlockedTab = await BrowserTestUtils.openNewForegroundTab(
+    gBrowser,
+    UNLOCKED_URL
+  );
+  Assert.ok(
+    getLockdownUrlbarButton().hidden,
+    "Urlbar button should be hidden after switching to a non-locked-down tab"
+  );
+
+  await BrowserTestUtils.switchTab(gBrowser, lockedTab);
+  Assert.ok(
+    !getLockdownUrlbarButton().hidden,
+    "Urlbar button should be visible after switching back to locked-down tab"
+  );
+
+  BrowserTestUtils.removeTab(lockedTab);
+  BrowserTestUtils.removeTab(unlockedTab);
+});
+
 add_task(async function test_button_position() {
   await setupWithSitePolicies();
 


### PR DESCRIPTION
Change `addTabsProgressListener` to `addProgressListener` to apply `onLocationChange` listener to both navigation and tab switches.