### PR TITLE
Bug 2030373: add alias for felt for static css checks browser_parsable_css.js

### DIFF
--- a/browser/extensions/felt/jar.mn
+++ b/browser/extensions/felt/jar.mn
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 browser.jar:
+% content felt %builtin-addons/felt/content/
     builtin-addons/felt/api.js (api.js)
     builtin-addons/felt/background.js (background.js)
     builtin-addons/felt/content/ (content/*)


### PR DESCRIPTION
Fixes the test browser_parsable_css.js

https://treeherder.mozilla.org/logviewer?job_id=558736019&repo=enterprise-firefox-pr&task=MZMRdnfEQ06Ex_NCWMF5ug.0

Currently the mapping to chrome//felt is done at .js level (not static) and the tools fail to check for files

https://searchfox.org/enterprise-main/rev/e8c0742b4526a683d68073e2eed2ece46a5a7164/browser/extensions/felt/api.js#53
