### PR TITLE
Bug 2026930 - Make CONSOLE_ADDRESS_PREF the only pref in ConsoleClient

### DIFF
--- a/browser/components/enterprise/modules/ConsoleClient.sys.mjs
+++ b/browser/components/enterprise/modules/ConsoleClient.sys.mjs
@@ -20,11 +20,9 @@ ChromeUtils.defineLazyGetter(lazy, "log", () => {
 });
 
 /**
- * Preferences used to integrate the a remote enterprise console
+ * Remote enterprise console preference
  */
-export const PREFS = {
-  CONSOLE_ADDRESS: "enterprise.console.address",
-};
+export const CONSOLE_ADDRESS_PREF = "enterprise.console.address";
 
 /**
  * Error logged when user needs to reauthenticate to obtain new token data
@@ -102,7 +100,7 @@ export const ConsoleClient = {
   get consoleBaseURI() {
     let consoleURI;
     try {
-      consoleURI = Services.prefs.getStringPref(PREFS.CONSOLE_ADDRESS);
+      consoleURI = Services.prefs.getStringPref(CONSOLE_ADDRESS_PREF);
     } catch (e) {
       console.error("Critial misconfiguration: Missing console URI.");
       throw e;

--- a/browser/components/enterprise/tests/browser/browser_enterprise_endpoints.js
+++ b/browser/components/enterprise/tests/browser/browser_enterprise_endpoints.js
@@ -3,7 +3,7 @@
 
 "use strict";
 
-const { ConsoleClient, PREFS } = ChromeUtils.importESModule(
+const { ConsoleClient, CONSOLE_ADDRESS_PREF } = ChromeUtils.importESModule(
   "resource:///modules/enterprise/ConsoleClient.sys.mjs"
 );
 const {
@@ -14,7 +14,6 @@ const {
   "resource:///modules/enterprise/EnterpriseEndpoints.sys.mjs"
 );
 
-const CONSOLE_ADDRESS_PREF = "enterprise.console.address";
 const CONSOLE_ADDRESS_PREF_VALUE =
   Services.prefs.getStringPref(CONSOLE_ADDRESS_PREF);
 

--- a/browser/extensions/felt/content/FeltProcessParent.sys.mjs
+++ b/browser/extensions/felt/content/FeltProcessParent.sys.mjs
@@ -7,7 +7,7 @@ const lazy = {};
 ChromeUtils.defineESModuleGetters(lazy, {
   Subprocess: "resource://gre/modules/Subprocess.sys.mjs",
   ConsoleClient: "resource:///modules/enterprise/ConsoleClient.sys.mjs",
-  PREFS: "resource:///modules/enterprise/ConsoleClient.sys.mjs",
+  CONSOLE_ADDRESS_PREF: "resource:///modules/enterprise/ConsoleClient.sys.mjs",
   isTesting: "resource:///modules/enterprise/EnterpriseCommon.sys.mjs",
   FeltCommon: "chrome://felt/content/FeltCommon.sys.mjs",
   FeltStorage: "resource:///modules/FeltStorage.sys.mjs",
@@ -262,7 +262,7 @@ export class FeltProcessParent extends JSProcessActorParent {
 
   sendPrefsToFirefox() {
     Services.felt.sendStringPreference(
-      lazy.PREFS.CONSOLE_ADDRESS,
+      lazy.CONSOLE_ADDRESS_PREF,
       lazy.ConsoleClient.consoleBaseURI
     );
 


### PR DESCRIPTION
I've seen non-console preference being added to `PREFS` in the `ConsoleClient`, which I'd like to avoid since the console address preference is the only preference that the `ConsoleClient` needs to know about.