### PR TITLE
Bug 2031238:  Use about:buildconfig for restart checks and reduce connect_child_browser wait

### DIFF
--- a/testing/enterprise/base_test.py
+++ b/testing/enterprise/base_test.py
@@ -106,7 +106,7 @@ class EnterpriseTestsBase(MarionetteTestCase):
     def open_tab_child(self, url):
         return self._open_tab(url, self._child_driver)
 
-    def get_marionette_port(self, max_try=100):
+    def get_marionette_port(self, max_try):
         marionette_port_file = os.path.join(
             self._child_profile_path, "MarionetteActivePort"
         )
@@ -124,8 +124,10 @@ class EnterpriseTestsBase(MarionetteTestCase):
 
         return (marionette_port, marionette_port_file)
 
-    def connect_child_browser(self, capabilities=None):
-        (marionette_port, marionette_port_file) = self.get_marionette_port()
+    def connect_child_browser(self, capabilities=None, max_try=100):
+        (marionette_port, marionette_port_file) = self.get_marionette_port(
+            max_try=max_try
+        )
         assert marionette_port > 0, "Valid marionette port"
         self._logger.info(f"Marionette PORT: {marionette_port}")
 

--- a/testing/enterprise/felt_browser_crashes.py
+++ b/testing/enterprise/felt_browser_crashes.py
@@ -24,7 +24,8 @@ class BrowserCrashes(FeltTests):
         try:
             # This is going to trigger exception for sure
             self._logger.info("Crashing main process")
-            self.open_tab_child("about:crashparent")
+            self._child_driver.set_context("content")
+            self._child_driver.navigate("about:crashparent")
         except Exception as ex:
             self._logger.info(f"Caught exception {ex}")
         finally:
@@ -45,10 +46,11 @@ class BrowserCrashes(FeltTests):
         self.connect_child_browser()
         self._browser_pid = self._child_driver.session_capabilities["moz:processID"]
         self._logger.info(f"Connected to {self._browser_pid}")
-        self.open_tab_child("about:support")
+        with self._child_driver.using_context("content"):
+            self._child_driver.navigate("about:buildconfig")
 
-        version_box = self.get_elem_child("#version-box")
-        self._child_wait.until(lambda d: len(version_box.text) > 0)
+        build_flags_box = self.get_elem_child("p:last-child")
+        self._child_wait.until(lambda d: len(build_flags_box.text) > 0)
 
     def run_felt_crash_parent_twice(self):
         self._manually_closed_child = True

--- a/testing/enterprise/test_felt_browser_crash_restart.py
+++ b/testing/enterprise/test_felt_browser_crash_restart.py
@@ -25,13 +25,4 @@ class BrowserCrashRestart(BrowserCrashes):
         self.run_felt_proper_restart_again()
 
     def run_felt_proper_restart_again(self):
-        self._manually_closed_child = False
-        self.wait_process_exit(self._browser_pid)
-        self._logger.info("Connecting to new browser")
-        self.connect_child_browser()
-        self._browser_pid = self._child_driver.session_capabilities["moz:processID"]
-        self._logger.info(f"Connected to {self._browser_pid}")
-        self.open_tab_child("about:support")
-
-        version_box = self.get_elem_child("#version-box")
-        self._child_wait.until(lambda d: len(version_box.text) > 0)
+        self.run_felt_proper_restart()

--- a/testing/enterprise/test_felt_browser_shutdown_crash_exit.py
+++ b/testing/enterprise/test_felt_browser_shutdown_crash_exit.py
@@ -55,7 +55,7 @@ class BrowserShutdownCrash(FeltStartsBrowser):
         self.wait_process_exit(browser_pid)
         try:
             self._logger.info("Trying to connect to new browser")
-            self.connect_child_browser()
+            self.connect_child_browser(max_try=40)
             new_browser_pid = self._child_driver.session_capabilities["moz:processID"]
             assert browser_pid != new_browser_pid, (
                 f"PID should not be the same: {browser_pid} != {new_browser_pid}"


### PR DESCRIPTION


Navigate (instead of new tab) for speed in CI, use different page because the other one is loading dlls when querying for info