### PR TITLE
Bug 2030640: Fix testPageBlockedByPolicy to use setupPolicyEngineWith…

### DIFF
--- a/browser/components/enterprisepolicies/tests/browser/head.js
+++ b/browser/components/enterprisepolicies/tests/browser/head.js
@@ -15,7 +15,7 @@ ChromeUtils.defineESModuleGetters(this, {
 
 PoliciesPrefTracker.start();
 
-async function setupPolicyEngineWithJson(json, customSchema, shutdown = false) {
+async function setupPolicyEngineWithJson(json, customSchema) {
   PoliciesPrefTracker.restoreDefaultValues();
   if (!Services.prefs.getBoolPref("browser.policies.testUseHttp", false)) {
     if (typeof json != "object") {
@@ -35,14 +35,11 @@ async function setupPolicyEngineWithJson(json, customSchema, shutdown = false) {
     );
   }
   if (JSON.stringify(json) === "{}") {
-    if (!shutdown) {
-      return EnterprisePolicyTesting.servePolicyWithJson(
-        { policies: {} },
-        {},
-        registerCleanupFunction
-      );
-    }
-    return EnterprisePolicyTesting.servePolicyWithJson({ policies: {} }, {});
+    return EnterprisePolicyTesting.servePolicyWithJson(
+      { policies: {} },
+      {},
+      registerCleanupFunction
+    );
   }
   return EnterprisePolicyTesting.servePolicyWithJson(
     json,


### PR DESCRIPTION
…Json wrapper

Fixes ```browser/components/enterprisepolicies/tests/browser/browser_policy_block_about.js```

```TEST-UNEXPECTED-FAIL | browser/components/enterprisepolicies/tests/browser/browser_policy_block_about.js | Cleanup function threw an exception - at resource://testing-common/EnterprisePolicyTesting.sys.mjs:88 - TypeError: registerCleanupFunction is not a function ```

testPageBlockedByPolicy was bypassing the head.js wrapper and calling EnterprisePolicyTesting.setupPolicyEngineWithJson directly this left _httpd uninitialized so the cleanup called servePolicyWithJson without registerCleanupFunction on a fresh server, causing a TypeError, leaked setInterval, and 404 spam
```
:13.90 GECKO(66642) console.warn: "RemotePoliciesProvider performPolling() with frequency 250 caused error Error: Fetch GET /api/browser/policies failed (404): <html>                    <head><title>404 Not Found</title></head>                    <body>                      <h1>404 Not Found</h1>                      <p>                        <span style='font-family: monospace;'>&#47;&#97;&#112;&#105;&#47;&#98;&#114;&#111;&#119;&#115;&#101;&#114;&#47;&#112;&#111;&#108;&#105;&#99;&#105;&#101;&#115;</span> was not found.                      </p>                    </body>                  </html>"
```