### PR TITLE
Bug 2019061 - CrashReporter: Add logic to automatically submit crash reports upon launch of crash reporter

### DIFF
--- a/toolkit/crashreporter/client/app/src/async_task.rs
+++ b/toolkit/crashreporter/client/app/src/async_task.rs
@@ -6,16 +6,26 @@
 //!
 //! Each thread has thread-bound data which can be accessed in queued task functions.
 
+use std::sync::Arc;
+
 pub type TaskFn<T> = Box<dyn FnOnce(&T) + Send + 'static>;
 
 pub struct AsyncTask<T> {
-    send: Box<dyn Fn(TaskFn<T>) + Send + Sync>,
+    send: Arc<dyn Fn(TaskFn<T>) + Send + Sync>,
+}
+
+impl<T> Clone for AsyncTask<T> {
+    fn clone(&self) -> Self {
+        AsyncTask {
+            send: Arc::clone(&self.send),
+        }
+    }
 }
 
 impl<T> AsyncTask<T> {
     pub fn new<F: Fn(TaskFn<T>) + Send + Sync + 'static>(send: F) -> Self {
         AsyncTask {
-            send: Box::new(send),
+            send: Arc::new(send),
         }
     }
 

--- a/toolkit/crashreporter/client/app/src/logic.rs
+++ b/toolkit/crashreporter/client/app/src/logic.rs
@@ -429,7 +429,7 @@ impl ReportCrash {
         let crash_ui = ReportCrashUI::new(
             &*self.settings.borrow(),
             self.config.clone(),
-            logic_remote_queue,
+            logic_remote_queue.clone(),
         );
 
         // Set the UI remote queue.
@@ -444,6 +444,15 @@ impl ReportCrash {
         }
         let logic_panic_handler = PanicHandler(Arc::downgrade(&crash_ui_async_task));
         self.ui = Some(crash_ui_async_task);
+
+        #[cfg(feature = "enterprise")]
+        // Set up logic thread to immediately send the report
+        // Normally we might do this asynchronously because it blocks,
+        // but with policy_auto_submit, the UI is intentionally not interactive until after the send completes,
+        // so we won't need the logic thread to be unblocked.
+        if self.config.policy_auto_submit {
+            logic_remote_queue.push(|s| { s.try_send(); });
+        }
 
         // Spawn a separate thread to handle all interactions with `self`. This prevents blocking
         // the UI for any reason.

--- a/toolkit/crashreporter/client/app/src/logic.rs
+++ b/toolkit/crashreporter/client/app/src/logic.rs
@@ -66,7 +66,36 @@ pub fn sha256_hash_file(path: &Path) -> crate::std::io::Result<String> {
 impl ReportCrash {
     pub fn new(config: Arc<Config>, extra: serde_json::Value) -> anyhow::Result<Self> {
         let settings_file = config.data_dir().join("crashreporter_settings.json");
-        let settings: Settings = match std::fs::File::open(&settings_file) {
+        let settings = {
+            #[cfg(feature = "enterprise")]
+            if config.policy_auto_submit {
+                Settings {
+                    submit_report: true,
+                    include_url: true,
+                    test_hardware: true,
+                }
+            } else {
+                ReportCrash::load_settings(&settings_file)
+            }
+
+            #[cfg(not(feature = "enterprise"))]
+            ReportCrash::load_settings(&settings_file)
+        };
+        log::debug!("loaded settings: {settings:?}");
+
+        Ok(ReportCrash {
+            config,
+            extra,
+            settings_file,
+            settings: settings.into(),
+            attempted_to_send: Default::default(),
+            ui: None,
+            memtest: None.into(),
+        })
+    }
+
+    fn load_settings(settings_file: &Path) -> Settings {
+        match std::fs::File::open(&settings_file) {
             Err(e) => {
                 if e.kind() != std::io::ErrorKind::NotFound {
                     log::warn!(
@@ -85,19 +114,8 @@ impl ReportCrash {
                     Default::default()
                 }
                 Ok(s) => s,
-            },
-        };
-        log::debug!("loaded settings: {settings:?}");
-
-        Ok(ReportCrash {
-            config,
-            extra,
-            settings_file,
-            settings: settings.into(),
-            attempted_to_send: Default::default(),
-            ui: None,
-            memtest: None.into(),
-        })
+            }
+        }
     }
 
     /// Returns whether an attempt was made to send the report.

--- a/toolkit/crashreporter/client/app/src/ui/mod.rs
+++ b/toolkit/crashreporter/client/app/src/ui/mod.rs
@@ -236,7 +236,7 @@ impl ReportCrashUI {
             data::Synchronized::join(send_report, &input_enabled, |s, e| *s && *e);
         #[cfg(feature = "enterprise")]
         let close_enabled = if policy_auto_submit {
-            data::Synchronized::new(true)
+            submit_state.mapped(|s| s == &SubmitState::Failure || s == &SubmitState::Success)
         } else {
             submit_state.mapped(|s| s == &SubmitState::Initial)
         };


### PR DESCRIPTION
This is a simplified approach at adding what should be asynchronous behavior (compare to https://github.com/mozilla/enterprise-firefox/pull/602), in favor of accomplishing the goal in a timely manner.

Observed behavior:
When crash reporter launches, a progress indicator shows that a crash report is being prepared and submitted. Once complete, the progress updates to a success or failure message, and the "Ok" button becomes enabled to dismiss the dialog.

This can be tested in local builds with `MOZ_CRASHREPORTER=1 MOZ_CRASHREPORTER_POLICY_AUTO_SUBMIT=1 mach run` for now. It will require a follow-up PR to set `MOZ_CRASHREPORTER_POLICY_AUTO_SUBMIT` when the policy is enabled.