### PR TITLE
Optimize out upload-symbols tasks on pull requests

### DIFF
--- a/taskcluster/gecko_taskgraph/decision.py
+++ b/taskcluster/gecko_taskgraph/decision.py
@@ -405,6 +405,11 @@ def get_decision_parameters(graph_config, options):
         )
         parameters.update(PER_PROJECT_PARAMETERS["default"])
 
+    if parameters.get("tasks_for", "").startswith("github-pull-request"):
+        parameters["optimize_strategies"] = (
+            "gecko_taskgraph.optimize:project.pull_request"
+        )
+
     # `target_tasks_method` has higher precedence than `project` parameters
     if options.get("target_tasks_method"):
         parameters["target_tasks_method"] = options["target_tasks_method"]

--- a/taskcluster/gecko_taskgraph/optimize/__init__.py
+++ b/taskcluster/gecko_taskgraph/optimize/__init__.py
@@ -131,6 +131,12 @@ class project:
     }
     """Strategy overrides that apply to beta."""
 
+    pull_request = {
+        "upload-symbols": Alias("always"),
+        "reprocess-symbols": Alias("always"),
+    }
+    """Strategy overrides that apply to pull requests."""
+
 
 class experimental:
     """Experimental strategies either under development or used as benchmarks.


### PR DESCRIPTION
Apply the same optimizations on github PRs that we do on try pushes.