### PR TITLE
Bug 2028569: Add badge as expected button in telemetry toolbar

### DIFF
--- a/browser/modules/test/browser/browser_UsageTelemetry_toolbars.js
+++ b/browser/modules/test/browser/browser_UsageTelemetry_toolbars.js
@@ -135,6 +135,10 @@ function assertVisibilityScalars(expected) {
     expected.push("menubar-items_pinned_menu-bar");
   }
 
+  if (AppConstants.MOZ_ENTERPRISE) {
+    expected.push("enterprise-badge-toolbar-button_pinned_nav-bar-end");
+  }
+
   // FIXME(bug 1883857): object metric type not available in artefact builds.
   const widgetPositions = Glean.browserUi.toolbarWidgets?.testGetValue();
   Services.fog.testResetFOG();


### PR DESCRIPTION
Fixes
```
TEST-UNEXPECTED-FAIL | browser/modules/test/browser/browser_UsageTelemetry_toolbars.js
```