### PR TITLE
Bug 2028555: Use default value in case for getStringPref in case pref is not set

### DIFF
--- a/browser/components/enterprise/EnterpriseHandler.sys.mjs
+++ b/browser/components/enterprise/EnterpriseHandler.sys.mjs
@@ -214,7 +214,7 @@ export const EnterpriseHandler = {
    * @returns {void}
    */
   _setupLearnMoreLink(win) {
-    const learnMoreUrl = Services.prefs.getStringPref(LEARN_MORE_URL_PREF);
+    const learnMoreUrl = Services.prefs.getStringPref(LEARN_MORE_URL_PREF, "");
 
     if (!learnMoreUrl) {
       lazy.log.warn("No learn more url available.");


### PR DESCRIPTION
Fixes
```
TEST-UNEXPECTED-FAIL | browser/base/content/test/popupNotifications/browser_popupNotification_no_anchors.js | uncaught exception - NS_ERROR_UNEXPECTED: Component returned failure code: 0x8000ffff (NS_ERROR_UNEXPECTED) [nsIPrefBranch.getStringPref] at 
```