### PR TITLE
Bug 2028565: Use overflows property to make the test pass

### DIFF
--- a/browser/components/enterprise/content/enterprise-badge.inc.xhtml
+++ b/browser/components/enterprise/content/enterprise-badge.inc.xhtml
@@ -2,8 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-<html:link rel="stylesheet" href="chrome://browser/content/enterprise/enterprise-badge.css" />
-<html:link rel="localization" href="browser/enterprise/enterprise.ftl" />
+<html:link rel="stylesheet" href="chrome://browser/content/enterprise/enterprise-badge.css" overflows="false"/>
+<html:link rel="localization" href="browser/enterprise/enterprise.ftl" overflows="false"/>
 
 <toolbarbutton id="enterprise-badge-toolbar-button" class="toolbarbutton-1" delegatesanchor="true" data-l10n-id="enterprise-toolbar-button" removable="false">
   <hbox>


### PR DESCRIPTION
Fixes JavaScript Error: "SyntaxError:   DocumentFragment.querySelector: '#' is not a valid selector.

There is some customizableui that checks if items are supposed to overflow on the toolbar and tries to use those html items id, as we have html:link those ones cannot have an id.  Adding "overflows" ignores the html items

https://searchfox.org/firefox-main/rev/07e27bfce5acf193bdb89c7ba2aa73451a3e43b4/browser/components/customizableui/CustomizableUI.sys.mjs#7809

https://searchfox.org/firefox-main/rev/07e27bfce5acf193bdb89c7ba2aa73451a3e43b4/browser/components/customizableui/PanelMultiView.sys.mjs#294


Issue in this test, but it happens in others
https://treeherder.mozilla.org/logviewer?job_id=558665153&repo=enterprise-firefox-pr&task=A2b8ttBMSauJuLmEQwunpA.0&lineNumber=2138

https://treeherder.mozilla.org/logviewer?job_id=558665153&repo=enterprise-firefox-pr&task=A2b8ttBMSauJuLmEQwunpA.0&lineNumber=50745