### PR TITLE
Fixes alphabetical order in testing/enterprise/manifest.toml

### DIFF
--- a/testing/enterprise/manifest.toml
+++ b/testing/enterprise/manifest.toml
@@ -2,9 +2,9 @@
 
 subsuite = "enterprise"
 
-["test_felt_browser_compulsory_restart.py"]
-
 ["test_felt_browser_about_config_blocked.py"]
+
+["test_felt_browser_compulsory_restart.py"]
 
 ["test_felt_browser_console_error.py"]
 
@@ -23,8 +23,6 @@ subsuite = "enterprise"
 ["test_felt_browser_fxa.py"]
 
 ["test_felt_browser_init_failures.py"]
-
-["test_felt_email_input_focus.py"]
 
 ["test_felt_browser_new_window_from_cli.py"]
 
@@ -48,11 +46,11 @@ run-if = [
 
 ["test_felt_browser_signout.py"]
 
-["test_felt_browser_token_refresh.py"]
-
 ["test_felt_browser_signout_verify.py"]
 
 ["test_felt_browser_starts.py"]
+
+["test_felt_browser_token_refresh.py"]
 
 ["test_felt_browser_updater_errors.py"]
 
@@ -65,5 +63,7 @@ run-if = [
 ["test_felt_browser_updates_forward.py"]
 
 ["test_felt_device_posture.py"]
+
+["test_felt_email_input_focus.py"]
 
 ["test_firefox_start.py"]


### PR DESCRIPTION
- Fixes eslinter error by correcting alphabetical order in `testing/enterprise/manifest.toml`