### PR TITLE
Bug 2030397: Do not use port 10080 for mock console as it is blocked by firefox

### DIFF
--- a/testing/enterprise/felt_tests.py
+++ b/testing/enterprise/felt_tests.py
@@ -7,13 +7,14 @@ import ctypes
 import datetime
 import json
 import os
-import random
 import shutil
+import socket
 import sys
 import tempfile
 import time
 import urllib.parse
 import uuid
+from contextlib import closing
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from multiprocessing import Array, Process, Value
 
@@ -599,6 +600,12 @@ class FeltLogoutChecker:
         return False
 
 
+def find_free_port():
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
 class FeltTestsBase(EnterpriseTestsBase):
     EXTRA_ENV = {}
 
@@ -606,8 +613,8 @@ class FeltTestsBase(EnterpriseTestsBase):
         # test_prefs = kwargs.get("test_prefs", [])
 
         self._manually_closed_child = False
-        self.console_port = random.randrange(10000, 14999)
-        self.sso_port = random.randrange(15000, 20000)
+        self.console_port = find_free_port()
+        self.sso_port = find_free_port()
         self.policy_block_about_config = Value("b", 1)
         self.policy_extensions = Value("B", 0)
         self.policies_fail_request = Value("B", 0)

--- a/testing/enterprise/test_felt_browser_console_error.py
+++ b/testing/enterprise/test_felt_browser_console_error.py
@@ -8,7 +8,7 @@ import sys
 
 sys.path.append(os.path.dirname(__file__))
 
-from felt_tests import FeltTestsBase
+from felt_tests import FeltTestsBase, find_free_port
 
 
 class FeltConsoleError(FeltTestsBase):
@@ -76,7 +76,7 @@ class FeltConsoleError(FeltTestsBase):
 
     def test_felt_error_details_include_console_address(self):
         # connectionFailure with host substitution so the console address appears in details.
-        refused_port = self.console_port + 20000
+        refused_port = find_free_port()
         console_addr = f"http://localhost:{refused_port}"
         return self.check_error_bar_message(
             console_addr,


### PR DESCRIPTION
The port 10080 is blocked on firefox, every once in a very while we get a CI failure because of this

https://searchfox.org/firefox-main/rev/6925ce3cf2987bec22cae8a32e1e8a57e49efd3b/netwerk/base/nsIOService.cpp#202