### PR TITLE
Bug 2028592: Use only enterprise on browser.toml (firefox not defined) r=jmendez

### DIFF
--- a/browser/components/downloads/test/unit/xpcshell.toml
+++ b/browser/components/downloads/test/unit/xpcshell.toml
@@ -15,9 +15,6 @@ firefox-appdir = "browser"
 
 ["test_DownloadsTelemetry_enterprise.js"]
 # Only run in MOZ_ENTERPRISE builds
-skip-if = [
-  "buildapp != 'firefox'",
-  "!enterprise",
-]
+run-if = ["enterprise"]
 
 ["test_DownloadsViewableInternally.js"]

--- a/browser/components/enterprisepolicies/tests/browser/browser.toml
+++ b/browser/components/enterprisepolicies/tests/browser/browser.toml
@@ -145,7 +145,4 @@ support-files = [
 
 ["browser_policy_websitefilter_telemetry.js"]
 # Only run in MOZ_ENTERPRISE builds
-skip-if = [
-  "buildapp != firefox",
-  "!enterprise",
-]
+run-if = ["enterprise"]


### PR DESCRIPTION
fixes
https://treeherder.mozilla.org/jobs?repo=enterprise-firefox-pr&selectedTaskRun=KJDvy73XSdudhfvENDsocw.0