### PR TITLE
Bug 2019068 - When crash autosubmit policy is applied, set env var to trigger autosubmit in CrashReporter app

### DIFF
--- a/browser/components/enterprisepolicies/Policies.sys.mjs
+++ b/browser/components/enterprisepolicies/Policies.sys.mjs
@@ -1076,6 +1076,7 @@ export var Policies = {
         );
         setAndLockPref("browser.tabs.crashReporting.sendReport", true);
         setAndLockPref("browser.tabs.crashReporting.includeURL", true);
+        Services.env.set("MOZ_CRASHREPORTER_POLICY_AUTO_SUBMIT", "1");
       }
     },
     onRemove(_manager, _oldParam) {
@@ -1083,6 +1084,7 @@ export var Policies = {
       unsetAndUnlockPref("browser.crashReports.unsubmittedCheck.autoSubmit2");
       unsetAndUnlockPref("browser.tabs.crashReporting.sendReport");
       unsetAndUnlockPref("browser.tabs.crashReporting.includeURL");
+      Services.env.set("MOZ_CRASHREPORTER_POLICY_AUTO_SUBMIT", "");
     },
   },
 

--- a/browser/components/enterprisepolicies/Policies.sys.mjs
+++ b/browser/components/enterprisepolicies/Policies.sys.mjs
@@ -1077,14 +1077,23 @@ export var Policies = {
         setAndLockPref("browser.tabs.crashReporting.sendReport", true);
         setAndLockPref("browser.tabs.crashReporting.includeURL", true);
         Services.env.set("MOZ_CRASHREPORTER_POLICY_AUTO_SUBMIT", "1");
+      } else {
+        // if ForceAutoSubmit is unset or is false
+        unsetAndUnlockPref("browser.crashReports.unsubmittedCheck.enabled");
+        unsetAndUnlockPref("browser.crashReports.unsubmittedCheck.autoSubmit2");
+        unsetAndUnlockPref("browser.tabs.crashReporting.sendReport");
+        unsetAndUnlockPref("browser.tabs.crashReporting.includeURL");
+        Services.env.set("MOZ_CRASHREPORTER_POLICY_AUTO_SUBMIT", "");
       }
     },
-    onRemove(_manager, _oldParam) {
-      unsetAndUnlockPref("browser.crashReports.unsubmittedCheck.enabled");
-      unsetAndUnlockPref("browser.crashReports.unsubmittedCheck.autoSubmit2");
-      unsetAndUnlockPref("browser.tabs.crashReporting.sendReport");
-      unsetAndUnlockPref("browser.tabs.crashReporting.includeURL");
-      Services.env.set("MOZ_CRASHREPORTER_POLICY_AUTO_SUBMIT", "");
+    onRemove(_manager, oldParam) {
+      if (oldParam.ForceAutoSubmit) {
+        unsetAndUnlockPref("browser.crashReports.unsubmittedCheck.enabled");
+        unsetAndUnlockPref("browser.crashReports.unsubmittedCheck.autoSubmit2");
+        unsetAndUnlockPref("browser.tabs.crashReporting.sendReport");
+        unsetAndUnlockPref("browser.tabs.crashReporting.includeURL");
+        Services.env.set("MOZ_CRASHREPORTER_POLICY_AUTO_SUBMIT", "");
+      }
     },
   },
 


### PR DESCRIPTION
Triggers the UI and behavior changes from #614 and #494 