### PR TITLE
Bug 2028771 - Fix test_felt_version.py to not error on release builds

### DIFF
--- a/testing/enterprise/test_felt_version.py
+++ b/testing/enterprise/test_felt_version.py
@@ -11,7 +11,7 @@ sys.path.append(os.path.dirname(__file__))
 from felt_tests import FeltTestsBase
 
 
-class FeltEmailInputFocus(FeltTestsBase):
+class FeltVersion(FeltTestsBase):
     """
     Tests the Firefox version in the Felt window
     """
@@ -31,25 +31,25 @@ class FeltEmailInputFocus(FeltTestsBase):
             );
 
             const version = AppConstants.MOZ_APP_VERSION_DISPLAY;
+            let l10n_id = "felt-version";
+            let isodate = null;
+            const is_nightly = AppConstants.NIGHTLY_BUILD === true;
 
-            if (AppConstants.NIGHTLY_BUILD) {
+            if (is_nightly) {
                 const buildID = Services.appinfo.appBuildID;
                 const year = buildID.slice(0, 4);
                 const month = buildID.slice(4, 6);
                 const day = buildID.slice(6, 8);
 
-            return {
-                is_nightly: true,
-                l10n_id: "felt-version-nightly",
-                version,
-                isodate: `${year}-${month}-${day}`,
-            };
+                l10n_id = "felt-version-nightly";
+                isodate = `${year}-${month}-${day}`;
             }
 
             return {
-                l10n_id: "felt-version",
+                is_nightly,
+                l10n_id,
                 version,
-                isodate: null,
+                isodate,
             };
             """
         )


### PR DESCRIPTION
The test setup executes a script to return expected values. The setup was not returning the `is_nightly` key for non-nightly builds, and the check did not account for the missing key. I balanced the test setup to always include the key (with a false value for non-nightly builds).

This was found when doing the uplift of the felt version changes. I will include this in the uplift PR to verify that it fixes the issue.