### PR TITLE
Bug 2030628: Do not put private properties in win + remove async from…

### DIFF
--- a/browser/base/content/browser-sets.js
+++ b/browser/base/content/browser-sets.js
@@ -15,7 +15,7 @@ document.addEventListener(
     document
       .getElementById("mainCommandSet")
       // eslint-disable-next-line complexity
-      .addEventListener("command", async event => {
+      .addEventListener("command", event => {
         switch (event.target.id) {
           case "cmd_newNavigator":
             OpenBrowserWindow();
@@ -202,7 +202,7 @@ document.addEventListener(
             gGestureSupport.rotateEnd();
             break;
           case "cmd_signoutEnterpriseUser":
-            await EnterpriseHandler.onSignOut(window);
+            EnterpriseHandler.onSignOut(window).catch(console.error);
             break;
           case "Browser:OpenLocation":
             openLocation(event);

--- a/browser/components/enterprise/EnterpriseHandler.sys.mjs
+++ b/browser/components/enterprise/EnterpriseHandler.sys.mjs
@@ -260,7 +260,6 @@ export const EnterpriseHandler = {
     lazy.log.debug(`Setting learn more uri to ${validLearnMoreUrl.href}`);
     learnMoreLink.setAttribute("href", validLearnMoreUrl.href);
 
-    win._isEnterpriseLearnMoreLinkConfigured = true;
     learnMoreLink.addEventListener("click", e => {
       let where = lazy.BrowserUtils.whereToOpenLink(e, false, false);
       if (where == "current") {
@@ -281,8 +280,9 @@ export const EnterpriseHandler = {
     win.PanelUI.showSubView("panelUI-enterprise", element, event);
     const document = element.ownerDocument;
 
-    if (!win._isEnterpriseLearnMoreLinkConfigured) {
+    if (!element._isEnterpriseLearnMoreLinkConfigured) {
       this._setupLearnMoreLink(win);
+      element._isEnterpriseLearnMoreLinkConfigured = true;
     }
 
     const email = document.querySelector(".panelUI-enterprise__email");


### PR DESCRIPTION
… cmds

Fixes the two issues that make the tests fail 
```MOZ_BYPASS_FELT=1 ./mach mochitest   browser/base/content/test/popupNotifications/browser_popupNotification_no_anchors.js``` 
```MOZ_BYPASS_FELT=1 ./mach mochitest  toolkit/components/printing/tests/browser_modal_print.js```

```test left unexpected property on window: _isEnterpriseLearnMoreLinkConfigured```

```
resource://testing-common/PromiseTestUtils.sys.mjs:assertNoUncaughtRejections:266
chrome://mochikit/content/browser-test.js:handleTask:1408
chrome://mochikit/content/browser-test.js:_runTaskBasedTest:1466
chrome://mochikit/content/browser-test.js:Tester_execTest:1617
chrome://mochikit/content/browser-test.js:nextTest/<:1356
chrome://mochikit/content/tests/SimpleTest/SimpleTest.js:SimpleTest.waitForFocus/<:1060
  FAIL testPrintMultiple - A promise chain failed to handle a rejection: Tab-modal print UI already open - stack: _openTabModalPrint@chrome://global/content/printUtils.js:181:13
 ```
 
 I also checked manually that when I open a new window the "learn more" button in the enterprise badge has the link ```github.com/mozilla/enterprise-firefox/```