### PR TITLE
Bug 2026203: Remove usage of Manager.Value on marionette testutils

### DIFF
--- a/testing/enterprise/felt_tests.py
+++ b/testing/enterprise/felt_tests.py
@@ -3,6 +3,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import ctypes
 import datetime
 import json
 import os
@@ -13,15 +14,45 @@ import tempfile
 import time
 import urllib.parse
 import uuid
-from ctypes import c_wchar_p
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from multiprocessing import Manager, Process, Value
+from multiprocessing import Array, Process, Value
 
 import felt_consts
 import requests
 from base_test import EnterpriseTestsBase
 from marionette_driver import expected
 from marionette_driver.by import By
+
+
+class SharedString:
+    """Process-safe string backed by shared memory.
+
+    Replaces Manager.Value(c_wchar_p, ...) to avoid the Manager IPC path, which
+    pickles data into a memoryview. Under GC pressure that memoryview can be
+    collected while still exported, triggering a CPython bug (bpo-77894 /
+    cpython#123898) that crashes the Manager's ServerProxy processes.
+    Using a shared memory Array avoids all IPC and memoryview allocation.
+    """
+
+    _MAX_SIZE = 128
+
+    def __init__(self, initial=""):
+        self._array = Array(ctypes.c_char, self._MAX_SIZE)
+        self.value = initial
+
+    @property
+    def value(self):
+        with self._array.get_lock():
+            return self._array._obj.value.decode("utf-8")
+
+    @value.setter
+    def value(self, s):
+        encoded = s.encode("utf-8")
+        assert len(encoded) < self._MAX_SIZE, (
+            f"SharedString value too long: {len(encoded)} >= {self._MAX_SIZE}"
+        )
+        with self._array.get_lock():
+            self._array._obj.value = encoded
 
 
 class LocalHttpRequestHandler(BaseHTTPRequestHandler):
@@ -488,9 +519,8 @@ class FeltTestsBase(EnterpriseTestsBase):
         if hasattr(self, "EXTRA_PREFS"):
             self._extra_prefs.update(self.EXTRA_PREFS)
 
-        manager = Manager()
-        self.policy_access_token = manager.Value(c_wchar_p, str(uuid.uuid4()))
-        self.policy_refresh_token = manager.Value(c_wchar_p, str(uuid.uuid4()))
+        self.policy_access_token = SharedString(str(uuid.uuid4()))
+        self.policy_refresh_token = SharedString(str(uuid.uuid4()))
 
         self.console_httpd = Process(
             target=serve,
@@ -508,8 +538,8 @@ class FeltTestsBase(EnterpriseTestsBase):
         )
         self.console_httpd.start()
 
-        self.cookie_name = manager.Value(c_wchar_p, str(uuid.uuid1()).split("-")[0])
-        self.cookie_value = manager.Value(c_wchar_p, str(uuid.uuid4()).split("-")[4])
+        self.cookie_name = SharedString(str(uuid.uuid1()).split("-")[0])
+        self.cookie_value = SharedString(str(uuid.uuid4()).split("-")[4])
         self.sso_httpd = Process(
             target=serve,
             args=(self.sso_port, SsoHttpHandler),


### PR DESCRIPTION
Remove Manager usage from the utils (also not used anywhere else on the codebase I could find).

This potentially will reduce the issue we are seeing.