### PR TITLE
Bug 2028259 - Introduce user icon fallbacks in enterprise badge

### DIFF
--- a/browser/components/enterprise/EnterpriseHandler.sys.mjs
+++ b/browser/components/enterprise/EnterpriseHandler.sys.mjs
@@ -189,21 +189,55 @@ export const EnterpriseHandler = {
    */
   updateBadge(window) {
     this._updateLogo(window);
+    this._updateUserIcon(window);
+  },
 
-    const userIcon = window.document.querySelector("#enterprise-user-icon");
-
+  /**
+   * Updates the user icon in the enterprise badge
+   *
+   * If the signed-in user information is available:
+   * - Uses the user's picture url (provided by the IdP) when available.
+   * - Falls back to displaying user initials when no picture url is provided.
+   *
+   * Hides the user icon if no user information is currently available.
+   *
+   * @param {Window} window - The chrome window containing the enterprise UI elements.
+   * @returns {void}
+   */
+  _updateUserIcon(window) {
     if (!this._signedInUser) {
-      // Hide user icon from enterprise badge until we have user information
-      userIcon.hidden = true;
-      console.warn(
+      // No user information available so user icon remains hidden
+      lazy.log.warn(
         "Unable to update user icon in badge without user information"
       );
       return;
     }
-    userIcon.style.setProperty(
-      "list-style-image",
-      `url("${this._signedInUser.pictureUrl}")`
+
+    const wrapper = window.document.getElementById(
+      "enterprise-user-icon__wrapper"
     );
+    const { name, pictureUrl } = this._signedInUser;
+    if (pictureUrl) {
+      const userIcon = window.document.querySelector(
+        "#enterprise-user-icon__picture"
+      );
+      userIcon.style.setProperty(
+        "list-style-image",
+        `url("${this._signedInUser.pictureUrl}")`
+      );
+      wrapper.dataset.userIconType = "picture";
+    } else if (name) {
+      // Fallback to user initials
+      const initials = name.trim().charAt(0).toUpperCase();
+      const initialsDiv = window.document.getElementById(
+        "enterprise-user-icon__initials"
+      );
+      initialsDiv.textContent = initials;
+      wrapper.dataset.userIconType = "initials";
+    } else {
+      wrapper.dataset.userIconType = "avatar";
+    }
+    wrapper.classList.remove("is-hidden");
   },
 
   /**

--- a/browser/components/enterprise/EnterpriseHandler.sys.mjs
+++ b/browser/components/enterprise/EnterpriseHandler.sys.mjs
@@ -198,6 +198,7 @@ export const EnterpriseHandler = {
    * If the signed-in user information is available:
    * - Uses the user's picture url (provided by the IdP) when available.
    * - Falls back to displaying user initials when no picture url is provided.
+   * - Finally falls back to generic avatar icon if neither picture nor name available.
    *
    * Hides the user icon if no user information is currently available.
    *
@@ -221,14 +222,11 @@ export const EnterpriseHandler = {
       const userIcon = window.document.querySelector(
         "#enterprise-user-icon__picture"
       );
-      userIcon.style.setProperty(
-        "list-style-image",
-        `url("${this._signedInUser.pictureUrl}")`
-      );
+      userIcon.style.setProperty("list-style-image", `url("${pictureUrl}")`);
       wrapper.dataset.userIconType = "picture";
     } else if (name) {
       // Fallback to user initials
-      const initials = name.trim().charAt(0).toUpperCase();
+      const initials = name.trim().charAt(0).toLocaleUpperCase();
       const initialsDiv = window.document.getElementById(
         "enterprise-user-icon__initials"
       );

--- a/browser/components/enterprise/content/enterprise-badge.css
+++ b/browser/components/enterprise/content/enterprise-badge.css
@@ -39,7 +39,7 @@
 
 .enterprise-badge {
   height: var(--size-item-large);
-  padding: var(--space-xxsmall) var(--space-xsmall);
+  padding: var(--space-xsmall) var(--space-small);
   align-items: center;
   gap: var(--space-small);
 

--- a/browser/components/enterprise/content/enterprise-badge.css
+++ b/browser/components/enterprise/content/enterprise-badge.css
@@ -73,10 +73,52 @@
   }
 }
 
-#enterprise-user-icon {
+#enterprise-user-icon__wrapper {
   width: var(--icon-size-small);
   height: var(--icon-size-small);
   border-radius: var(--border-radius-circle);
+  overflow: hidden;
+}
+
+#enterprise-user-icon__picture,
+#enterprise-user-icon__initials,
+#enterprise-user-icon__avatar-wrapper {
+  width: 100%;
+  height: 100%;
+  display: none;
+}
+
+#enterprise-user-icon__initials,
+#enterprise-user-icon__avatar-wrapper {
+  background: var(--button-background-color);
+  align-items: center;
+  justify-content: center;
+}
+
+#enterprise-user-icon__avatar {
+  width: var(--icon-size-xsmall);
+  height: var(--icon-size-xsmall);
+  -moz-context-properties: fill;
+  fill: var(--button-icon-fill);
+  list-style-image: url(chrome://browser/content/enterprise/user-avatar.svg);
+}
+
+#enterprise-user-icon__initials {
+  color: var(--button-text-color);
+  font-weight: var(--font-weight-semibold);
+  line-height: normal;
+}
+
+#enterprise-user-icon__wrapper[data-user-icon-type="picture"] > #enterprise-user-icon__picture {
+  display: block;
+}
+
+#enterprise-user-icon__wrapper[data-user-icon-type="initials"] > #enterprise-user-icon__initials {
+  display: flex;
+}
+
+#enterprise-user-icon__wrapper[data-user-icon-type="avatar"] > #enterprise-user-icon__avatar-wrapper {
+  display: flex;
 }
 
 .is-hidden {

--- a/browser/components/enterprise/content/enterprise-badge.css
+++ b/browser/components/enterprise/content/enterprise-badge.css
@@ -74,8 +74,8 @@
 }
 
 #enterprise-user-icon {
-  width: var(--icon-size-medium);
-  height: var(--icon-size-medium);
+  width: var(--icon-size-small);
+  height: var(--icon-size-small);
   border-radius: var(--border-radius-circle);
 }
 

--- a/browser/components/enterprise/content/enterprise-badge.css
+++ b/browser/components/enterprise/content/enterprise-badge.css
@@ -85,7 +85,7 @@
 #enterprise-user-icon__avatar-wrapper {
   width: 100%;
   height: 100%;
-  display: none;
+  display: none; /* Overridden by rule below for specific available user icon type */
 }
 
 #enterprise-user-icon__initials,

--- a/browser/components/enterprise/content/enterprise-badge.inc.xhtml
+++ b/browser/components/enterprise/content/enterprise-badge.inc.xhtml
@@ -11,7 +11,13 @@
       <div id="enterprise-company-logo__wrapper" class="is-hidden">
         <image />
       </div>
-      <image id="enterprise-user-icon" />
+      <div id="enterprise-user-icon__wrapper" class="is-hidden">
+        <image id="enterprise-user-icon__picture" />
+        <div id="enterprise-user-icon__initials"></div>
+        <div id="enterprise-user-icon__avatar-wrapper">
+          <image id="enterprise-user-icon__avatar" />
+        </div>
+      </div>
     </div>
   </hbox>
 </toolbarbutton>

--- a/browser/components/enterprise/content/icons/user-avatar.svg
+++ b/browser/components/enterprise/content/icons/user-avatar.svg
@@ -1,0 +1,7 @@
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+<svg width="9" height="11" viewBox="0 0 9 11" fill="context-fill" xmlns="http://www.w3.org/2000/svg">
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M6.75 5.625C7.99275 5.625 9 6.63225 9 7.875V9.5625C9 9.9765 8.664 10.3125 8.25 10.3125H0.75C0.336 10.3125 0 9.9765 0 9.5625V7.875C0 6.63225 1.00725 5.625 2.25 5.625H6.75ZM2.25 6.75C1.62975 6.75 1.125 7.25475 1.125 7.875V9.1875H7.875V7.875C7.875 7.25475 7.37025 6.75 6.75 6.75H2.25Z" />
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M4.5 0C5.7945 0 6.84375 1.04925 6.84375 2.34375C6.84375 3.63825 5.7945 4.6875 4.5 4.6875C3.2055 4.6875 2.15625 3.63825 2.15625 2.34375C2.15625 1.04925 3.2055 0 4.5 0ZM4.5 1.125C3.828 1.125 3.28125 1.67175 3.28125 2.34375C3.28125 3.01575 3.828 3.5625 4.5 3.5625C5.172 3.5625 5.71875 3.01575 5.71875 2.34375C5.71875 1.67175 5.172 1.125 4.5 1.125Z" />
+</svg>

--- a/browser/components/enterprise/jar.mn
+++ b/browser/components/enterprise/jar.mn
@@ -11,6 +11,7 @@ browser.jar:
   content/browser/enterprise/enterprise-urlbar-actions.css  (content/enterprise-urlbar-actions.css)
   content/browser/enterprise/enterprise-urlbar-panels.inc.xhtml (content/enterprise-urlbar-panels.inc.xhtml)
   content/browser/enterprise/lockdown-mode.svg              (content/icons/lockdown-mode.svg)
+  content/browser/enterprise/user-avatar.svg                (content/icons/user-avatar.svg)
 
   content/builtin-themes/enterprise-light                   (theme/light/*.svg)
   content/builtin-themes/enterprise-light                   (theme/light/*.png)

--- a/testing/enterprise/test_felt_browser_enterprise_toolbar_button.py
+++ b/testing/enterprise/test_felt_browser_enterprise_toolbar_button.py
@@ -31,7 +31,7 @@ class EnterpriseBadgeTests(FeltTests):
         badge = self.get_elem_child("#enterprise-badge-toolbar-button")
 
         self._logger.info("Checking user icon is updated in badge.")
-        user_icon = self.get_elem_child("#enterprise-user-icon")
+        user_icon = self.get_elem_child("#enterprise-user-icon__picture")
         picture_url = user_icon.value_of_css_property("list-style-image")
         assert picture_url == f'url("{user["picture"]}")', (
             "User's picture not correctly set on user icon"


### PR DESCRIPTION
## Context
The `EnterpriseHandler` fetches signed-in user information via `GET` to `api/browser/whoami`. The console forwards the requests to the IdP and returns whatever user information the IdP returns. Aside from the key `email` we can't say for sure what information we can use (which returned values are not `null`). 
Currently, we always attempt to show the user's picture. If the IdP does not provide a `pictureUrl`, this results in an empty user icon being shown.

_Current UI with missing `pictureUrl`:_
<img width="280" height="43"  alt="Screenshot 2026-04-01 at 18 14 17" src="https://github.com/user-attachments/assets/81744727-154b-45a1-855d-44b16f528899" />


## Changes
- Display the user’s picture when `pictureUrl` is present.
- Fall back to displaying user initials (first letter of the `name` field) when `pictureUrl` is missing but `name` is available.
- Fall back to a generic user avatar when neither `pictureUrl` nor `name` is provided.

**Drive-by fixes:** 
- Adjust user icon size (`20px` to `16px`)
- Fix padding on `.enterprise-badge`

## Screenshots

Figma design link: https://www.figma.com/design/xYH6L8QrDz0Q16XFvdo7We/%F0%9F%A6%8A-Client-Design?node-id=1069-3121&m=dev

_Light mode with user icon type `picture`:_
<img width="280" height="43" alt="Screenshot 2026-04-01 at 18 03 55" src="https://github.com/user-attachments/assets/fb9c3815-90bd-456c-9377-f5ae0199e123" />

_Light mode with user icon type `initials`:_
<img width="279" height="40" alt="Screenshot 2026-04-01 at 18 04 40" src="https://github.com/user-attachments/assets/40cad39b-6142-4aa4-a17b-57ffbd0e867c" />


_Light mode with user icon type `avatar`:_
<img width="281" height="43" alt="Screenshot 2026-04-01 at 18 03 13" src="https://github.com/user-attachments/assets/214b0467-0439-4120-84a9-44c92d4c94a1" />

_Dark mode with user icon type `picture`:_
<img width="280" height="43" alt="Screenshot 2026-04-01 at 17 59 50" src="https://github.com/user-attachments/assets/6e91e318-d33e-4793-9993-be4531eb36d1" />

_Dark mode with user icon type `initials`:_
<img width="280" height="43" alt="Screenshot 2026-04-01 at 18 01 10" src="https://github.com/user-attachments/assets/97ca3a68-745e-4057-a673-085c4790ab0b" />

_Dark mode with user icon type `avatar`:_
<img width="280" height="43" alt="Screenshot 2026-04-01 at 18 01 55" src="https://github.com/user-attachments/assets/ea00b2ce-789b-48ce-9fee-2f314f46ad15" />