### PR TITLE
Bug 2012690 - Enterprise: limit new windows on FELT

### DIFF
--- a/browser/base/content/browser-init.js
+++ b/browser/base/content/browser-init.js
@@ -197,6 +197,19 @@ var gBrowserInit = {
     // Call this after we set attributes that might change toolbars' computed
     // text color.
     ToolbarIconColor.init(window);
+
+    // Windows opened when running as Felt should not allow the user to escape
+    // hence remove toolbar, location bar, menubar
+    if (AppConstants.MOZ_ENTERPRISE && Services.felt?.isFeltUI()) {
+      [
+        "tabbrowser-tabs",
+        "toolbar-menubar",
+        "nav-bar",
+        "PersonalToolbar",
+      ].forEach(id => {
+        document.getElementById(id)?.setAttribute("hide-in-felt", "true");
+      });
+    }
   },
 
   onDOMContentLoaded() {

--- a/toolkit/themes/shared/global-shared.css
+++ b/toolkit/themes/shared/global-shared.css
@@ -421,3 +421,9 @@ button.text-link .button-text {
 #ContentSelectDropdown menuitem[indented] > .menu-text {
   padding-inline-start: var(--space-xxlarge);
 }
+
+/* When in Enterprise and running in Felt mode, some parts of browser should
+ * not be accessible */
+[hide-in-felt="true"] {
+  display: none;
+}


### PR DESCRIPTION
While running in FELT, it is not desirable that the user can escape the login process to browse the web as they like. During the SSO flow this can be triggered with one of the page offering a window.open() call, e.g. the Duo documentation. Let's limit the new windows opened in FELT mode to very limited ability to interact: no location bar, no toolbar, no menu.