### PR TITLE
Bug 2030963:  Add isEnterpriseManagedPrimaryPassword to LoginHelper mock in browser_primaryPassword test

### DIFF
--- a/browser/components/preferences/tests/credentials/browser_primaryPassword.js
+++ b/browser/components/preferences/tests/credentials/browser_primaryPassword.js
@@ -42,6 +42,10 @@ add_task(async function () {
     getOSAuthEnabled() {
       return true; // Since enabled by default.
     },
+    // Simulate non-enterprise-managed browser
+    isEnterpriseManagedPrimaryPassword() {
+      return false;
+    },
   };
 
   let checkbox = doc.querySelector("#useMasterPassword");
@@ -171,6 +175,10 @@ add_task(async function () {
     },
     getOSAuthEnabled() {
       return true; // Since enabled by default.
+    },
+    // Simulate non-enterprise-managed browser
+    isEnterpriseManagedPrimaryPassword() {
+      return false;
     },
   };
 


### PR DESCRIPTION
Fixes the test by adding missing method in mock (pretending we are not enterprise as it is m-c test)
```
MOZ_BYPASS_FELT=1 ./mach mochitest browser/components/preferences/tests/credentials/browser_primaryPassword.js           
```

Issue
```
JavaScript Error: "TypeError: LoginHelper.isEnterpriseManagedPrimaryPassword is not a function"
```