### PR TITLE
Bug 2030603: restore breakpad.reportURL for mochitests

### DIFF
--- a/testing/profiles/mochitest/user.js
+++ b/testing/profiles/mochitest/user.js
@@ -37,6 +37,10 @@ user_pref("places.history.floodingPrevention.enabled", false);
 // don't do that.
 user_pref("geo.prompt.open_system_prefs", false);
 
-// Set a dummy push server URL for mochitest runs. In enterprise builds the
+// Set a push server URL for mochitest runs. In enterprise builds the
 // default is an empty string, but push tests need a non-empty value.
 user_pref("dom.push.serverURL", "wss://push.services.mozilla.com/");
+
+// Set a breakpad URL for mochitest runs. In enterprise builds the
+// default is an empty string, but push tests need a non-empty value.
+user_pref("breakpad.reportURL", "https://crash-stats.mozilla.org/report/index/");


### PR DESCRIPTION
Fixes the test toolkit/crashreporter/test/browser/browser_aboutCrashes.js

The issue is the setting was removed for enterprise builds (i.e populated from console)

https://searchfox.org/enterprise-main/rev/e8c0742b4526a683d68073e2eed2ece46a5a7164/browser/app/profile/firefox.js#1531

https://treeherder.mozilla.org/logviewer?job_id=558778676&repo=enterprise-firefox-pr&task=Emuk3kfTR2qd1zNLaLgPnA.0&lineNumber=19399