### PR TITLE
Bug 2030392: handle exception if browser closes faster than marionette request

### DIFF
--- a/testing/enterprise/test_felt_browser_token_refresh.py
+++ b/testing/enterprise/test_felt_browser_token_refresh.py
@@ -41,7 +41,16 @@ class BrowserTokenRefresh(FeltTests):
         with self.felt_logout_checker.assert_browser_logouts_with(
             "console-forced-logout"
         ):
-            self.get_logged_in_user_info(env=Environment.FIREFOX)
+            self._child_driver.set_context("chrome")
+            # Run synchronously without awaiting the promise — the only purpose is
+            # to trigger a 401/403 response which causes the browser to shut down.
+            self._child_driver.execute_script("""
+                const { ConsoleClient } = ChromeUtils.importESModule(
+                    "resource:///modules/enterprise/ConsoleClient.sys.mjs"
+                );
+                ConsoleClient.getLoggedInUserInfo();
+            """)
+
         self._manually_closed_child = True
         self.assert_child_browser_closed()
 


### PR DESCRIPTION
[Bug-2030392](https://bugzilla.mozilla.org/show_bug.cgi?id=2030392)
The browser is closing faster than marionette in the CI sometimes, this makes send_async_script request from marionette fail.
https://searchfox.org/enterprise-main/rev/8ad7bae3daf8c761d6611955fb03602820ef04a3/testing/enterprise/test_felt_browser_token_refresh.py#44
https://searchfox.org/enterprise-main/rev/8ad7bae3daf8c761d6611955fb03602820ef04a3/testing/enterprise/base_test.py#169

To prevent that we just add a try-catch