### PR TITLE
Enterprise release uplift 2026032700

### DIFF
--- a/browser/base/content/aboutTabCrashed.js
+++ b/browser/base/content/aboutTabCrashed.js
@@ -148,14 +148,29 @@ var AboutTabCrashed = {
   onSetCrashReportAvailable(message) {
     let data = message.data;
 
-    if (data.hasReport) {
-      this.hasReport = true;
+    if (data.hasReport || data.policyAutoSubmit) {
+      this.hasReport = !data.policyAutoSubmit;
       document.documentElement.classList.add("crashDumpAvailable");
 
       document.getElementById("sendReport").checked = data.sendReport;
       document.getElementById("includeURL").checked = data.includeURL;
 
-      this.showCrashReportUI(data.sendReport);
+      if (data.policyAutoSubmit) {
+        // Report is automatically sent, hide default title and message
+        // and disable reporting options since there's no report to customize.
+        document.getElementById("crashedRequestHelp").hidden = true;
+        document.getElementById("requestAutoSubmit").hidden = true;
+        document.getElementById("comments").hidden = true;
+        document.getElementById("sendReport").disabled = true;
+        document.getElementById("includeURL").disabled = true;
+        document.getElementById("autoSubmit").disabled = true;
+
+        // Show the policy-based title and message.
+        document.getElementById("policyAutoSubmitTitle").hidden = false;
+        document.getElementById("policyAutoSubmitMessage").hidden = false;
+      }
+
+      this.showCrashReportUI(data.policyAutoSubmit || data.sendReport);
     } else {
       this.showCrashReportUI(false);
     }

--- a/browser/base/content/aboutTabCrashed.xhtml
+++ b/browser/base/content/aboutTabCrashed.xhtml
@@ -33,6 +33,7 @@
     />
     <link rel="localization" href="branding/brand.ftl" />
     <link rel="localization" href="browser/aboutTabCrashed.ftl" />
+    <link rel="localization" href="browser/enterprise/enterprise.ftl" />
 
     <title data-l10n-id="crashed-title"></title>
   </head>
@@ -56,10 +57,20 @@
       </div>
 
       <div id="reportBox">
-        <h2 data-l10n-id="crashed-request-help"></h2>
+        <h2 id="crashedRequestHelp" data-l10n-id="crashed-request-help"></h2>
+        <h2
+          id="policyAutoSubmitTitle"
+          data-l10n-id="crashed-policy-auto-submit-title"
+          hidden="true"
+        ></h2>
         <p data-l10n-id="crashed-request-help-message"></p>
 
         <h2 data-l10n-id="crashed-request-report-title"></h2>
+        <p
+          id="policyAutoSubmitMessage"
+          data-l10n-id="crashed-policy-auto-submit-message"
+          hidden="true"
+        ></p>
 
         <label class="toggle-container-with-text">
           <input type="checkbox" id="sendReport" role="checkbox" />

--- a/browser/components/enterprise/EnterpriseHandler.sys.mjs
+++ b/browser/components/enterprise/EnterpriseHandler.sys.mjs
@@ -148,7 +148,8 @@ export const EnterpriseHandler = {
     const email = document.querySelector(".panelUI-enterprise__email");
     if (!this._signedInUser) {
       email.hidden = true;
-      document.querySelector("#PanelUI-enterprise-separator").hidden = true;
+      document.querySelector("#PanelUI-enterprise-email-separator").hidden =
+        true;
       console.warn(
         "Unable to update email in enterprise panel without user information"
       );

--- a/browser/components/enterprise/EnterpriseHandler.sys.mjs
+++ b/browser/components/enterprise/EnterpriseHandler.sys.mjs
@@ -79,9 +79,9 @@ export const EnterpriseHandler = {
       window.PanelUI.showSubView("panelUI-lockdown-mode", button, event);
     });
 
-    window.gBrowser.addTabsProgressListener({
-      onLocationChange(browser, _webProgress, _request, location) {
-        if (browser !== window.gBrowser.selectedBrowser) {
+    window.gBrowser.addProgressListener({
+      onLocationChange(webProgress, _request, location) {
+        if (!webProgress.isTopLevel) {
           return;
         }
         let isLockedDown = false;

--- a/browser/components/enterprise/EnterpriseHandler.sys.mjs
+++ b/browser/components/enterprise/EnterpriseHandler.sys.mjs
@@ -25,6 +25,7 @@ ChromeUtils.defineLazyGetter(lazy, "log", () => {
 });
 
 const PROMPT_ON_SIGNOUT_PREF = "enterprise.promptOnSignout";
+const LOGO_URL = "enterprise.logo_url";
 
 export const EnterpriseHandler = {
   /**
@@ -96,11 +97,13 @@ export const EnterpriseHandler = {
   },
 
   /**
-   * Updates the user icon
+   * Updates the user icon and badge logo
    *
    * @param {Window} window chrome window
    */
   updateBadge(window) {
+    this._updateLogo(window);
+
     const userIcon = window.document.querySelector("#enterprise-user-icon");
 
     if (!this._signedInUser) {
@@ -236,5 +239,39 @@ export const EnterpriseHandler = {
   uninit() {
     this._signedInUser = {};
     this._isInitialized = false;
+  },
+
+  _updateLogo(window) {
+    const logoUrl = Services.prefs.getStringPref(LOGO_URL, "");
+
+    if (!logoUrl) {
+      console.warn(`${LOGO_URL} pref is not set, skipping logo update`);
+      return;
+    }
+
+    let validLogoUrl;
+    try {
+      validLogoUrl = new URL(logoUrl);
+    } catch {
+      throw new Error(`Invalid logo URL in pref: ${logoUrl}`);
+    }
+
+    if (validLogoUrl.protocol === "https:") {
+      if (validLogoUrl.origin !== lazy.ConsoleClient.consoleBaseURI.origin) {
+        throw new Error(`Logo URL must be hosted from the console: ${logoUrl}`);
+      }
+    } else if (
+      !/^data:image\/(?:png|jpeg|gif|webp|svg\+xml);base64,/.test(logoUrl)
+    ) {
+      throw new Error(`Invalid logo URL in pref: ${logoUrl}`);
+    }
+
+    const toolbarLogo = window.document.querySelector(
+      "#enterprise-company-logo__wrapper > image"
+    );
+    toolbarLogo.style.setProperty(
+      "list-style-image",
+      `url("${validLogoUrl.href}")`
+    );
   },
 };

--- a/browser/components/enterprise/content/enterprise-badge.css
+++ b/browser/components/enterprise/content/enterprise-badge.css
@@ -19,6 +19,8 @@
 }
 
 #enterprise-badge-toolbar-button {
+  flex-shrink: 0;
+
   &:focus-visible {
     outline: none;
 
@@ -40,7 +42,6 @@
   padding: var(--space-xxsmall) var(--space-xsmall);
   align-items: center;
   gap: var(--space-small);
-  flex-shrink: 0;
 
   border-radius: var(--border-radius-medium);
   /* stylelint-disable-next-line stylelint-plugin-mozilla/use-design-tokens */
@@ -59,10 +60,10 @@
 #enterprise-company-logo__wrapper {
   /* stylelint-disable-next-line stylelint-plugin-mozilla/use-design-tokens */
   max-width: 80px;
-  max-height: var(--size-item-medium);
+  /* stylelint-disable-next-line stylelint-plugin-mozilla/use-design-tokens */
+  height: var(--size-item-medium);
   justify-content: center;
   align-items: center;
-  flex-shrink: 0;
 
   > image {
     width: 100%;

--- a/browser/components/enterprise/content/enterprise-panel.inc.xhtml
+++ b/browser/components/enterprise/content/enterprise-panel.inc.xhtml
@@ -8,7 +8,7 @@
   <vbox class="panel-subview-body panelUI-enterprise__main-frame">
     <html:div class="panelUI-enterprise__email"></html:div>
 
-    <toolbarseparator id="PanelUI-enterprise-separator" />
+    <toolbarseparator id="PanelUI-enterprise-email-separator" />
 
     <vbox class="panelUI-enterprise__info-frame">
       <hbox class="panelUI-enterprise__alert">
@@ -19,7 +19,7 @@
       <html:a id="enterprise-learn-more-link" class="learnMore" data-l10n-id="enterprise-panel-learn-more" />
     </vbox>
 
-    <toolbarseparator id="PanelUI-enterprise-separator" />
+    <toolbarseparator id="PanelUI-enterprise-info-separator" />
 
     <toolbarbutton class="subviewbutton panelUI-enterprise__sign-out-btn closemenu"
       data-l10n-id="enterprise-panel-sign-out-btn" command="cmd_signoutEnterpriseUser"/>

--- a/browser/components/enterprise/modules/ConsoleClient.sys.mjs
+++ b/browser/components/enterprise/modules/ConsoleClient.sys.mjs
@@ -118,7 +118,6 @@ export const ConsoleClient = {
       SSO: "/sso/login",
       SIGNOUT: "/sso/logout",
       SSO_CALLBACK: "/sso/callback",
-      STARTUP_PREFS: "/api/browser/hacks/startup",
       DEFAULT_PREFS: "/api/browser/hacks/default",
       REMOTE_POLICIES: "/api/browser/policies",
       KEY: "/api/browser/key",
@@ -191,13 +190,6 @@ export const ConsoleClient = {
     url.pathname = this._paths.SSO_CALLBACK;
     url.port = "";
     return url.href + "?*";
-  },
-
-  // prefs that needs to be read at startup, i.e., written to profile's prefs.js
-  // tbd: remove
-  async getStartupPrefs() {
-    const payload = await this._get(this._paths.STARTUP_PREFS);
-    return payload;
   },
 
   // prefs that do not need to be written and can be sent during runtime

--- a/browser/components/enterprise/modules/Updates.sys.mjs
+++ b/browser/components/enterprise/modules/Updates.sys.mjs
@@ -23,6 +23,8 @@ export const Updates = {
     this._errorReporter = errorReporter;
 
     this.maybeShowUpdateSuccess();
+    // Check this early to avoid re-downloading updates when it would fail
+    await this.updateCheckingAllowed();
 
     if (this._initialized) {
       this.displayLoginState();
@@ -38,7 +40,9 @@ export const Updates = {
 
     this._checkingTimeout = null;
     this._receivedStaging = false;
-    this.displayUpdateState();
+    if (this._canDoUpdateChecking) {
+      this.displayUpdateState();
+    }
 
     if (lazy.isUpdatesTesting()) {
       // on Windows at least, during testing, make sure we let time for the UI to show up
@@ -52,6 +56,14 @@ export const Updates = {
     this.forceUpdateCheck();
 
     this._initialized = true;
+  },
+
+  uninit() {
+    this.unobserve();
+    this.cancelDelayedUpdateCheckUI();
+    this._document = undefined;
+    this._errorReporter = undefined;
+    this._initialized = false;
   },
 
   maybeShowUpdateSuccess() {
@@ -73,6 +85,44 @@ export const Updates = {
     );
   },
 
+  async updateCheckingAllowed() {
+    const UM = Cc["@mozilla.org/updates/update-manager;1"].getService(
+      Ci.nsIUpdateManager
+    );
+    // History is limited to 10 items, each install attempt should report a failure
+    const history = await UM.getHistory().catch(ex => {
+      console.error(`FeltUpdates: updateCheckingAllowed failed`, ex);
+      return null;
+    });
+    if (history) {
+      // The UpdaterManager history's capped at 10 max.
+      const maxConsecutiveUpdateFailures = Math.min(
+        Services.prefs.getIntPref(
+          "enterprise.felt.max_consecutive_update_failure",
+          3
+        ),
+        10
+      );
+      const firstNonFailed = history.findIndex(
+        update => update.state !== "failed"
+      );
+      const consecutiveUpdateFailures =
+        firstNonFailed === -1 ? history.length : firstNonFailed;
+      console.warn(
+        `FeltUpdates: updateCheckingAllowed: ${consecutiveUpdateFailures}, max ${maxConsecutiveUpdateFailures}`
+      );
+      if (consecutiveUpdateFailures > maxConsecutiveUpdateFailures) {
+        console.warn(
+          `FeltUpdates: updateCheckingAllowed: skip startup update check because consecutive update failures: ${consecutiveUpdateFailures}, max ${maxConsecutiveUpdateFailures}`
+        );
+        this._canDoUpdateChecking = false;
+        return;
+      }
+    }
+
+    this._canDoUpdateChecking = true;
+  },
+
   prepareUpdateCheck() {
     this._appUpdater = new lazy.AppUpdater();
     this._updaterCallback = this.appUpdaterCallback.bind(this);
@@ -83,10 +133,21 @@ export const Updates = {
   },
 
   forceUpdateCheck() {
+    if (this._canDoUpdateChecking !== true) {
+      console.warn(
+        `FeltUpdates: forceUpdateCheck(): skip because previous updates failures`
+      );
+      this.displayLoginStateWithUpdateError("contact-admin");
+      return;
+    }
+
     this._appUpdater
       .check()
       .catch(err => {
-        console.error(`AppUpdater failure: ${err}`, err);
+        console.error(
+          `Felt: forceUpdateCheck(): AppUpdater failure: ${err}`,
+          err
+        );
         this.displayLoginStateWithUpdateError("contact-admin");
       })
       .finally(() => {
@@ -276,6 +337,13 @@ export const Updates = {
       });
   },
 
+  unobserve() {
+    Services.obs.removeObserver(this, "update-staged");
+    Services.obs.removeObserver(this, "update-downloaded");
+    Services.obs.removeObserver(this, "update-error");
+    Services.obs.removeObserver(this, "xpcom-shutdown");
+  },
+
   observe(subject, topic, state) {
     // We would coerce subject
     //   update = subject && subject.QueryInterface(Ci.nsIUpdate);
@@ -284,10 +352,7 @@ export const Updates = {
     console.warn(`FeltUpdates: observer: topic:${topic} state:${state}`);
     switch (topic) {
       case "xpcom-shutdown":
-        Services.obs.removeObserver(this, "update-staged");
-        Services.obs.removeObserver(this, "update-downloaded");
-        Services.obs.removeObserver(this, "update-error");
-        Services.obs.removeObserver(this, "xpcom-shutdown");
+        this.unobserve();
         break;
       case "update-staged":
       case "update-downloaded":

--- a/browser/components/enterprise/tests/browser/browser_lockdown_mode_page_action.js
+++ b/browser/components/enterprise/tests/browser/browser_lockdown_mode_page_action.js
@@ -111,6 +111,37 @@ add_task(async function test_button_toggles_with_navigation() {
   });
 });
 
+add_task(async function test_button_hidden_when_switching_to_non_locked_tab() {
+  await setupWithSitePolicies();
+
+  let lockedTab = await BrowserTestUtils.openNewForegroundTab(
+    gBrowser,
+    LOCKED_URL
+  );
+  Assert.ok(
+    !getLockdownUrlbarButton().hidden,
+    "Urlbar button should be visible on a locked-down page"
+  );
+
+  let unlockedTab = await BrowserTestUtils.openNewForegroundTab(
+    gBrowser,
+    UNLOCKED_URL
+  );
+  Assert.ok(
+    getLockdownUrlbarButton().hidden,
+    "Urlbar button should be hidden after switching to a non-locked-down tab"
+  );
+
+  await BrowserTestUtils.switchTab(gBrowser, lockedTab);
+  Assert.ok(
+    !getLockdownUrlbarButton().hidden,
+    "Urlbar button should be visible after switching back to locked-down tab"
+  );
+
+  BrowserTestUtils.removeTab(lockedTab);
+  BrowserTestUtils.removeTab(unlockedTab);
+});
+
 add_task(async function test_button_position() {
   await setupWithSitePolicies();
 

--- a/browser/components/enterprisepolicies/Policies.sys.mjs
+++ b/browser/components/enterprisepolicies/Policies.sys.mjs
@@ -1009,6 +1009,26 @@ export var Policies = {
     },
   },
 
+  CrashReportsSubmit: {
+    onBeforeAddons(_manager, param) {
+      if (param.ForceAutoSubmit) {
+        setAndLockPref("browser.crashReports.unsubmittedCheck.enabled", true);
+        setAndLockPref(
+          "browser.crashReports.unsubmittedCheck.autoSubmit2",
+          true
+        );
+        setAndLockPref("browser.tabs.crashReporting.sendReport", true);
+        setAndLockPref("browser.tabs.crashReporting.includeURL", true);
+      }
+    },
+    onRemove(_manager, _oldParam) {
+      unsetAndUnlockPref("browser.crashReports.unsubmittedCheck.enabled");
+      unsetAndUnlockPref("browser.crashReports.unsubmittedCheck.autoSubmit2");
+      unsetAndUnlockPref("browser.tabs.crashReporting.sendReport");
+      unsetAndUnlockPref("browser.tabs.crashReporting.includeURL");
+    },
+  },
+
   DefaultDownloadDirectory: {
     onBeforeAddons(manager, param) {
       PoliciesUtils.setDefaultPref(

--- a/browser/components/enterprisepolicies/schemas/policies-schema.json
+++ b/browser/components/enterprisepolicies/schemas/policies-schema.json
@@ -452,6 +452,15 @@
       }
     },
 
+    "CrashReportsSubmit": {
+      "type": "object",
+      "properties": {
+        "ForceAutoSubmit": {
+          "type": "boolean"
+        }
+      }
+    },
+
     "DefaultDownloadDirectory": {
       "type": "string"
     },

--- a/browser/components/tests/marionette/test_no_errors_clean_profile.py
+++ b/browser/components/tests/marionette/test_no_errors_clean_profile.py
@@ -83,6 +83,7 @@ known_errors = [
     },
     {"message": "FeltExtension: _refreshSession()"},
     {"message": "Unable to update user icon in badge without user information"},
+    {"message": "enterprise.logo_url pref is not set, skipping logo update"},
 ]
 
 # Same rules apply here - please don't add anything! - but headless runs

--- a/browser/extensions/felt/api.js
+++ b/browser/extensions/felt/api.js
@@ -202,6 +202,10 @@ this.felt = class extends ExtensionAPI {
       await lazy.FeltStorage.init();
       this.showWindow();
       Services.ppmm.addMessageListener("FeltParent:FirefoxNormalExit", this);
+      Services.ppmm.addMessageListener(
+        "FeltParent:FirefoxRestartUpdateExit",
+        this
+      );
       Services.ppmm.addMessageListener("FeltParent:FirefoxLogoutExit", this);
       Services.ppmm.addMessageListener("FeltParent:FirefoxAbnormalExit", this);
       Services.ppmm.addMessageListener(
@@ -240,6 +244,17 @@ this.felt = class extends ExtensionAPI {
           Services.felt.makeBackgroundProcess(false);
           this.showWindow();
         }
+        break;
+      }
+
+      case "FeltParent:FirefoxRestartUpdateExit": {
+        Services.ppmm.removeMessageListener(
+          "FeltParent:FirefoxRestartUpdateExit",
+          this
+        );
+        Services.startup.quit(
+          Ci.nsIAppStartup.eAttemptQuit | Ci.nsIAppStartup.eRestart
+        );
         break;
       }
 

--- a/browser/extensions/felt/content/FeltProcessParent.sys.mjs
+++ b/browser/extensions/felt/content/FeltProcessParent.sys.mjs
@@ -147,48 +147,86 @@ export class FeltProcessParent extends JSProcessActorParent {
               "enterprise.disable_restart",
               false
             );
-            console.debug(
-              `FeltExtension: ParentProcess: restart notification, restartDisabled=${restartDisabled}`
+
+            const UM = Cc["@mozilla.org/updates/update-manager;1"].getService(
+              Ci.nsIUpdateManager
             );
-            // Kill Firefox directly instead of broadcasting to receiveMessage()
-            // since gFeltProcessParentInstance is accessible here
-            if (gFeltProcessParentInstance?.proc) {
-              gFeltProcessParentInstance.restartReported = true;
-              gFeltProcessParentInstance.firefox = null;
-              console.debug(
-                `FeltExtension: ParentProcess: Killing Firefox PID=${gFeltProcessParentInstance.proc.pid}`
-              );
-              gFeltProcessParentInstance.proc
-                .kill()
-                .then(() => {
+            UM.getReadyUpdate()
+              .then(readyUpdate => {
+                let pendingUpdate = false;
+                if (readyUpdate) {
+                  // Updates states when restarting will finish the update
+                  const readyStates = [
+                    "pending",
+                    "pending-service",
+                    "pending-elevate",
+                    "applied",
+                    "applied-service",
+                  ];
+                  pendingUpdate = readyStates.includes(readyUpdate.state);
+                }
+                return pendingUpdate;
+              })
+              .catch(err => {
+                console.debug(
+                  `FeltExtension: ParentProcess: getReadyUpdate failed: ${err}`
+                );
+              })
+              .then(pendingUpdate => {
+                console.debug(
+                  `FeltExtension: ParentProcess: restart notification, restartDisabled=${restartDisabled}`
+                );
+                // Kill Firefox directly instead of broadcasting to receiveMessage()
+                // since gFeltProcessParentInstance is accessible here
+                if (gFeltProcessParentInstance?.proc) {
+                  gFeltProcessParentInstance.restartReported = true;
+                  gFeltProcessParentInstance.firefox = null;
                   console.debug(
-                    `FeltExtension: ParentProcess: Killed Firefox, restartDisabled=${restartDisabled}`
+                    `FeltExtension: ParentProcess: Killing Firefox PID=${gFeltProcessParentInstance.proc.pid}`
                   );
-                  if (!restartDisabled) {
-                    console.debug(
-                      `FeltExtension: ParentProcess: Starting new Firefox`
-                    );
-                    gFeltProcessParentInstance.startFirefox(
-                      PROCESS_START_REASON.RESTART
-                    );
-                  } else {
-                    console.debug(
-                      `FeltExtension: ParentProcess: Restart disabled, sending normal exit to restore FELT UI`
-                    );
-                    Services.cpmm.sendAsyncMessage(
-                      "FeltParent:FirefoxNormalExit",
-                      {}
-                    );
-                  }
-                })
-                .catch(err => {
+                  gFeltProcessParentInstance.proc
+                    .kill()
+                    .then(() => {
+                      console.debug(
+                        `FeltExtension: ParentProcess: Killed Firefox, restartDisabled=${restartDisabled}`
+                      );
+
+                      if (!restartDisabled && !pendingUpdate) {
+                        console.debug(
+                          `FeltExtension: ParentProcess: Starting new Firefox`
+                        );
+                        gFeltProcessParentInstance.startFirefox(
+                          PROCESS_START_REASON.RESTART
+                        );
+                      } else if (pendingUpdate) {
+                        console.debug(
+                          `FeltExtension: ParentProcess: Restart requested and pending update, restarting FELT UI`
+                        );
+                        Services.cpmm.sendAsyncMessage(
+                          "FeltParent:FirefoxRestartUpdateExit",
+                          {}
+                        );
+                      } else {
+                        console.debug(
+                          `FeltExtension: ParentProcess: Restart disabled, sending normal exit to restore FELT UI`
+                        );
+                        Services.cpmm.sendAsyncMessage(
+                          "FeltParent:FirefoxNormalExit",
+                          {}
+                        );
+                      }
+                    })
+                    .catch(err => {
+                      console.debug(
+                        `FeltExtension: ParentProcess: Kill failed: ${err}`
+                      );
+                    });
+                } else {
                   console.debug(
-                    `FeltExtension: ParentProcess: Kill failed: ${err}`
+                    `FeltExtension: ParentProcess: No proc to kill!`
                   );
-                });
-            } else {
-              console.debug(`FeltExtension: ParentProcess: No proc to kill!`);
-            }
+                }
+              });
             break;
           }
           case "felt-extension-ready": {

--- a/browser/extensions/felt/content/FeltProcessParent.sys.mjs
+++ b/browser/extensions/felt/content/FeltProcessParent.sys.mjs
@@ -263,41 +263,6 @@ export class FeltProcessParent extends JSProcessActorParent {
     };
   }
 
-  sanitizePrefs(prefs) {
-    let sanitized = [];
-    prefs?.forEach(pref => {
-      const name = JSON.stringify(pref[0]);
-      console.debug(`Felt: sanitizePrefs() ${pref[0]} => ${name})`);
-      let value = pref[1];
-      switch (typeof pref[1]) {
-        case "string":
-          value = JSON.stringify(value);
-          break;
-
-        case "boolean":
-          break;
-
-        case "number":
-          if (!Number.isInteger(pref[1])) {
-            value = `"${pref[1]}"`;
-          } else {
-            value = Number(pref[1]);
-          }
-          break;
-
-        default:
-          console.warn(`Pref ${pref[0]} with value '${pref[1]}' not valid`);
-          value = null;
-          break;
-      }
-
-      if (value !== null) {
-        sanitized.push([name, value]);
-      }
-    });
-    return sanitized;
-  }
-
   sendPrefsToFirefox() {
     Services.felt.sendStringPreference(
       lazy.PREFS.CONSOLE_ADDRESS,
@@ -308,10 +273,6 @@ export class FeltProcessParent extends JSProcessActorParent {
     Services.felt.sendBoolPreference(
       "browser.policies.live_polling.enabled",
       true
-    );
-    Services.felt.sendIntPreference(
-      "browser.policies.live_polling.frequency",
-      lazy.FeltCommon.POLICY_POLLING_FREQUENCY
     );
   }
 
@@ -350,7 +311,6 @@ export class FeltProcessParent extends JSProcessActorParent {
         Services.felt.sendTokens();
         lazy.ConsoleClient.isSessionRefreshBlocked = true;
 
-        // Gets sync tokenserver uri from the console amongst other prefs
         const { prefs } = await lazy.ConsoleClient.getDefaultPrefs();
         prefs.forEach(pref => {
           const name = pref[0];
@@ -546,20 +506,6 @@ export class FeltProcessParent extends JSProcessActorParent {
     if (Services.felt.isFeltSafeMode()) {
       extraRunArgs.push("--safe-mode");
     }
-
-    const prefsJsFile = PathUtils.join(profilePath, "prefs.js");
-    let prefsJsContent = "";
-    if (await IOUtils.exists(prefsJsFile)) {
-      prefsJsContent = await IOUtils.readUTF8(prefsJsFile);
-    }
-
-    const startupPrefs = (await lazy.ConsoleClient.getStartupPrefs()).prefs;
-    this.sanitizePrefs(startupPrefs).forEach(pref => {
-      prefsJsContent += `\nuser_pref(${pref[0]}, ${pref[1]});`;
-    });
-    prefsJsContent += "\n";
-
-    await IOUtils.writeUTF8(prefsJsFile, prefsJsContent);
 
     const firefoxRunArgs = [
       "--foreground",

--- a/browser/extensions/felt/content/window.js
+++ b/browser/extensions/felt/content/window.js
@@ -290,6 +290,7 @@ async function connectToConsole(email) {
   );
 
   ErrorReport.reset();
+  document.querySelector(".felt-updates-message").classList.add("is-hidden");
   document.querySelector(".felt-login__email-pane").classList.add("is-hidden");
   document.querySelector(".felt-login__sso").classList.remove("is-hidden");
 

--- a/browser/extensions/felt/content/window.js
+++ b/browser/extensions/felt/content/window.js
@@ -312,8 +312,6 @@ async function listenFormEmailSubmission() {
     signInBtn.disabled = emailInput.value.trim() === "";
   });
 
-  emailInput.focus();
-
   // <moz-button> does not trigger the native "submit" event on <form>
   // so we manually handle submission on button click and when Enter is pressed
   signInBtn.addEventListener("click", () => {
@@ -473,6 +471,25 @@ function setupPopupNotifications() {
   });
 }
 
+// Focus the email input whenever the login pane becomes visible. A
+// MutationObserver is used because Updates.init() may hide the login pane
+// during its update check and only show it again once the check completes,
+// so a direct focus() call at startup would fire while the pane is hidden.
+function focusEmailOnLoginVisible() {
+  const loginPane = document.querySelector(".felt-login");
+  const emailInput = document.getElementById("felt-form__email");
+
+  new MutationObserver(() => {
+    if (!loginPane.classList.contains("is-hidden")) {
+      emailInput?.focus();
+    }
+  }).observe(loginPane, { attributeFilter: ["class"] });
+
+  if (!loginPane.classList.contains("is-hidden")) {
+    emailInput?.focus();
+  }
+}
+
 window.addEventListener(
   "load",
   () => {
@@ -482,6 +499,7 @@ window.addEventListener(
     setupPopupNotifications();
     setupContextMenu();
     listenFormEmailSubmission();
+    focusEmailOnLoginVisible();
     informAboutPotentialStartupFailure();
   },
   true

--- a/browser/locales/en-US/browser/enterprise/enterprise-policies-descriptions.ftl
+++ b/browser/locales/en-US/browser/enterprise/enterprise-policies-descriptions.ftl
@@ -7,3 +7,4 @@ policy-DownloadTelemetry = Enable and configure security logging/telemetry when 
 policy-EnterpriseStorageEncryption = Enable enterprise-managed primary password for encrypted storage.
 policy-PrintPageTelemetry = Enable and configure security logging/telemetry when a page is printed.
 policy-Sync = Enable or disable sync and define which data to include.
+policy-CrashReportsSubmit = Configure crash report submission settings.

--- a/browser/locales/en-US/browser/enterprise/enterprise.ftl
+++ b/browser/locales/en-US/browser/enterprise/enterprise.ftl
@@ -50,3 +50,6 @@ enterprise-access-connector-button =
   .tooltiptext = Access Connector
 enterprise-access-connector-status-label-active = active
 enterprise-access-connector-status-label-inactive = inactive
+
+crashed-policy-auto-submit-title = Crash reports help us improve
+crashed-policy-auto-submit-message = Your administrator has configured { -brand-short-name } to send crash reports automatically.

--- a/browser/modules/ContentCrashHandlers.sys.mjs
+++ b/browser/modules/ContentCrashHandlers.sys.mjs
@@ -531,6 +531,18 @@ export var TabCrashHandler = {
    *        The browser that has recently crashed.
    */
   sendToTabCrashedPage(browser) {
+    if (
+      AppConstants.MOZ_CRASHREPORTER &&
+      Services.policies.getActivePolicies()?.CrashReportsSubmit?.ForceAutoSubmit
+    ) {
+      let dumpID = this.getDumpID(browser);
+      if (dumpID) {
+        lazy.CrashSubmit.submit(dumpID, lazy.CrashSubmit.SUBMITTED_FROM_AUTO);
+        let childID = this.browserMap.get(browser);
+        this.childMap.set(childID, null); // Avoid resubmission from about:tabcrashed.
+      }
+    }
+
     let title = browser.contentTitle;
     let uri = browser.currentURI;
     let gBrowser = browser.getTabBrowser();

--- a/browser/modules/ContentCrashHandlers.sys.mjs
+++ b/browser/modules/ContentCrashHandlers.sys.mjs
@@ -690,7 +690,12 @@ export var TabCrashHandler = {
     }
 
     let dumpID = this.getDumpID(browser);
-    if (!dumpID) {
+    let policyAutoSubmit =
+      !!Services.policies.getActivePolicies()?.CrashReportsSubmit
+        ?.ForceAutoSubmit;
+    // When ForceAutoSubmit is active, the crash report is submitted automatically
+    // at crash time, so no dumpID is available. Allow the flow to continue.
+    if (!dumpID && !policyAutoSubmit) {
       return {
         hasReport: false,
       };
@@ -700,14 +705,23 @@ export var TabCrashHandler = {
     let sendReport = this.prefs.getBoolPref("sendReport");
     let includeURL = this.prefs.getBoolPref("includeURL");
 
-    let data = {
+    // With ForceAutoSubmit, the report was already submitted so we skip the
+    // normal report UI, but still signal the policy state to the crash page.
+    if (policyAutoSubmit) {
+      return {
+        hasReport: false,
+        policyAutoSubmit,
+        sendReport,
+        includeURL,
+      };
+    }
+
+    return {
       hasReport: true,
       sendReport,
       includeURL,
       requestAutoSubmit,
     };
-
-    return data;
   },
 
   onAboutTabCrashedUnload(browser) {

--- a/testing/enterprise/base_test.py
+++ b/testing/enterprise/base_test.py
@@ -37,7 +37,7 @@ class EnterpriseTestsBase(MarionetteTestCase):
             self.marionette.instance.app_args += self._extra_cli_args
 
         self.marionette.quit(in_app=False, clean=True)
-        self.marionette.start_session()
+        self.marionette.start_session(timeout=60)
 
         if hasattr(self, "_extra_prefs"):
             self.marionette.enforce_gecko_prefs(self._extra_prefs)
@@ -137,7 +137,7 @@ class EnterpriseTestsBase(MarionetteTestCase):
         assert marionette_port != 2828, "Marionette port should not be default value"
 
         self._child_driver = Marionette(host="127.0.0.1", port=new_marionette_port)
-        self._child_driver.start_session(capabilities)
+        self._child_driver.start_session(capabilities, timeout=60)
 
     def get_driver(self, env):
         return self._driver if env == Environment.FELT else self._child_driver

--- a/testing/enterprise/base_test.py
+++ b/testing/enterprise/base_test.py
@@ -135,9 +135,24 @@ class EnterpriseTestsBase(MarionetteTestCase):
         self._logger.info(f"Marionette PORT NEW: {new_marionette_port}")
         assert marionette_port == new_marionette_port, "STILL Valid marionette port"
         assert marionette_port != 2828, "Marionette port should not be default value"
+        self._logger.info(f"Marionette PORT NEW: {new_marionette_port} OK")
 
+        self._logger.info(f"New Marionette port={new_marionette_port}")
         self._child_driver = Marionette(host="127.0.0.1", port=new_marionette_port)
+        self._logger.info(f"New Marionette port={new_marionette_port} OK")
         self._child_driver.start_session(capabilities, timeout=60)
+        self._logger.info(f"New Marionette port={new_marionette_port} OK SESSION")
+
+        port_file_copy = f"{marionette_port_file}.bak"
+        self._logger.info(
+            f"New Marionette port={new_marionette_port} MOVE OUT {marionette_port_file}"
+        )
+        if os.path.isfile(port_file_copy):
+            os.unlink(port_file_copy)
+        os.rename(marionette_port_file, port_file_copy)
+        self._logger.info(
+            f"New Marionette MOVED OUT {marionette_port_file} TO {port_file_copy}"
+        )
 
     def get_driver(self, env):
         return self._driver if env == Environment.FELT else self._child_driver

--- a/testing/enterprise/felt_browser_crashes.py
+++ b/testing/enterprise/felt_browser_crashes.py
@@ -35,7 +35,7 @@ class BrowserCrashes(FeltTests):
 
     def run_felt_proper_restart(self):
         self._manually_closed_child = False
-        self.wait_process_exit()
+        self.wait_process_exit(self._browser_pid)
         self._logger.info("Connecting to new browser")
         self.connect_child_browser()
         self._browser_pid = self._child_driver.session_capabilities["moz:processID"]

--- a/testing/enterprise/felt_browser_starts.py
+++ b/testing/enterprise/felt_browser_starts.py
@@ -37,8 +37,8 @@ class FeltStartsBrowser(FeltTests):
             f"Cookie {self.cookie_name} was properly set on Firefox started by FELT"
         )
 
-    def run_felt_verify_prefs(self):
-        for pref in felt_consts.live_prefs + felt_consts.userjs_prefs:
+    def run_ensure_config_prefs_set_in_browser(self):
+        for pref in felt_consts.config_prefs:
             value = self.get_pref_child(pref[0], self.python_type_to_js(pref[1]))
             assert value == pref[1], (
                 f"Mismatching pref {pref[0]} value {value} instead of {pref[1]}"

--- a/testing/enterprise/felt_consts.py
+++ b/testing/enterprise/felt_consts.py
@@ -4,14 +4,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 
-live_prefs = [
-    ["browser.sessionstore.restore_on_demand", False],
-    ["browser.sessionstore.resume_from_crash", False],
+config_prefs = [
     ["browser.policies.live_polling.frequency", 500],
-]
-
-userjs_prefs = [
-    ["devtools.browsertoolbox.scope", "everything"],
-    ["enterprise.console.test_float", 1.5],
-    ["enterprise.console.test_bool", True],
+    ["identity.sync.tokenserver.uri", ""],
 ]

--- a/testing/enterprise/felt_tests.py
+++ b/testing/enterprise/felt_tests.py
@@ -215,20 +215,18 @@ class ConsoleHttpHandler(LocalHttpRequestHandler):
             })
             contentType = "application/json"
 
+        elif path == "/api/browser/forced_updates_count":
+            """
+            This is a test only endpoint to verify how many updates were served
+            """
+
+            m = json.dumps({
+                "serve_forced_updates_count": self.server.serve_forced_updates_count
+            })
+            contentType = "application/json"
+
         # /api/browser/updates/FirefoxEnterprise/149.0a1/20260218134117/Linux_x86_64-gcc3/en-US/default/Linux%25206.17.0-8-generic%2520(GTK%25203.24.50%252Clibpulse%252017.0.0)/ISET%3ASSE4_2%2CMEM%3A85823/default/default/update.xml?force=1"
         elif path.startswith("/api/browser/updates"):
-            # Versions are important, they need to be equal or higher than the
-            # curernt binary otherwise no update will be downloaded
-            display_version = self.server.serve_updates_version["application_version"][
-                0
-            ]
-            app_version = self.server.serve_updates_version["application_version"][0]
-            platform_version = self.server.serve_updates_version["platform_version"][0]
-            # BuildID also needs to be different, fake it as newer
-            build_id = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
-            # Hash is not verified client side? At least we can put what we want
-            hash_value = "ecee0f4b9f0af06cfa3a89c328e4cbb7dd075a0d411ef1b968a072a7995a0753dd96d3d541f0781ab95fdb61e3df7252a9379fc620f2b660ecaed582f2c5246d"
-
             # Producing this requires:
             # $ mach build && mach package
             # then extract the tar somewhere, you have firefox/
@@ -239,6 +237,22 @@ class ConsoleHttpHandler(LocalHttpRequestHandler):
                 os.path.dirname(__file__), os.path.basename("complete.mar")
             )
             if self.server.serve_updates and os.path.isfile(complete_mar):
+                # Versions are important, they need to be equal or higher than the
+                # curernt binary otherwise no update will be downloaded
+                display_version = self.server.serve_updates_version[
+                    "application_version"
+                ][0]
+                app_version = self.server.serve_updates_version["application_version"][
+                    0
+                ]
+                platform_version = self.server.serve_updates_version[
+                    "platform_version"
+                ][0]
+                # BuildID also needs to be different, fake it as newer
+                build_id = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
+                # Hash is not verified client side? At least we can put what we want
+                hash_value = "ecee0f4b9f0af06cfa3a89c328e4cbb7dd075a0d411ef1b968a072a7995a0753dd96d3d541f0781ab95fdb61e3df7252a9379fc620f2b660ecaed582f2c5246d"
+
                 size = os.stat(complete_mar).st_size
                 m = f"""<?xml version="1.0"?>
 <updates>
@@ -248,6 +262,9 @@ class ConsoleHttpHandler(LocalHttpRequestHandler):
 </updates>"""
             else:
                 m = """<?xml version="1.0"?><updates></updates>"""
+
+            if "?force=1" in self.path:
+                self.server.serve_forced_updates_count += 1
 
             contentType = "text/xml"
 
@@ -382,6 +399,14 @@ class ConsoleHttpHandler(LocalHttpRequestHandler):
             self.check_auth()
             m = json.dumps(None)
 
+        elif path == "/api/browser/forced_updates_count":
+            """
+            This is a test only endpoint to reset how many updates were served
+            """
+
+            self.server.serve_forced_updates_count = 0
+            m = json.dumps(None)
+
         elif path.startswith("/api/browser/updates"):
             self.server.serve_updates = not self.server.serve_updates
             payload = self.rfile.read(int(self.headers.get("Content-Length"))).decode(
@@ -450,6 +475,7 @@ def serve(
         httpd.policy_refresh_token = policy_refresh_token
     httpd.serve_updates = False
     httpd.serve_updates_version = ""
+    httpd.serve_forced_updates_count = 0
     """
     TODO: Behavior is not yet clearly defined
     if device_posture_reply_forbidden is not None:

--- a/testing/enterprise/felt_tests.py
+++ b/testing/enterprise/felt_tests.py
@@ -238,7 +238,7 @@ class ConsoleHttpHandler(LocalHttpRequestHandler):
             )
             if self.server.serve_updates and os.path.isfile(complete_mar):
                 # Versions are important, they need to be equal or higher than the
-                # curernt binary otherwise no update will be downloaded
+                # current binary otherwise no update will be downloaded
                 display_version = self.server.serve_updates_version[
                     "application_version"
                 ][0]
@@ -679,31 +679,61 @@ class FeltTestsBase(EnterpriseTestsBase):
     def find_elem_child(self, e):
         return self._child_driver.find_element(By.CSS_SELECTOR, e)
 
-    def wait_process_exit(self):
-        self._logger.info("Waiting a few seconds ...")
-        if sys.platform == "win32":
-            time.sleep(8)
-        else:
-            time.sleep(3)
-        self._logger.info(f"Checking PID {self._browser_pid}")
-
+    def wait_process_exit(self, pid_to_check):
+        self._logger.info(f"Checking PID {pid_to_check}")
         import psutil
 
-        if not psutil.pid_exists(self._browser_pid):
-            self._logger.info(f"No more PID {self._browser_pid}")
-        else:
+        # Wait for a process termination
+        continue_checking = True
+        iterations = 0
+        while continue_checking and psutil.pid_exists(pid_to_check) and iterations < 30:
+            iterations += 1
+            self._logger.info(f"PID {pid_to_check} still exists")
+
             try:
-                process = psutil.Process(pid=self._browser_pid)
+                process = psutil.Process(pid=pid_to_check)
+                process_status = process.status()
+                self._logger.info(f"Found PID {pid_to_check}: STATUS:{process_status}")
+                continue_checking = process_status not in [
+                    psutil.STATUS_STOPPED,
+                    psutil.STATUS_ZOMBIE,
+                    psutil.STATUS_DEAD,
+                ]
+            except psutil.NoSuchProcess:
+                continue_checking = False
+            except psutil.ZombieProcess:
+                continue_checking = False
+
+            time.sleep(1)
+
+        self._logger.info(
+            f"Active waiting for PID {pid_to_check} DONE => continue_checking:{continue_checking} iterations:{iterations} psutil.pid_exists(pid_to_check):{psutil.pid_exists(pid_to_check)}"
+        )
+
+        if psutil.pid_exists(pid_to_check):
+            # Process is still not terminated, try to verify if it is still the same
+            # or if the PID was re-used.
+            try:
+                process = psutil.Process(pid=pid_to_check)
+                process_status = process.status()
                 process_name = process.name()
                 process_exe = process.exe()
                 process_basename = os.path.basename(process_name)
                 process_cmdline = process.cmdline()
                 self._logger.info(
-                    f"Found PID {self._browser_pid}: EXE:{process_exe} :: NAME:{process_name} :: CMDLINE:{process_cmdline} :: BASENAME:'{process_basename}'"
+                    f"Found PID {pid_to_check}: STATUS:{process_status} :: EXE:{process_exe} :: NAME:{process_name} :: CMDLINE:{process_cmdline} :: BASENAME:'{process_basename}'"
                 )
-                assert process_basename != "firefox", "Process is not Firefox"
+                # If process basename is not Firefox, then it is just PID re-use
+                assert not process_basename.startswith("firefox"), (
+                    f"Process PID {pid_to_check} should not be Firefox"
+                )
+            except psutil.NoSuchProcess:
+                self._logger.info(f"PID disappeared {pid_to_check}")
             except psutil.ZombieProcess:
-                self._logger.info(f"Zombie found as {self._browser_pid}")
+                # If it is a zombie, it is fine as well
+                self._logger.info(f"Zombie found as {pid_to_check}")
+
+        self._logger.info(f"All done for PID {pid_to_check}")
 
     def run_felt_base(self):
         self.run_felt_chrome_on_email_submit()

--- a/testing/enterprise/felt_tests.py
+++ b/testing/enterprise/felt_tests.py
@@ -155,20 +155,7 @@ class ConsoleHttpHandler(LocalHttpRequestHandler):
         elif path == "/api/browser/hacks/default":
             # Browser prefs that can be applied live
             m = json.dumps({
-                "prefs": felt_consts.live_prefs
-                + [
-                    [
-                        "identity.sync.tokenserver.uri",
-                        "https://ent-dev-tokenserver.sync.nonprod.webservices.mozgcp.net/1.0/sync/1.5",
-                    ]
-                ]
-            })
-            contentType = "application/json"
-        elif path == "/api/browser/hacks/startup":
-            # Browser prefs that needs to be set in the prefs.js file
-            m = json.dumps({
-                "prefs": felt_consts.userjs_prefs + [["marionette.port", 0]],
-            })
+                "prefs": felt_consts.config_prefs + [["marionette.port", 0]]})
             contentType = "application/json"
 
         elif path == "/api/browser/policies":

--- a/testing/enterprise/felt_tests.py
+++ b/testing/enterprise/felt_tests.py
@@ -155,7 +155,8 @@ class ConsoleHttpHandler(LocalHttpRequestHandler):
         elif path == "/api/browser/hacks/default":
             # Browser prefs that can be applied live
             m = json.dumps({
-                "prefs": felt_consts.config_prefs + [["marionette.port", 0]]})
+                "prefs": felt_consts.config_prefs + [["marionette.port", 0]]
+            })
             contentType = "application/json"
 
         elif path == "/api/browser/policies":

--- a/testing/enterprise/felt_tests.py
+++ b/testing/enterprise/felt_tests.py
@@ -3,6 +3,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import ctypes
 import datetime
 import json
 import os
@@ -13,15 +14,45 @@ import tempfile
 import time
 import urllib.parse
 import uuid
-from ctypes import c_wchar_p
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from multiprocessing import Manager, Process, Value
+from multiprocessing import Array, Process, Value
 
 import felt_consts
 import requests
 from base_test import EnterpriseTestsBase
 from marionette_driver import expected
 from marionette_driver.by import By
+
+
+class SharedString:
+    """Process-safe string backed by shared memory.
+
+    Replaces Manager.Value(c_wchar_p, ...) to avoid the Manager IPC path, which
+    pickles data into a memoryview. Under GC pressure that memoryview can be
+    collected while still exported, triggering a CPython bug (bpo-77894 /
+    cpython#123898) that crashes the Manager's ServerProxy processes.
+    Using a shared memory Array avoids all IPC and memoryview allocation.
+    """
+
+    _MAX_SIZE = 128
+
+    def __init__(self, initial=""):
+        self._array = Array(ctypes.c_char, self._MAX_SIZE)
+        self.value = initial
+
+    @property
+    def value(self):
+        with self._array.get_lock():
+            return self._array._obj.value.decode("utf-8")
+
+    @value.setter
+    def value(self, s):
+        encoded = s.encode("utf-8")
+        assert len(encoded) < self._MAX_SIZE, (
+            f"SharedString value too long: {len(encoded)} >= {self._MAX_SIZE}"
+        )
+        with self._array.get_lock():
+            self._array._obj.value = encoded
 
 
 class LocalHttpRequestHandler(BaseHTTPRequestHandler):
@@ -502,9 +533,8 @@ class FeltTestsBase(EnterpriseTestsBase):
         if hasattr(self, "EXTRA_PREFS"):
             self._extra_prefs.update(self.EXTRA_PREFS)
 
-        manager = Manager()
-        self.policy_access_token = manager.Value(c_wchar_p, str(uuid.uuid4()))
-        self.policy_refresh_token = manager.Value(c_wchar_p, str(uuid.uuid4()))
+        self.policy_access_token = SharedString(str(uuid.uuid4()))
+        self.policy_refresh_token = SharedString(str(uuid.uuid4()))
 
         self.console_httpd = Process(
             target=serve,
@@ -522,8 +552,8 @@ class FeltTestsBase(EnterpriseTestsBase):
         )
         self.console_httpd.start()
 
-        self.cookie_name = manager.Value(c_wchar_p, str(uuid.uuid1()).split("-")[0])
-        self.cookie_value = manager.Value(c_wchar_p, str(uuid.uuid4()).split("-")[4])
+        self.cookie_name = SharedString(str(uuid.uuid1()).split("-")[0])
+        self.cookie_value = SharedString(str(uuid.uuid4()).split("-")[4])
         self.sso_httpd = Process(
             target=serve,
             args=(self.sso_port, SsoHttpHandler),

--- a/testing/enterprise/felt_tests.py
+++ b/testing/enterprise/felt_tests.py
@@ -192,6 +192,9 @@ class ConsoleHttpHandler(LocalHttpRequestHandler):
 
         elif path == "/api/browser/policies":
             self.check_auth()
+            if self.server.policies_fail_request.value:
+                self.reply("", 500, "Internal Server Error", "application/json")
+                return
             policy_content = {}
             policy_value = (
                 False if self.server.policy_block_about_config.value == 0 else True
@@ -474,6 +477,7 @@ def serve(
     policy_extensions=None,
     policy_access_token=None,
     policy_refresh_token=None,
+    policies_fail_request=None,
     # TODO: Behavior is not yet clearly defined
     # device_posture_reply_forbidden=None,
 ):
@@ -492,6 +496,9 @@ def serve(
         httpd.policy_access_token = policy_access_token
     if policy_refresh_token:
         httpd.policy_refresh_token = policy_refresh_token
+    httpd.policies_fail_request = (
+        policies_fail_request if policies_fail_request is not None else Value("B", 0)
+    )
     httpd.serve_updates = False
     httpd.serve_updates_version = ""
     httpd.serve_forced_updates_count = 0
@@ -520,6 +527,7 @@ class FeltTestsBase(EnterpriseTestsBase):
         self.sso_port = random.randrange(15000, 20000)
         self.policy_block_about_config = Value("B", 1)
         self.policy_extensions = Value("B", 0)
+        self.policies_fail_request = Value("B", 0)
         """
         TODO: Behavior is not yet clearly defined
         self.device_posture_reply_forbidden = Value("B", 0)
@@ -546,6 +554,7 @@ class FeltTestsBase(EnterpriseTestsBase):
                 policy_extensions=self.policy_extensions,
                 policy_access_token=self.policy_access_token,
                 policy_refresh_token=self.policy_refresh_token,
+                policies_fail_request=self.policies_fail_request,
                 # TODO: Behavior is not yet clearly defined
                 # device_posture_reply_forbidden=self.device_posture_reply_forbidden,
             ),

--- a/testing/enterprise/felt_updater_errors.py
+++ b/testing/enterprise/felt_updater_errors.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import os
+import sys
+
+import requests
+
+sys.path.append(os.path.dirname(__file__))
+
+from felt_tests import FeltTests
+
+
+class FeltUpdaterErrorsBase(FeltTests):
+    def get_update_config_file_path(self):
+        self._driver.set_context("chrome")
+        rv = self._driver.execute_script(
+            """
+            const { UpdateUtils } = ChromeUtils.importESModule("resource://gre/modules/UpdateUtils.sys.mjs");
+            return UpdateUtils.getConfigFilePath();
+            """
+        )
+        self._driver.set_context("content")
+        return rv
+
+    def reload_chrome_window(self):
+        self._driver.set_context("chrome")
+        self._driver.execute_async_script(
+            """
+            const callback = arguments[arguments.length - 1];
+            const UM = Cc["@mozilla.org/updates/update-manager;1"].getService(Ci.nsIUpdateManager);
+            UM.internal.reload(false).then(() => {
+              const { Updates } = ChromeUtils.importESModule("resource:///modules/enterprise/Updates.sys.mjs");
+              Updates.uninit();
+              window.location.reload();
+            }).finally(() => callback());
+            """
+        )
+        self._driver.set_context("content")
+
+    def get_updates_served(self):
+        return requests.get(
+            f"http://localhost:{self.console_port}/api/browser/forced_updates_count"
+        ).json()["serve_forced_updates_count"]
+
+    def assert_updates_served(self, amount):
+        served = self.get_updates_served()
+        self._logger.info(f"Checking updates served: {amount} vs {served}")
+        self._wait.until(lambda mn: self.get_updates_served() == amount)
+        served = self.get_updates_served()
+        assert served == amount, (
+            f"There should have been {amount} update served but {served}"
+        )
+
+    def assert_updates_check_allowed(self, allowed):
+        self._driver.set_context("chrome")
+        rv = self._driver.execute_async_script(
+            """
+            const callback = arguments[arguments.length - 1];
+            const UM = Cc["@mozilla.org/updates/update-manager;1"].getService(Ci.nsIUpdateManager);
+            UM.internal.reload(false).then(() => {
+              const { Updates } = ChromeUtils.importESModule("resource:///modules/enterprise/Updates.sys.mjs");
+              Updates.updateCheckingAllowed().then(() => callback(Updates._canDoUpdateChecking));
+            });
+            """
+        )
+        self._driver.set_context("content")
+        print(f"assert_updates_check_allowed: {rv}")
+        assert rv == allowed, f"Update checks are {rv} but expected {allowed}"
+
+    def assert_error_displayed(self):
+        self._driver.set_context("chrome")
+
+        browser_error = self.get_elem(".felt-browser-error")
+        assert browser_error, "Error dialog present"
+
+        error_details = self.get_elem(
+            ".felt-updates-error-messages .felt-browser-error-details"
+        )
+        error_msg = error_details.text
+
+        self._driver.set_context("content")
+
+        assert error_msg == "Please contact your administrator.", (
+            "Should display a contact your administrator error message"
+        )
+
+    def reset_updates_served(self):
+        self._logger.info("Reset updates served")
+        requests.post(
+            f"http://localhost:{self.console_port}/api/browser/forced_updates_count"
+        )
+
+    def one_xml(self, state):
+        return f"""
+<update xmlns="http://www.mozilla.org/2005/app-update" appVersion="2000.0a1" buildID="22221010555555" channel="default" detailsURL="https://www.mozilla.org/en-US/firefox/notes" displayVersion="2000.0a1" platformVersion="2000.0a1" installDate="1773852795836" isCompleteUpdate="true" name="Firefox Enterprise 2000.0a1" previousAppVersion="150.0a1" promptWaitTime="691200" serviceURL="http://localhost:8000/api/browser/updates/FirefoxEnterprise/150.0a1/20260317000000/Darwin_aarch64-gcc3/en-US/default/Darwin%252025.3.0/ISET%3ANEON%2CMEM%3A24576/default/default/update.xml?force=1" type="major" statusText="Install Pending" foregroundDownload="true">
+  <patch size="83136062" type="complete" URL="http://localhost:8000/firefox-150.0a1.en-US.mac.complete.mar" errorCode="9" finalURL="http://localhost:8000/firefox-150.0a1.en-US.mac.complete.mar?backgroundTaskMode=0" selected="true" state="{state}" internalResult="0" numTotalInstallAttempts="1"/>
+</update>
+"""
+
+    def write_updates_xml(self, updates=None):
+        self._logger.info(
+            f"Writing {len(updates)} updates failures in {self._updates_history}"
+        )
+
+        with open(self._updates_history, "w") as output_xml:
+            output_xml.write(f"""<?xml version="1.0"?>
+<updates xmlns="http://www.mozilla.org/2005/app-update">
+  {"".join(updates)}
+</updates>""")

--- a/testing/enterprise/manifest.toml
+++ b/testing/enterprise/manifest.toml
@@ -46,6 +46,8 @@ run-if = [
 
 ["test_felt_browser_starts.py"]
 
+["test_felt_browser_updater_errors.py"]
+
 ["test_felt_browser_updates_apply.py"]
 
 ["test_felt_browser_updates_basic.py"]

--- a/testing/enterprise/manifest.toml
+++ b/testing/enterprise/manifest.toml
@@ -20,6 +20,8 @@ subsuite = "enterprise"
 
 ["test_felt_browser_fxa.py"]
 
+["test_felt_email_input_focus.py"]
+
 ["test_felt_browser_new_window_from_cli.py"]
 
 ["test_felt_browser_rapid_new_tabs_from_cli.py"]

--- a/testing/enterprise/manifest.toml
+++ b/testing/enterprise/manifest.toml
@@ -20,6 +20,8 @@ subsuite = "enterprise"
 
 ["test_felt_browser_fxa.py"]
 
+["test_felt_browser_init_failures.py"]
+
 ["test_felt_email_input_focus.py"]
 
 ["test_felt_browser_new_window_from_cli.py"]

--- a/testing/enterprise/test_felt_browser_crash_restart.py
+++ b/testing/enterprise/test_felt_browser_crash_restart.py
@@ -26,7 +26,7 @@ class BrowserCrashRestart(BrowserCrashes):
 
     def run_felt_proper_restart_again(self):
         self._manually_closed_child = False
-        self.wait_process_exit()
+        self.wait_process_exit(self._browser_pid)
         self._logger.info("Connecting to new browser")
         self.connect_child_browser()
         self._browser_pid = self._child_driver.session_capabilities["moz:processID"]

--- a/testing/enterprise/test_felt_browser_exit_tokens.py
+++ b/testing/enterprise/test_felt_browser_exit_tokens.py
@@ -26,14 +26,13 @@ class BrowserExitTokens(FeltTests):
         self.assert_felt_refresh_blocked(False)
         self.run_felt_base()
         self.connect_child_browser()
-        # Record process PID we will have to wait for in self.wait_process_exit()
-        self._browser_pid = self._child_driver.session_capabilities["moz:processID"]
+        browser_pid = self._child_driver.session_capabilities["moz:processID"]
         self.assert_felt_refresh_blocked(True)
         self.check_felt_and_firefox_tokens_in_sync()
         self.force_and_refresh_tokens()
         self.check_firefox_tokens_updated_after_session_refresh()
         self.perform_quit()
-        self.wait_process_exit()
+        self.wait_process_exit(browser_pid)
         self.await_felt_auth_window()
         self.assert_felt_refresh_blocked(False)
         self.force_window()

--- a/testing/enterprise/test_felt_browser_init_failures.py
+++ b/testing/enterprise/test_felt_browser_init_failures.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import os
+import sys
+
+sys.path.append(os.path.dirname(__file__))
+
+from base_test import Environment
+from felt_tests import FeltTests
+
+
+class BrowserInitFailures(FeltTests):
+    def test_browser_init_policy_fetch_fail(self):
+        self.policies_fail_request.value = 1
+        super().run_felt_base()
+        self._manually_closed_child = True
+
+        self.await_felt_auth_window()
+        self.policies_fail_request.value = 0
+        self.force_window()
+        self.assert_user_signed_out(env=Environment.FELT)

--- a/testing/enterprise/test_felt_browser_restart_works.py
+++ b/testing/enterprise/test_felt_browser_restart_works.py
@@ -44,7 +44,7 @@ class BrowserRestartWorks(FeltTests):
             self._manually_closed_child = True
 
     def run_felt_restart_new_process(self):
-        self.wait_process_exit()
+        self.wait_process_exit(self._browser_pid)
         self._logger.info("Connecting to new browser")
         self.connect_child_browser()
         new_browser_pid = self._child_driver.session_capabilities["moz:processID"]

--- a/testing/enterprise/test_felt_browser_shutdown_crash_exit.py
+++ b/testing/enterprise/test_felt_browser_shutdown_crash_exit.py
@@ -44,7 +44,7 @@ class BrowserShutdownCrash(FeltStartsBrowser):
         self._child_driver.set_context("chrome")
 
         self._logger.info("Trigger quit, expected to crash")
-        self._browser_pid = self._child_driver.session_capabilities["moz:processID"]
+        browser_pid = self._child_driver.session_capabilities["moz:processID"]
         try:
             self._child_driver.execute_script(
                 "Services.startup.quit(Ci.nsIAppStartup.eForceQuit);"
@@ -52,13 +52,13 @@ class BrowserShutdownCrash(FeltStartsBrowser):
         except Exception:
             pass
 
-        self.wait_process_exit()
+        self.wait_process_exit(browser_pid)
         try:
             self._logger.info("Trying to connect to new browser")
             self.connect_child_browser()
             new_browser_pid = self._child_driver.session_capabilities["moz:processID"]
-            assert self._browser_pid != new_browser_pid, (
-                f"PID should not be the same: {self._browser_pid} != {new_browser_pid}"
+            assert browser_pid != new_browser_pid, (
+                f"PID should not be the same: {browser_pid} != {new_browser_pid}"
             )
             assert new_browser_pid is None, (
                 f"Should not have started a new browser: {new_browser_pid}"

--- a/testing/enterprise/test_felt_browser_starts.py
+++ b/testing/enterprise/test_felt_browser_starts.py
@@ -15,4 +15,4 @@ class FeltStartsBrowserCli(FeltStartsBrowser):
     def test_felt_browser_start_from_cli(self):
         super().run_felt_base()
         self.run_felt_browser_started()
-        self.run_felt_verify_prefs()
+        self.run_ensure_config_prefs_set_in_browser()

--- a/testing/enterprise/test_felt_browser_updater_errors.py
+++ b/testing/enterprise/test_felt_browser_updater_errors.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import os
+import sys
+
+sys.path.append(os.path.dirname(__file__))
+
+from felt_updater_errors import FeltUpdaterErrorsBase
+
+
+class FeltUpdaterErrors(FeltUpdaterErrorsBase):
+    EXTRA_PREFS = {
+        "app.update.log": True,
+        "app.update.disabledForTesting": False,
+        "app.update.BITS.enabled": False,
+        "enterprise.felt_tests.is_updates_testing": False,
+    }
+
+    def test_felt_updater_errors(self):
+        self._update_root = os.path.dirname(self.get_update_config_file_path())
+        self._updates_history = os.path.join(self._update_root, "updates.xml")
+        self._logger.info(f"Updates history {self._updates_history}")
+
+        if os.path.isfile(self._updates_history):
+            os.unlink(self._updates_history)
+            self._logger.info(f"Updates history {self._updates_history} removed.")
+
+        # Browser is not being started in this test, so there is no need to
+        # check for its proper close
+        self._manually_closed_child = True
+
+        self.reset_updates_served()
+        self.reload_chrome_window()
+        self.assert_updates_check_allowed(True)
+        self.assert_updates_served(1)
+
+        # Just one failure should not block
+        self.write_updates_xml([self.one_xml("failed")])
+        self.assert_updates_check_allowed(True)
+
+        # Three consecutive failures, we still allow
+        self.write_updates_xml([
+            self.one_xml("failed"),
+            self.one_xml("failed"),
+            self.one_xml("failed"),
+            self.one_xml("succeeded"),
+        ])
+        self.reset_updates_served()
+        self.reload_chrome_window()
+        self.assert_updates_check_allowed(True)
+        self.assert_updates_served(1)
+
+        # Four consecutive failures, we block
+        self.write_updates_xml([
+            self.one_xml("failed"),
+            self.one_xml("failed"),
+            self.one_xml("failed"),
+            self.one_xml("failed"),
+            self.one_xml("succeeded"),
+        ])
+        self.reset_updates_served()
+        self.reload_chrome_window()
+        self.assert_updates_check_allowed(False)
+        self.assert_updates_served(0)
+        self.assert_error_displayed()
+
+        # This should count as two consecutive failures, so we still allow
+        self.write_updates_xml([
+            self.one_xml("failed"),
+            self.one_xml("failed"),
+            self.one_xml("succeeded"),
+            self.one_xml("failed"),
+            self.one_xml("failed"),
+            self.one_xml("failed"),
+            self.one_xml("failed"),
+            self.one_xml("succeeded"),
+        ])
+        self.reset_updates_served()
+        self.reload_chrome_window()
+        self.assert_updates_check_allowed(True)
+        self.assert_updates_served(1)
+
+        # Four consecutive failures, but first is OK, we allow
+        self.write_updates_xml([
+            self.one_xml("succeeded"),
+            self.one_xml("failed"),
+            self.one_xml("failed"),
+            self.one_xml("failed"),
+            self.one_xml("failed"),
+            self.one_xml("succeeded"),
+        ])
+        self.reset_updates_served()
+        self.reload_chrome_window()
+        self.assert_updates_check_allowed(True)
+        self.assert_updates_served(1)
+
+        assert os.path.isfile(self._updates_history), (
+            f"Updates history is present at {self._updates_history}"
+        )
+        os.unlink(self._updates_history)

--- a/testing/enterprise/test_felt_browser_updates_forward.py
+++ b/testing/enterprise/test_felt_browser_updates_forward.py
@@ -9,6 +9,9 @@ import sys
 sys.path.append(os.path.dirname(__file__))
 
 from felt_tests import FeltTests
+from marionette_driver.errors import (
+    JavascriptException,
+)
 
 
 class FeltUpdatesForward(FeltTests):
@@ -16,11 +19,87 @@ class FeltUpdatesForward(FeltTests):
         "enterprise.felt_tests.should_not_close_window": True,
     }
 
+    def install_update_manager_mock(self, ready_update=None):
+        self._driver.set_context("chrome")
+        self._driver.execute_script(
+            """
+            const UM = Cc["@mozilla.org/updates/update-manager;1"].getService(Ci.nsIUpdateManager);
+            UM.internal.readyUpdate = {
+                state: arguments[0],
+                QueryInterface: ChromeUtils.generateQI(["nsIUpdate"]),
+            };
+        """,
+            [ready_update],
+        )
+        self._driver.set_context("content")
+
     def test_felt_updates_forward(self):
+        original_felt_pid = self._driver.session_capabilities["moz:processID"]
         self.run_felt_base()
         self.run_felt_browser_started()
+        browser_pid = self._child_driver.session_capabilities["moz:processID"]
+
+        # Using a context manager and using_prefs() would fail at shutdown time
+        # because of FELT restarting in the end of the process
+        self._driver.set_pref(
+            "enterprise.felt_tests.should_not_close_window",
+            False,
+            default_branch=True,
+        )
+
+        # Update is still applying, so do not perform a FELT restart since
+        # it is not ready yet to run the updater
+        self.install_update_manager_mock("applying")
         self.run_felt_trigger_update()
-        self.run_felt_check_browser_notification()
+        self.run_felt_click_browser_notification()
+        # This is waiting on the browser to exit
+        self._logger.info(f"Waiting on browser {browser_pid} restart")
+        self.wait_process_exit(browser_pid)
+        self._logger.info(f"Waited on browser {browser_pid} restart: done")
+        self.run_felt_browser_started()
+
+        # Next restart is for FELT so wait on it
+        felt_pid = self._driver.session_capabilities["moz:processID"]
+        assert original_felt_pid == felt_pid, (
+            "FELT should not have restarted after browser restart and 'applying' state for update"
+        )
+
+        # Update is ready to run by the updater, perform a FELT restart
+        self.install_update_manager_mock("applied")
+        self.run_felt_trigger_update()
+        self.run_felt_click_browser_notification()
+        # This is waiting on FELT to restart
+        self._logger.info(f"Waiting on FELT {felt_pid} restart")
+        self.wait_process_exit(felt_pid)
+        self._logger.info(f"Waited on FELT {felt_pid} restart: done")
+
+        # Verify the restarted process
+        self._driver.start_session()
+        self._logger.info("Reconnected to FELT")
+
+        new_felt_pid = self._driver.session_capabilities["moz:processID"]
+        self._logger.info(f"Reconnected to FELT with {new_felt_pid}")
+        assert original_felt_pid != new_felt_pid, (
+            "FELT should have restarted after browser restart and 'applied' state for update"
+        )
+
+        self._driver.set_context("chrome")
+        email = self.get_elem("#felt-form__email")
+        assert email, "Found an email field for login page"
+
+        mock_console = f"http://localhost:{self.console_port}"
+        console_addr = self._driver.get_pref("enterprise.console.address")
+        assert console_addr.startswith(mock_console), (
+            f"Console in restarted FELT is mock: {mock_console}, found {console_addr}"
+        )
+
+        # Browser is not being started again
+        self._manually_closed_child = True
+
+        self._driver.execute_script(
+            "Services.startup.quit(Ci.nsIAppStartup.eForceQuit);"
+        )
+        self.wait_process_exit(new_felt_pid)
 
     def run_felt_browser_started(self):
         self.connect_child_browser()
@@ -35,7 +114,7 @@ class FeltUpdatesForward(FeltTests):
         )
         self._driver.set_context("content")
 
-    def run_felt_check_browser_notification(self):
+    def run_felt_click_browser_notification(self):
         self._child_driver.set_context("chrome")
         notifications = self._child_driver.execute_script(
             """
@@ -52,3 +131,23 @@ class FeltUpdatesForward(FeltTests):
                 break
 
         assert found_update_ready, "Found an update-restart notification"
+
+        try:
+            self._child_driver.set_context("chrome")
+            self._child_driver.execute_script(
+                """
+                const { AppMenuNotifications } = ChromeUtils.importESModule("resource://gre/modules/AppMenuNotifications.sys.mjs");
+                AppMenuNotifications.notifications.forEach(notification => {
+                  console.debug(`FeltTests: notification: ${notification} => ${JSON.stringify(notification)}`);
+                  if (notification.id === "update-restart") {
+                    notification.mainAction.callback();
+                  }
+                });
+                """
+            )
+            self._child_driver.set_context("content")
+        except JavascriptException as ex:
+            raise ex
+        except Exception:
+            # Exceptions here are expected since this triggers a restart
+            pass

--- a/testing/enterprise/test_felt_email_input_focus.py
+++ b/testing/enterprise/test_felt_email_input_focus.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import os
+import sys
+
+sys.path.append(os.path.dirname(__file__))
+
+from felt_tests import FeltTestsBase
+
+
+class FeltEmailInputFocus(FeltTestsBase):
+    """
+    Test that the email input in the FELT login form is focused on launch.
+    """
+
+    def teardown(self):
+        self._manually_closed_child = True
+        super().teardown()
+
+    # Bug 2006564
+    def test_felt_email_input_is_focused(self):
+        self._driver.set_context("chrome")
+
+        self._wait.until(
+            lambda _: self._driver.execute_script(
+                """
+                const host = document.getElementById("felt-form__email");
+                const focused = document.commandDispatcher.focusedElement;
+                return focused === host || host?.shadowRoot?.contains(focused);
+                """
+            )
+        )
+
+        self._driver.set_context("content")

--- a/toolkit/components/enterprisepolicies/EnterprisePoliciesParent.sys.mjs
+++ b/toolkit/components/enterprisepolicies/EnterprisePoliciesParent.sys.mjs
@@ -10,6 +10,8 @@ ChromeUtils.defineESModuleGetters(lazy, {
   JsonSchemaValidator:
     "resource://gre/modules/components-utils/JsonSchemaValidator.sys.mjs",
   // eslint-disable-next-line mozilla/no-browser-refs-in-toolkit
+  EnterpriseHandler: "resource:///modules/enterprise/EnterpriseHandler.sys.mjs",
+  // eslint-disable-next-line mozilla/no-browser-refs-in-toolkit
   Policies: "resource:///modules/policies/Policies.sys.mjs",
   WindowsGPOParser: "resource://gre/modules/policies/WindowsGPOParser.sys.mjs",
   macOSPoliciesParser:
@@ -169,6 +171,11 @@ EnterprisePoliciesManager.prototype = {
     // Fetch first set of remote policies during the
     // initialization of the policy engine
     await remoteProvider.fetchPoliciesOnStartup();
+    if (Services.felt?.isFeltBrowser() && remoteProvider.failed) {
+      // bug 2027006 will move the fetching of policies to felt
+      // and not shutdown will be needed then
+      await lazy.EnterpriseHandler.initiateShutdown();
+    }
     remoteProvider.onPoliciesChanges(handler);
 
     if (platformProvider && platformProvider.hasPolicies) {

--- a/toolkit/crashreporter/client/app/src/async_task.rs
+++ b/toolkit/crashreporter/client/app/src/async_task.rs
@@ -6,16 +6,26 @@
 //!
 //! Each thread has thread-bound data which can be accessed in queued task functions.
 
+use std::sync::Arc;
+
 pub type TaskFn<T> = Box<dyn FnOnce(&T) + Send + 'static>;
 
 pub struct AsyncTask<T> {
-    send: Box<dyn Fn(TaskFn<T>) + Send + Sync>,
+    send: Arc<dyn Fn(TaskFn<T>) + Send + Sync>,
+}
+
+impl<T> Clone for AsyncTask<T> {
+    fn clone(&self) -> Self {
+        AsyncTask {
+            send: Arc::clone(&self.send),
+        }
+    }
 }
 
 impl<T> AsyncTask<T> {
     pub fn new<F: Fn(TaskFn<T>) + Send + Sync + 'static>(send: F) -> Self {
         AsyncTask {
-            send: Box::new(send),
+            send: Arc::new(send),
         }
     }
 

--- a/toolkit/crashreporter/client/app/src/logic.rs
+++ b/toolkit/crashreporter/client/app/src/logic.rs
@@ -67,7 +67,36 @@ pub fn sha256_hash_file(path: &Path) -> crate::std::io::Result<String> {
 impl ReportCrash {
     pub fn new(config: Arc<Config>, extra: serde_json::Value) -> anyhow::Result<Self> {
         let settings_file = config.data_dir().join("crashreporter_settings.json");
-        let settings: Settings = match std::fs::File::open(&settings_file) {
+        let settings = {
+            #[cfg(feature = "enterprise")]
+            if config.policy_auto_submit {
+                Settings {
+                    submit_report: true,
+                    include_url: true,
+                    test_hardware: true,
+                }
+            } else {
+                ReportCrash::load_settings(&settings_file)
+            }
+
+            #[cfg(not(feature = "enterprise"))]
+            ReportCrash::load_settings(&settings_file)
+        };
+        log::debug!("loaded settings: {settings:?}");
+
+        Ok(ReportCrash {
+            config,
+            extra,
+            settings_file,
+            settings: settings.into(),
+            attempted_to_send: Default::default(),
+            ui: None,
+            memtest: None.into(),
+        })
+    }
+
+    fn load_settings(settings_file: &Path) -> Settings {
+        match std::fs::File::open(&settings_file) {
             Err(e) => {
                 if e.kind() != std::io::ErrorKind::NotFound {
                     log::warn!(
@@ -86,19 +115,8 @@ impl ReportCrash {
                     Default::default()
                 }
                 Ok(s) => s,
-            },
-        };
-        log::debug!("loaded settings: {settings:?}");
-
-        Ok(ReportCrash {
-            config,
-            extra,
-            settings_file,
-            settings: settings.into(),
-            attempted_to_send: Default::default(),
-            ui: None,
-            memtest: None.into(),
-        })
+            }
+        }
     }
 
     /// Returns whether an attempt was made to send the report.

--- a/toolkit/crashreporter/client/app/src/logic.rs
+++ b/toolkit/crashreporter/client/app/src/logic.rs
@@ -445,7 +445,7 @@ impl ReportCrash {
         let crash_ui = ReportCrashUI::new(
             &*self.settings.borrow(),
             self.config.clone(),
-            logic_remote_queue,
+            logic_remote_queue.clone(),
         );
 
         // Set the UI remote queue.
@@ -460,6 +460,15 @@ impl ReportCrash {
         }
         let logic_panic_handler = PanicHandler(Arc::downgrade(&crash_ui_async_task));
         self.ui = Some(crash_ui_async_task);
+
+        #[cfg(feature = "enterprise")]
+        // Set up logic thread to immediately send the report
+        // Normally we might do this asynchronously because it blocks,
+        // but with policy_auto_submit, the UI is intentionally not interactive until after the send completes,
+        // so we won't need the logic thread to be unblocked.
+        if self.config.policy_auto_submit {
+            logic_remote_queue.push(|s| { s.try_send(); });
+        }
 
         // Spawn a separate thread to handle all interactions with `self`. This prevents blocking
         // the UI for any reason.

--- a/toolkit/crashreporter/client/app/src/ui/mod.rs
+++ b/toolkit/crashreporter/client/app/src/ui/mod.rs
@@ -236,7 +236,7 @@ impl ReportCrashUI {
             data::Synchronized::join(send_report, &input_enabled, |s, e| *s && *e);
         #[cfg(feature = "enterprise")]
         let close_enabled = if policy_auto_submit {
-            data::Synchronized::new(true)
+            submit_state.mapped(|s| s == &SubmitState::Failure || s == &SubmitState::Success)
         } else {
             submit_state.mapped(|s| s == &SubmitState::Initial)
         };

--- a/toolkit/xre/nsAppRunner.cpp
+++ b/toolkit/xre/nsAppRunner.cpp
@@ -2612,7 +2612,6 @@ void UnlockProfile() {
 nsresult LaunchChild(bool aBlankCommandLine, bool aTryExec) {
   // Restart this process by exec'ing it into the current process
   // if supported by the platform.  Otherwise, use NSPR.
-
   if (aBlankCommandLine) {
     gRestartArgc = 1;
     gRestartArgv[gRestartArgc] = nullptr;
@@ -3131,7 +3130,27 @@ static nsresult SelectProfile(nsToolkitProfileService* aProfileSvc,
 #if defined(MOZ_ENTERPRISE)
   {
     auto forcedProfile = geckoargs::sProfile.IsPresent(gArgc, gArgv);
-    if (is_felt_ui() && !forcedProfile) {
+    // Those env var are set by LaunchChild() when performing a restart. Make
+    // sure the values are there and non empty to consider them as forced.
+    //
+    // AppShutdown::OnShutdownConfirmed() save them both so it is fine assuming
+    // they should be present both.
+    const char* xreProfilePath = PR_GetEnv("XRE_PROFILE_PATH");
+    auto savedProfile = xreProfilePath && *xreProfilePath;
+    const char* xreProfileLocalPath = PR_GetEnv("XRE_PROFILE_LOCAL_PATH");
+    auto savedLocalProfile = xreProfileLocalPath && *xreProfileLocalPath;
+
+    // When running as FELT UI use a hardcoded profile named "felt" and living
+    // in the OS' temporary directory. There are a few special cases where it is
+    // required to use a profile that is being given from different means:
+    //  - CLI argument "-profile ..."
+    //  - environment variables "XRE_PROFILE_PATH" / "XRE_PROFILE_LOCAL_PATH"
+    //
+    // If either of those are present, the following code is skipped and profile
+    // selection continues. This accounts for manually setting the profile,
+    // which is required including when using "mach run" as well as when FELT
+    // restarts for updates.
+    if (is_felt_ui() && !forcedProfile && !savedProfile && !savedLocalProfile) {
       nsCOMPtr<nsIFile> file;
       MOZ_TRY(GetSpecialSystemDirectory(OS_TemporaryDirectory,
                                         getter_AddRefs(file)));


### PR DESCRIPTION
a994db55f80f Bug 2026954: Fix html duplicated id on toolbarseparator (#620)
881fc254c545 Bug 2019061 - Call try_send synchronously after UI is up and only enable button when complete
611d300521a4 Bug 1998394: Add shutdown on failing to retrieve policies (#585)
81e8cb2a0c57 Bug 2019058 - Enterprise: show policy notice and disable crash report UI when CrashReportsAutoSubmit is enforced (#531)
a0940dc8d1ed Bug 2026203: Remove usage of Manager.Value on marionette testutils (#612)
c096b61479e5 Bug 2019061 - Make AsyncTask cloneable
b6954e85b5fa Bug 2019061 - Force various settings when policy is enabled
0788744b6d7b Remove synk token server assertion
1f45214b30dd Lint
9d05834e3bd3 Remove /hacks/startup dependencies from tests
75801f7abda8 Remove /api/browser/hacks/startup endpoint

a73e7574fb07 Bug 2019063 - Tab crash logic to auto send crash report if policy enabled (#530)
41f2b24b8d72 Bug 2024587 - Enterprise: restart felt when browser requests restart and there is a ready update
09a9ffe6c2fa Bug 2006564: Focus email input when login is visible (#611)
ac42d0328528 Bug 2026878 - Enterprise: update expected errors list
~~daa1fae9dc8b Update enterprise-l10n-changesets.json from main~~
1428899a30d9 Bug 2023485 - Enterprise: check for consecutive updates failures
3b23c8091691 Bug 2012082 - Enterprise: Add custom enterprise logo on toolbar
e426eab2da35 Bug 2026576 - Fix SitePolicies Lockdown UI button persisting through tab change
bff68e85d7a8 Bug 2026578 - Hide uptodate message on sso load