### PR TITLE
Bug 2027073: Load startup image when it is visible

### DIFF
--- a/browser/themes/shared/customizableui/panelUI-shared.css
+++ b/browser/themes/shared/customizableui/panelUI-shared.css
@@ -2465,9 +2465,12 @@ radiogroup:focus-visible > .subviewradio[focused="true"] {
 .panelUI-enterprise__alert__icon {
   width: var(--icon-size);
   height: var(--icon-size);
-  list-style-image: url(chrome://browser/content/enterprise/alert.svg);
   -moz-context-properties: fill;
   fill: currentColor;
+
+  #panelUI-enterprise[visible] & {
+    list-style-image: url(chrome://browser/content/enterprise/alert.svg);
+  }
 }
 
 .panelUI-enterprise__alert__message {


### PR DESCRIPTION
Fixes MOZ_BYPASS_FELT=1 ./mach mochitest browser/base/content/test/performance/browser_startup_images.js