### PR TITLE
Bug 2030711 - Enterprise: do not set intl.locale.requested on deb repackage

### DIFF
--- a/browser/installer/linux/app/debian/distribution.ini
+++ b/browser/installer/linux/app/debian/distribution.ini
@@ -4,5 +4,4 @@ version=1.0
 about=Mozilla Firefox Debian Package
 
 [Preferences]
-intl.locale.requested=""
 browser.gnome-search-provider.enabled=true


### PR DESCRIPTION
Pref intl.locale.requested="" is useful on debian package when localization depends on langpack, which is not the case of Enterprise builds as of now. Removing it to ensure that FELT is not going to automagically fallback to en-US locale when ran on a system that is not a fr locale.

### Test plan
(adjust path as needed)
- `./mach build`
- `./mach package`
- `./mach repackage deb --arch x86_64 --templates browser/installer/linux/app/debian --version 151.0a1 --build-number 1 --product firefox --release-type nightly-enterprise --input obj-felt-dbg/dist/firefox-151.0a1.en-US.linux-x86_64.tar.xz --output obj-felt-dbg/dist/firefox-151.0a1.en-US.linux-x86_64.deb`
- `sudo dpkg -i obj-felt-dbg/dist/firefox-151.0a1.en-US.linux-x86_64.deb`
- `cat /usr/lib/firefoxenterprise/distribution/distribution.ini`: you should not see `intl.locale.requested=""`

(testing locale for real requires a locallized build which requires more work https://firefox-source-docs.mozilla.org/build/buildsystem/locales.html#instructions-for-single-locale-repacks-for-developers)