### PR TITLE
Bug 2030649: Fix BASE_CONSOLE_URI_PREFS test assertion to compare nor…

### DIFF
--- a/browser/components/enterprise/tests/browser/browser_enterprise_endpoints.js
+++ b/browser/components/enterprise/tests/browser/browser_enterprise_endpoints.js
@@ -36,7 +36,7 @@ add_task(async function test_endpoints_derived_from_console_address() {
   for (const pref of BASE_CONSOLE_URI_PREFS) {
     Assert.equal(
       Services.prefs.getStringPref(pref),
-      CONSOLE_ADDRESS_PREF_VALUE,
+      new URL(CONSOLE_ADDRESS_PREF_VALUE).href,
       `Expected ${pref} to be set to the console address`
     );
     Assert.ok(


### PR DESCRIPTION
…malized URL

The comparision in the test is failing "http://localhost:49437/" == "http://localhost:49437"

```
TEST-UNEXPECTED-FAIL | browser/components/enterprise/tests/browser/browser_enterprise_endpoints.js | test_endpoints_derived_from_console_address - Expected browser.ipProtection.guardian.endpoint to be set to the console address - "http://localhost:49437/" == "http://localhost:49437"
TEST-UNEXPECTED-FAIL | browser/components/enterprise/tests/browser/browser_enterprise_endpoints.js | test_endpoints_derived_from_console_address - Expected identity.fxaccounts.remote.root to be set to the console address - "http://localhost:49437/" == "http://localhost:49437
```