### PR TITLE
Bug 2006564: Put app as active on startup(macos) and focus email on windows focus r=lissyx

### DIFF
--- a/browser/base/content/nonbrowser-mac.js
+++ b/browser/base/content/nonbrowser-mac.js
@@ -157,6 +157,11 @@ var NonBrowserWindow = {
       privateWindowItem.setAttribute("disabled", "true");
     }
 
+    // bug 2006564
+    // make sure that when application starts from dock it enforces windows'focus via activateApplication
+    // https://searchfox.org/enterprise-main/rev/4b4e7c59db50500302fa0e437ee07a84d92aa076/widget/nsIMacDockSupport.idl#36-45
+    this.dockSupport.activateApplication(true);
+
     waitForFeltFirefoxWindowReady().then(() => {
       if (newWindowItem) {
         newWindowItem.removeAttribute("disabled");

--- a/browser/extensions/felt/content/window.js
+++ b/browser/extensions/felt/content/window.js
@@ -480,15 +480,19 @@ function focusEmailOnLoginVisible() {
   const loginPane = document.querySelector(".felt-login");
   const emailInput = document.getElementById("felt-form__email");
 
-  new MutationObserver(() => {
+  function maybeFocusEmail() {
     if (!loginPane.classList.contains("is-hidden")) {
       emailInput?.focus();
     }
-  }).observe(loginPane, { attributeFilter: ["class"] });
-
-  if (!loginPane.classList.contains("is-hidden")) {
-    emailInput?.focus();
   }
+
+  new MutationObserver(maybeFocusEmail).observe(loginPane, {
+    attributeFilter: ["class"],
+  });
+
+  window.addEventListener("focus", maybeFocusEmail);
+
+  maybeFocusEmail();
 }
 
 /**


### PR DESCRIPTION
…indows focus

The app currently is not set as active if you start it from the dock or desktop in macos, I used this to verify(or you can see it is just behind apps)

` while true; do osascript -e 'tell application "System Events" to get name of (first application process whose frontmost is true)'; sleep 0.5; done`