### PR TITLE
Bug 2030263 - Add created_at field to mock entitlement response in GuardianClient to fix Access Connector initialization

### DIFF
--- a/browser/components/ipprotection/GuardianClient.sys.mjs
+++ b/browser/components/ipprotection/GuardianClient.sys.mjs
@@ -247,6 +247,7 @@ export class GuardianClient {
         subscribed: true,
         uid: 1,
         maxBytes: "1000000",
+        created_at: new Date().toISOString(),
       });
       return { status: 200, entitlement };
     }


### PR DESCRIPTION
# Summary

This PR fixes Access Connector on `enterprise-release` by adding `created_at` to the mock `Entitlement` constructor payload, which was causing the Access Connector to throw when trying to create a new `Date` object.

## Related Issues

- Bug-2030263