### PR TITLE
Bug 2027777- Fetch Firefox configurations from api/browser/config

### DIFF
--- a/browser/components/enterprise/modules/ConsoleClient.sys.mjs
+++ b/browser/components/enterprise/modules/ConsoleClient.sys.mjs
@@ -116,7 +116,7 @@ export const ConsoleClient = {
       SSO: "/sso/login",
       SIGNOUT: "/sso/logout",
       SSO_CALLBACK: "/sso/callback",
-      DEFAULT_PREFS: "/api/browser/hacks/default",
+      CONFIG: "/api/browser/config",
       REMOTE_POLICIES: "/api/browser/policies",
       KEY: "/api/browser/key",
       TOKEN: "/sso/token",
@@ -190,11 +190,13 @@ export const ConsoleClient = {
     return url.href + "?*";
   },
 
-  // prefs that do not need to be written and can be sent during runtime
-  // tbd: remove
-  async getDefaultPrefs() {
-    const payload = await this._get(this._paths.DEFAULT_PREFS);
-    return payload;
+  /**
+   * Fetches configurations for Firefox
+   *
+   * @returns {Promise<object>}
+   */
+  async getFirefoxConfigs() {
+    return this._get(this._paths.CONFIG);
   },
 
   /**

--- a/browser/extensions/felt/content/FeltProcessParent.sys.mjs
+++ b/browser/extensions/felt/content/FeltProcessParent.sys.mjs
@@ -276,6 +276,75 @@ export class FeltProcessParent extends JSProcessActorParent {
     );
   }
 
+  /**
+   * Fetches the configurations for Firefox and sends
+   * each configuration point over to Firefox as preferences
+   */
+  async _applyFirefoxConfigs() {
+    const {
+      learn_more_url,
+      company_logo_url,
+      policies: { polling_frequency },
+      services: { push_url, remote_settings_url, tokenserver_url },
+      extra_prefs,
+    } = await lazy.ConsoleClient.getFirefoxConfigs();
+
+    Services.felt.sendStringPreference(
+      "enterprise.configs.learn_more_url",
+      learn_more_url
+    );
+    Services.felt.sendStringPreference(
+      "enterprise.configs.company_logo_url",
+      company_logo_url
+    );
+    Services.felt.sendIntPreference(
+      "browser.policies.live_polling.frequency",
+      polling_frequency
+    );
+
+    Services.felt.sendStringPreference(
+      "identity.sync.tokenserver.uri",
+      tokenserver_url
+    );
+    Services.felt.sendStringPreference(
+      "services.settings.server",
+      remote_settings_url
+    );
+    Services.felt.sendStringPreference("dom.push.serverURL", push_url);
+
+    extra_prefs.forEach(pref => {
+      this._setPrefInFirefox(pref);
+    });
+  }
+
+  /**
+   * Sends preference to Firefox through felt
+   *
+   * @param {[key: string, value: boolean|string|number]} pref
+   */
+  _setPrefInFirefox(pref) {
+    const name = pref[0];
+    const value = pref[1];
+    console.debug(`Felt: Services.felt(${name}, ${value})`);
+
+    switch (typeof value) {
+      case "boolean":
+        Services.felt.sendBoolPreference(name, value);
+        break;
+
+      case "string":
+        Services.felt.sendStringPreference(name, value);
+        break;
+
+      case "number":
+        Services.felt.sendIntPreference(name, value);
+        break;
+
+      default:
+        console.warn(`Unsupported pref type for ${name}:`, value);
+    }
+  }
+
   async startFirefox(startReason, ssoCollectedCookies = []) {
     this.restartReported = false;
     this.logoutReported = false;
@@ -311,27 +380,7 @@ export class FeltProcessParent extends JSProcessActorParent {
         Services.felt.sendTokens();
         lazy.ConsoleClient.isSessionRefreshBlocked = true;
 
-        const { prefs } = await lazy.ConsoleClient.getDefaultPrefs();
-        prefs.forEach(pref => {
-          const name = pref[0];
-          const value = pref[1];
-
-          console.debug(`Felt: Services.felt(${name}, ${value})`);
-
-          switch (typeof value) {
-            case "boolean":
-              Services.felt.sendBoolPreference(name, value);
-              break;
-
-            case "string":
-              Services.felt.sendStringPreference(name, value);
-              break;
-
-            case "number":
-              Services.felt.sendIntPreference(name, value);
-              break;
-          }
-        });
+        await this._applyFirefoxConfigs();
 
         Services.felt.sendCookies(ssoCollectedCookies);
         Services.felt.sendReady();

--- a/browser/extensions/felt/content/FeltProcessParent.sys.mjs
+++ b/browser/extensions/felt/content/FeltProcessParent.sys.mjs
@@ -325,7 +325,9 @@ export class FeltProcessParent extends JSProcessActorParent {
   _setPrefInFirefox(pref) {
     const name = pref[0];
     const value = pref[1];
-    console.debug(`Felt: Services.felt(${name}, ${value})`);
+    console.debug(
+      `Sending preference ${name} with value ${value} from Felt to Firefox`
+    );
 
     switch (typeof value) {
       case "boolean":

--- a/browser/extensions/felt/content/FeltProcessParent.sys.mjs
+++ b/browser/extensions/felt/content/FeltProcessParent.sys.mjs
@@ -289,28 +289,56 @@ export class FeltProcessParent extends JSProcessActorParent {
       extra_prefs,
     } = await lazy.ConsoleClient.getFirefoxConfigs();
 
-    Services.felt.sendStringPreference(
-      "enterprise.configs.learn_more_url",
-      learn_more_url
-    );
-    Services.felt.sendStringPreference(
-      "enterprise.configs.company_logo_url",
-      company_logo_url
-    );
-    Services.felt.sendIntPreference(
-      "browser.policies.live_polling.frequency",
-      polling_frequency
-    );
+    if (learn_more_url === null) {
+      console.error("No learn_more_url in Firefox configuration");
+    } else {
+      Services.felt.sendStringPreference(
+        "enterprise.configs.learn_more_url",
+        learn_more_url
+      );
+    }
 
-    Services.felt.sendStringPreference(
-      "identity.sync.tokenserver.uri",
-      tokenserver_url
-    );
-    Services.felt.sendStringPreference(
-      "services.settings.server",
-      remote_settings_url
-    );
-    Services.felt.sendStringPreference("dom.push.serverURL", push_url);
+    if (company_logo_url === null) {
+      console.error("No company_logo_url in Firefox configuration");
+    } else {
+      Services.felt.sendStringPreference(
+        "enterprise.configs.company_logo_url",
+        company_logo_url
+      );
+    }
+
+    if (polling_frequency === null) {
+      console.error("No polling_frequency in Firefox configuration");
+    } else {
+      Services.felt.sendIntPreference(
+        "browser.policies.live_polling.frequency",
+        polling_frequency
+      );
+    }
+
+    if (tokenserver_url === null) {
+      console.error("No tokenserver_url in Firefox configuration");
+    } else {
+      Services.felt.sendStringPreference(
+        "identity.sync.tokenserver.uri",
+        tokenserver_url
+      );
+    }
+
+    if (remote_settings_url === null) {
+      console.error("No remote_settings_url in Firefox configuration");
+    } else {
+      Services.felt.sendStringPreference(
+        "services.settings.server",
+        remote_settings_url
+      );
+    }
+
+    if (push_url === null) {
+      console.error("No push_url in Firefox configuration");
+    } else {
+      Services.felt.sendStringPreference("dom.push.serverURL", push_url);
+    }
 
     extra_prefs.forEach(pref => {
       this._setPrefInFirefox(pref);

--- a/testing/enterprise/felt_browser_starts.py
+++ b/testing/enterprise/felt_browser_starts.py
@@ -37,9 +37,13 @@ class FeltStartsBrowser(FeltTests):
             f"Cookie {self.cookie_name} was properly set on Firefox started by FELT"
         )
 
-    def run_ensure_config_prefs_set_in_browser(self):
-        for pref in felt_consts.config_prefs:
-            value = self.get_pref_child(pref[0], self.python_type_to_js(pref[1]))
-            assert value == pref[1], (
-                f"Mismatching pref {pref[0]} value {value} instead of {pref[1]}"
+    def run_ensure_firefox_config_set_in_browser(self):
+        for key, entry in felt_consts.firefox_config.items():
+            pref_id = entry["pref_id"]
+            expected_value = entry["pref_value"]
+
+            value = self.get_pref_child(pref_id, self.python_type_to_js(expected_value))
+
+            assert value == expected_value, (
+                f"[{key}] Mismatching pref {pref_id} value {value} instead of {expected_value}"
             )

--- a/testing/enterprise/felt_consts.py
+++ b/testing/enterprise/felt_consts.py
@@ -3,8 +3,28 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-
-config_prefs = [
-    ["browser.policies.live_polling.frequency", 500],
-    ["identity.sync.tokenserver.uri", ""],
-]
+firefox_config = {
+    "learn_more_url": {
+        "pref_id": "enterprise.configs.learn_more_url",
+        "pref_value": "",
+    },
+    "company_logo_url": {
+        "pref_id": "enterprise.configs.company_logo_url",
+        "pref_value": "",
+    },
+    "polling_frequency": {
+        "pref_id": "browser.policies.live_polling.frequency",
+        "pref_value": 500,
+    },
+    "tokenserver_url": {
+        "pref_id": "identity.sync.tokenserver.uri",
+        "pref_value": "",
+    },
+    "push_url": {
+        "pref_id": "dom.push.serverURL",
+        "pref_value": "",
+    },
+    # Not checking remote settings url (services.settings.server),
+    # it's pre-populated in marionette test environemtns:
+    #  https://searchfox.org/firefox-main/rev/9a3317a65545e83f4e32b94fdf1f6860342423ef/remote/shared/RecommendedPreferences.sys.mjs#381-382
+}

--- a/testing/enterprise/felt_tests.py
+++ b/testing/enterprise/felt_tests.py
@@ -17,7 +17,6 @@ import uuid
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from multiprocessing import Array, Process, Value
 
-import felt_consts
 import requests
 from base_test import EnterpriseTestsBase
 from marionette_driver import expected
@@ -183,12 +182,18 @@ class ConsoleHttpHandler(LocalHttpRequestHandler):
             self.end_headers()
             return
 
-        elif path == "/api/browser/hacks/default":
-            # Browser prefs that can be applied live
+        elif path == "/api/browser/config":
             m = json.dumps({
-                "prefs": felt_consts.config_prefs + [["marionette.port", 0]]
+                "learn_more_url": "",
+                "company_logo_url": "",
+                "policies": {"polling_frequency": 500},
+                "services": {
+                    "push_url": "",
+                    "remote_settings_url": "",
+                    "tokenserver_url": "",
+                },
+                "extra_prefs": [["marionette.port", 0]],
             })
-            contentType = "application/json"
 
         elif path == "/api/browser/policies":
             self.check_auth()

--- a/testing/enterprise/test_felt_browser_about_config_blocked.py
+++ b/testing/enterprise/test_felt_browser_about_config_blocked.py
@@ -9,7 +9,7 @@ import time
 
 sys.path.append(os.path.dirname(__file__))
 
-from felt_consts import config_prefs
+from felt_consts import firefox_config
 from felt_tests import FeltTests
 from marionette_driver.errors import UnknownException
 
@@ -51,17 +51,7 @@ class BrowserAboutConfigBlocked(FeltTests):
         self.policy_block_about_config.value = new_value
 
         # Polling frequency + 1s, defaulting to 2s in total if missing pref
-        waiting_time = (
-            next(
-                (
-                    v
-                    for k, v in config_prefs
-                    if k == "browser.policies.live_polling.frequency"
-                ),
-                1000,
-            )
-            / 1000
-        ) + 1
+        waiting_time = (firefox_config["polling_frequency"]["pref_value"] / 1000) + 1
         # Give time to make sure Policy got applied
         time.sleep(waiting_time)
         self._logger.info(

--- a/testing/enterprise/test_felt_browser_about_config_blocked.py
+++ b/testing/enterprise/test_felt_browser_about_config_blocked.py
@@ -50,7 +50,7 @@ class BrowserAboutConfigBlocked(FeltTests):
         self._logger.info("Changing BlockAboutConfig policy")
         self.policy_block_about_config.value = new_value
 
-        # Polling frequency + 1s, defaulting to 2s in total if missing pref
+        # Polling frequency + 1s
         waiting_time = (firefox_config["polling_frequency"]["pref_value"] / 1000) + 1
         # Give time to make sure Policy got applied
         time.sleep(waiting_time)

--- a/testing/enterprise/test_felt_browser_starts.py
+++ b/testing/enterprise/test_felt_browser_starts.py
@@ -15,4 +15,4 @@ class FeltStartsBrowserCli(FeltStartsBrowser):
     def test_felt_browser_start_from_cli(self):
         super().run_felt_base()
         self.run_felt_browser_started()
-        self.run_ensure_config_prefs_set_in_browser()
+        self.run_ensure_firefox_config_set_in_browser()


### PR DESCRIPTION
#### Changes
- Removes support for `api/browser/default` endpoint.
- Fetched Firefox configrations from `api/browser/config` endpoint.
- Sends configuration to Firefox via preferences through felt.

#### Tests
- [run_ensure_config_prefs_set_in_browser](https://searchfox.org/enterprise-main/rev/9042fdcca27a917ffddfd171644e103c676b4e58/testing/enterprise/felt_browser_starts.py#40-45) in `felt_browser_starts.py` tests that the config preferences are set in Firefox.