### PR TITLE
Cleanup unused FXA path entries in ConsoleClient

### DIFF
--- a/browser/components/enterprise/modules/ConsoleClient.sys.mjs
+++ b/browser/components/enterprise/modules/ConsoleClient.sys.mjs
@@ -123,9 +123,6 @@ export const ConsoleClient = {
       DEVICE_POSTURE: "/sso/device_posture",
       WHOAMI: "/api/browser/whoami",
       FXACCOUNT: "/api/browser/account",
-      FXACCOUNTS_OAUTH: "/api/fxa/oauth/v1",
-      FXACCOUNTS_PROFILE: "/api/fxa/profile/v1",
-      FXACCOUNTS_AUTH: "/api/fxa/api/v1",
     };
   },
 


### PR DESCRIPTION
## Context

https://github.com/mozilla/enterprise-firefox/pull/571 moved setting and locking the fxa enterprise endpoints to `EnterpriseEndpoints.sys.mjs`. We missed to remove the unused fxa path entries from `ConsoleClient._paths`.

## Changes
- Removes the unused `ConsoleClient._paths`'s fxa entries