### PR TITLE
Bug 2028563: Give expected schema on policy testutils when empty policies

### DIFF
--- a/browser/components/enterprisepolicies/tests/browser/head.js
+++ b/browser/components/enterprisepolicies/tests/browser/head.js
@@ -37,12 +37,12 @@ async function setupPolicyEngineWithJson(json, customSchema, shutdown = false) {
   if (JSON.stringify(json) === "{}") {
     if (!shutdown) {
       return EnterprisePolicyTesting.servePolicyWithJson(
-        {},
+        { policies: {} },
         {},
         registerCleanupFunction
       );
     }
-    return EnterprisePolicyTesting.servePolicyWithJson({}, {});
+    return EnterprisePolicyTesting.servePolicyWithJson({ policies: {} }, {});
   }
   return EnterprisePolicyTesting.servePolicyWithJson(
     json,


### PR DESCRIPTION
Fixes " Engine is inactive at the start of the test". Fails in here without it https://searchfox.org/enterprise-main/source/toolkit/components/enterprisepolicies/EnterprisePoliciesParent.sys.mjs#1027
```
- browser_policies_notice_in_aboutpreferences.js
  - browser_policies_setAndLockPref_API.js
  - browser_policy_allowfileselectiondialogs.js
  - browser_policy_app_auto_update.js
  - browser_policy_app_update.js
  - browser_policy_background_app_update.js
  ```