### PR TITLE
Bug 2012442 - Sign out session when Firefox exits normally

### DIFF
--- a/browser/extensions/felt/api.js
+++ b/browser/extensions/felt/api.js
@@ -28,6 +28,7 @@ ChromeUtils.defineESModuleGetters(lazy, {
   BrowserWindowTracker: "resource:///modules/BrowserWindowTracker.sys.mjs",
   FeltStorage: "resource:///modules/FeltStorage.sys.mjs",
   PrivateBrowsingUtils: "resource://gre/modules/PrivateBrowsingUtils.sys.mjs",
+  ConsoleClient: "resource:///modules/enterprise/ConsoleClient.sys.mjs",
   isBlockingShutdown: "resource:///modules/enterprise/EnterpriseCommon.sys.mjs",
   shouldNotCloseWindow:
     "resource:///modules/enterprise/EnterpriseCommon.sys.mjs",
@@ -247,15 +248,27 @@ this.felt = class extends ExtensionAPI {
           this
         );
 
-        // This is only useful for testing purpose when we need to exit the
-        // browser cleanly but need to keep felt alive for some processing after
-        if (!lazy.isBlockingShutdown()) {
-          Services.startup.quit(
-            Ci.nsIAppStartup.eAttemptQuit | Ci.nsIAppStartup.eConsiderQuit
-          );
-        } else if (!this._win) {
-          Services.felt.makeBackgroundProcess(false);
-          this.showWindow();
+        const doShutdown = () => {
+          // This is only useful for testing purpose when we need to exit the
+          // browser cleanly but need to keep felt alive for some processing after
+          if (!lazy.isBlockingShutdown()) {
+            Services.startup.quit(
+              Ci.nsIAppStartup.eAttemptQuit | Ci.nsIAppStartup.eConsiderQuit
+            );
+          } else if (!this._win) {
+            Services.felt.makeBackgroundProcess(false);
+            this.showWindow();
+          }
+        };
+
+        if (message.data?.performLogout === true) {
+          lazy.ConsoleClient._post(lazy.ConsoleClient._paths.SIGNOUT)
+            .catch(e => {
+              console.error(`FeltExtension: Failed to post signout: ${e}`);
+            })
+            .then(doShutdown);
+        } else {
+          doShutdown();
         }
         break;
       }

--- a/browser/extensions/felt/content/FeltProcessParent.sys.mjs
+++ b/browser/extensions/felt/content/FeltProcessParent.sys.mjs
@@ -427,7 +427,7 @@ export class FeltProcessParent extends JSProcessActorParent {
         );
 
         this.proc.exitPromise
-          .then(ev => {
+          .then(async ev => {
             lazy.ConsoleClient.isSessionRefreshBlocked = false;
             console.debug(`firefox exit: ev`, JSON.stringify(ev));
             console.debug(
@@ -438,6 +438,15 @@ export class FeltProcessParent extends JSProcessActorParent {
               if (this.proc.exitCode === 0) {
                 this.abnormalExitCounter = 0;
                 this.abnormalExitFirstTime = 0;
+                // A clean exit that wasn't a restart or explicit logout
+                // means the user closed Firefox. Sign out the session.
+                try {
+                  await lazy.ConsoleClient._post(
+                    lazy.ConsoleClient._paths.SIGNOUT
+                  );
+                } catch (e) {
+                  console.error(`FeltExtension: Failed to post signout: ${e}`);
+                }
                 Services.cpmm.sendAsyncMessage(
                   "FeltParent:FirefoxNormalExit",
                   {}

--- a/browser/extensions/felt/content/FeltProcessParent.sys.mjs
+++ b/browser/extensions/felt/content/FeltProcessParent.sys.mjs
@@ -427,7 +427,7 @@ export class FeltProcessParent extends JSProcessActorParent {
         );
 
         this.proc.exitPromise
-          .then(async ev => {
+          .then(ev => {
             lazy.ConsoleClient.isSessionRefreshBlocked = false;
             console.debug(`firefox exit: ev`, JSON.stringify(ev));
             console.debug(
@@ -438,19 +438,9 @@ export class FeltProcessParent extends JSProcessActorParent {
               if (this.proc.exitCode === 0) {
                 this.abnormalExitCounter = 0;
                 this.abnormalExitFirstTime = 0;
-                // A clean exit that wasn't a restart or explicit logout
-                // means the user closed Firefox. Sign out the session.
-                try {
-                  await lazy.ConsoleClient._post(
-                    lazy.ConsoleClient._paths.SIGNOUT
-                  );
-                } catch (e) {
-                  console.error(`FeltExtension: Failed to post signout: ${e}`);
-                }
-                Services.cpmm.sendAsyncMessage(
-                  "FeltParent:FirefoxNormalExit",
-                  {}
-                );
+                Services.cpmm.sendAsyncMessage("FeltParent:FirefoxNormalExit", {
+                  performLogout: true,
+                });
               } else {
                 this.handleRestartAfterAbnormalExit();
               }

--- a/testing/enterprise/felt_tests.py
+++ b/testing/enterprise/felt_tests.py
@@ -296,6 +296,8 @@ class ConsoleHttpHandler(LocalHttpRequestHandler):
             contentType = "text/xml"
 
         elif path == "/sso/callback":
+            self.server.policy_access_token.value = str(uuid.uuid4())
+            self.server.policy_refresh_token.value = str(uuid.uuid4())
             policy_access_token = self.server.policy_access_token.value
             policy_refresh_token = self.server.policy_refresh_token.value
 
@@ -424,6 +426,10 @@ class ConsoleHttpHandler(LocalHttpRequestHandler):
 
         elif path == "/sso/logout":
             self.check_auth()
+            with self.server.signout_count.get_lock():
+                self.server.signout_count.value += 1
+            self.server.policy_access_token.value = ""
+            self.server.policy_refresh_token.value = ""
             m = json.dumps(None)
 
         elif path == "/api/browser/forced_updates_count":
@@ -483,6 +489,7 @@ def serve(
     policy_access_token=None,
     policy_refresh_token=None,
     policies_fail_request=None,
+    signout_count=None,
     # TODO: Behavior is not yet clearly defined
     # device_posture_reply_forbidden=None,
 ):
@@ -504,6 +511,7 @@ def serve(
     httpd.policies_fail_request = (
         policies_fail_request if policies_fail_request is not None else Value("B", 0)
     )
+    httpd.signout_count = signout_count if signout_count is not None else Value("i", 0)
     httpd.serve_updates = False
     httpd.serve_updates_version = ""
     httpd.serve_forced_updates_count = 0
@@ -616,8 +624,9 @@ class FeltTestsBase(EnterpriseTestsBase):
         if hasattr(self, "EXTRA_PREFS"):
             self._extra_prefs.update(self.EXTRA_PREFS)
 
-        self.policy_access_token = SharedString(str(uuid.uuid4()))
-        self.policy_refresh_token = SharedString(str(uuid.uuid4()))
+        self.policy_access_token = SharedString("")
+        self.policy_refresh_token = SharedString("")
+        self.signout_count = Value("i", 0)
 
         self.console_httpd = Process(
             target=serve,
@@ -630,6 +639,7 @@ class FeltTestsBase(EnterpriseTestsBase):
                 policy_access_token=self.policy_access_token,
                 policy_refresh_token=self.policy_refresh_token,
                 policies_fail_request=self.policies_fail_request,
+                signout_count=self.signout_count,
                 # TODO: Behavior is not yet clearly defined
                 # device_posture_reply_forbidden=self.device_posture_reply_forbidden,
             ),

--- a/testing/enterprise/manifest.toml
+++ b/testing/enterprise/manifest.toml
@@ -46,6 +46,8 @@ run-if = [
 
 ["test_felt_browser_signout.py"]
 
+["test_felt_browser_signout_on_exit.py"]
+
 ["test_felt_browser_signout_verify.py"]
 
 ["test_felt_browser_starts.py"]

--- a/testing/enterprise/test_felt_browser_signout_on_exit.py
+++ b/testing/enterprise/test_felt_browser_signout_on_exit.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import os
+import sys
+
+sys.path.append(os.path.dirname(__file__))
+
+from base_test import Environment
+from felt_tests import FeltTests
+
+
+class BrowserSignoutOnExit(FeltTests):
+    """Verify that closing Firefox normally signs out the session."""
+
+    def test_browser_signout_on_exit(self):
+        self.get_driver(Environment.FELT).set_prefs(
+            {
+                "enterprise.felt_tests.should_not_close_window": True,
+                "enterprise.felt_tests.is_blocking_shutdown": True,
+            },
+            default_branch=True,
+        )
+        self.run_felt_base()
+        self.connect_child_browser()
+        self.assert_user_signed_in(env=Environment.FIREFOX)
+
+        browser_pid = self._child_driver.session_capabilities["moz:processID"]
+
+        assert self.signout_count.value == 0, "No signout should have been posted yet"
+
+        self.perform_quit()
+        self.wait_process_exit(browser_pid)
+        self.await_felt_auth_window()
+        self.force_window()
+
+        assert self.signout_count.value == 1, (
+            f"Expected exactly 1 signout request, got {self.signout_count.value}"
+        )
+
+        self.assert_user_signed_out(env=Environment.FELT)
+
+    def perform_quit(self):
+        driver = self.get_driver(Environment.FIREFOX)
+        driver.set_context("chrome")
+        driver.execute_script(
+            """
+            Services.startup.quit(Ci.nsIAppStartup.eForceQuit);
+            """,
+        )
+        driver.set_context("content")
+        self._manually_closed_child = True


### PR DESCRIPTION
Post /sso/logout from FELT when Firefox exits with code 0 and the exit was not a restart or explicit logout.