### PR TITLE
Bug 2031236: ensure child browser has harness prefs set before launch

### DIFF
--- a/testing/enterprise/base_test.py
+++ b/testing/enterprise/base_test.py
@@ -156,8 +156,6 @@ class EnterpriseTestsBase(MarionetteTestCase):
         self._logger.info(
             f"New Marionette MOVED OUT {marionette_port_file} TO {port_file_copy}"
         )
-        self._child_driver.set_pref("enterprise.is_testing", True)
-        self._child_driver.set_pref("enterprise.log_level", "Debug")
 
     def get_driver(self, env):
         return self._driver if env == Environment.FELT else self._child_driver

--- a/testing/enterprise/felt_tests.py
+++ b/testing/enterprise/felt_tests.py
@@ -23,6 +23,8 @@ from base_test import EnterpriseTestsBase
 from felt_consts import firefox_config
 from marionette_driver import expected
 from marionette_driver.by import By
+from marionette_driver.geckoinstance import DesktopInstance, GeckoInstance
+from mozprofile.prefs import Preferences
 
 
 class SharedString:
@@ -696,6 +698,7 @@ class FeltTestsBase(EnterpriseTestsBase):
             name="enterprise-tests-browser"
         )
         self._logger.info(f"Using browser profile at {self._child_profile_path}")
+        self._apply_marionette_and_local_prefs_to_child_profile()
 
         # Pref does not like passing '\' ?
         if sys.platform == "win32":
@@ -736,6 +739,22 @@ class FeltTestsBase(EnterpriseTestsBase):
         if hasattr(self, "_child_profile_path"):
             self._logger.info(f"Removing browser profile at {self._child_profile_path}")
             shutil.rmtree(self._child_profile_path, ignore_errors=True)
+
+    def _apply_marionette_and_local_prefs_to_child_profile(self):
+        prefs = {
+            k: v
+            for k, v in {
+                **GeckoInstance.required_prefs,
+                **DesktopInstance.desktop_prefs,
+            }.items()
+            # Drop prefs with %-style format placeholders (e.g. "%(server)s")
+            # as they require interpolation that isn't performed here.
+            if not isinstance(v, str) or "%" not in v
+        }
+        prefs.update({"enterprise.is_testing": True, "enterprise.log_level": "Debug"})
+        if hasattr(self, "EXTRA_CHILD_PREFS"):
+            prefs.update(self.EXTRA_CHILD_PREFS)
+        Preferences.write(os.path.join(self._child_profile_path, "user.js"), prefs)
 
     def set_string_pref(self, pref_name, pref_value):
         self._logger.info(f"Setting {pref_name} to {pref_value}")

--- a/testing/enterprise/manifest.toml
+++ b/testing/enterprise/manifest.toml
@@ -70,6 +70,8 @@ run-if = [
 
 ["test_felt_email_input_focus.py"]
 
+["test_felt_harness_prefs.py"]
+
 ["test_felt_version.py"]
 
 ["test_firefox_start.py"]

--- a/testing/enterprise/test_felt_browser_restart_is_quit.py
+++ b/testing/enterprise/test_felt_browser_restart_is_quit.py
@@ -47,6 +47,10 @@ class BrowserRestartIsQuit(FeltTests):
             self._logger.info("Received expected UnknownException")
         except NoSuchWindowException:
             self._logger.info("Received expected NoSuchWindowException")
+        except OSError:
+            self._logger.info(
+                "Firefox quit before execute_script returned, Marionette socket was closed"
+            )
         finally:
             self._logger.info(
                 f"Issued restartecting quit underway, checking PID {self._browser_pid}"

--- a/testing/enterprise/test_felt_browser_restart_works.py
+++ b/testing/enterprise/test_felt_browser_restart_works.py
@@ -37,6 +37,10 @@ class BrowserRestartWorks(FeltTests):
             self._logger.info("Received expected UnknownException")
         except NoSuchWindowException:
             self._logger.info("Received expected NoSuchWindowException")
+        except OSError:
+            self._logger.info(
+                "Firefox quit before execute_script returned, no data received over Marionette socket"
+            )
         finally:
             self._logger.info(
                 f"Issued restartecting quit underway, checking PID {self._browser_pid}"

--- a/testing/enterprise/test_felt_browser_signout.py
+++ b/testing/enterprise/test_felt_browser_signout.py
@@ -12,6 +12,7 @@ sys.path.append(os.path.dirname(__file__))
 from base_test import Environment
 from felt_tests import FeltTests
 from marionette_driver.errors import (
+    NoAlertPresentException,
     UnexpectedAlertOpen,
 )
 
@@ -33,14 +34,7 @@ class BaseBrowserSignout(FeltTests):
         self._driver.set_context("content")
         return private_cookies
 
-    def run_perform_signout(self):
-        self.connect_child_browser(
-            capabilities={
-                # Do not auto-handle prompts.
-                "unhandledPromptBehavior": "ignore"
-            }
-        )
-
+    def _do_signout(self):
         self.assert_user_signed_in(env=Environment.FIREFOX)
         # Cache email for later use in prefilled email input field assertion
         user = self.get_logged_in_user_info(env=Environment.FIREFOX)
@@ -66,14 +60,18 @@ class BaseBrowserSignout(FeltTests):
             pass
 
         self._logger.info("Waiting for the signout dialog to open")
-        alert = self._child_driver.switch_to_alert()
-        # Wait(self._child_driver, 5).until(alert)
 
-        self._logger.info(
-            "Signing out the user by clicking the Signout button in the dialog"
-        )
-        # This target the primary action, which is clicking the Signout button
-        alert.accept()
+        def wait_for_and_accept_alert(driver):
+            try:
+                driver.switch_to_alert().accept()
+                self._logger.info(
+                    "Signing out the user by clicking the Signout button in the dialog"
+                )
+                return True
+            except NoAlertPresentException:
+                return False
+
+        self._waiter(self._child_driver).until(wait_for_and_accept_alert)
 
         self._child_driver.set_context("content")
 
@@ -96,6 +94,15 @@ class BaseBrowserSignout(FeltTests):
         # Verify no cookies from the previous sign in session
         cookies = self.get_private_cookies()
         assert len(cookies) == 0, f"No private cookies, found {len(cookies)}"
+
+    def run_perform_signout(self):
+        self.connect_child_browser(
+            capabilities={
+                # Do not auto-handle prompts.
+                "unhandledPromptBehavior": "ignore"
+            }
+        )
+        self._do_signout()
 
     def run_prefilled_email_submit(self):
         self._driver.set_context("chrome")

--- a/testing/enterprise/test_felt_browser_signout_on_exit.py
+++ b/testing/enterprise/test_felt_browser_signout_on_exit.py
@@ -50,5 +50,10 @@ class BrowserSignoutOnExit(FeltTests):
             Services.startup.quit(Ci.nsIAppStartup.eForceQuit);
             """,
         )
-        driver.set_context("content")
+        try:
+            driver.set_context("content")
+        except OSError:
+            self._logger.info(
+                "Firefox quit before set_context returned, no data received over Marionette socket"
+            )
         self._manually_closed_child = True

--- a/testing/enterprise/test_felt_harness_prefs.py
+++ b/testing/enterprise/test_felt_harness_prefs.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import os
+import sys
+
+sys.path.append(os.path.dirname(__file__))
+
+from marionette_driver.geckoinstance import DesktopInstance, GeckoInstance
+from test_felt_browser_signout import BaseBrowserSignout
+
+
+class HarnessPrefs(BaseBrowserSignout):
+    EXTRA_PREFS = {
+        "enterprise.felt_tests.harness_sets_pref": True,
+    }
+    EXTRA_CHILD_PREFS = {
+        "enterprise.felt_tests.harness_sets_child_pref": True,
+    }
+
+    def _check_prefs(self, driver, expected_prefs, label):
+        failures = []
+        for pref_name, expected_value in expected_prefs.items():
+            actual = driver.get_pref(pref_name)
+            if actual != expected_value:
+                failures.append(
+                    f"  {pref_name}: expected {expected_value!r}, got {actual!r}"
+                )
+        assert not failures, f"[{label}] Pref mismatches:\n" + "\n".join(failures)
+
+    def _check_env(self, expected, excluded):
+        failures = []
+        with self._driver.using_context("chrome"):
+            for key, value in expected.items():
+                actual = self._driver.execute_script(
+                    """
+                    const env = Cc["@mozilla.org/process/environment;1"].getService(Ci.nsIEnvironment);
+                    return env.get(arguments[0]);
+                    """,
+                    script_args=[key],
+                )
+                if actual != value:
+                    failures.append(f"  {key}: expected {value!r}, got {actual!r}")
+            for key in excluded:
+                exists = self._driver.execute_script(
+                    """
+                    const env = Cc["@mozilla.org/process/environment;1"].getService(Ci.nsIEnvironment);
+                    return env.exists(arguments[0]);
+                    """,
+                    script_args=[key],
+                )
+                if exists:
+                    failures.append(f"  {key}: expected absent in Firefox process")
+        assert not failures, "Env mismatches:\n" + "\n".join(failures)
+
+    def run_check_felt_prefs(self):
+        self._check_prefs(self._driver, self._extra_prefs, "FELT UI")
+        self._check_env(
+            getattr(self, "EXTRA_ENV", {}),
+            getattr(self, "EXCLUDED_ENV", set()),
+        )
+
+    def run_check_child_prefs(self):
+        # EnterpriseEndpoints.init() sets and locks these prefs on the default branch,
+        # pointing them at the enterprise console. Mirror RELATIVE_CONSOLE_ENDPOINT_PREFS
+        # and BASE_CONSOLE_URI_PREFS from EnterpriseEndpoints.sys.mjs.
+        base = f"http://localhost:{self.console_port}/"
+        enterprise_prefs = {
+            "identity.fxaccounts.remote.oauth.uri": f"{base}api/fxa/oauth/v1",
+            "identity.fxaccounts.remote.profile.uri": f"{base}api/fxa/profile/v1",
+            "identity.fxaccounts.auth.uri": f"{base}api/fxa/api/v1",
+            "security.certerrors.mitm.priming.endpoint": f"{base}api/misc/mitm/",
+            "captivedetect.canonicalURL": f"{base}api/misc/portal/canonical.html",
+            "network.connectivity-service.IPv4.url": f"{base}api/misc/connectivity?ipv4",
+            "network.connectivity-service.IPv6.url": f"{base}api/misc/connectivity?ipv6",
+            "browser.ipProtection.guardian.endpoint": base,
+            "identity.fxaccounts.remote.root": base,
+        }
+
+        gecko_prefs = {
+            k: v
+            for k, v in GeckoInstance.required_prefs.items()
+            # Drop prefs with %-style format placeholders (e.g. "%(server)s")
+            # as they require interpolation that isn't performed here.
+            if (not isinstance(v, str) or "%" not in v) and k not in enterprise_prefs
+        }
+        child_prefs = {
+            **gecko_prefs,
+            **DesktopInstance.desktop_prefs,
+            **enterprise_prefs,
+            # services.settings.server is set to "" by FELT via FeltProcessParent,
+            # which forwards remote_settings_url from the console Firefox configuration.
+            "services.settings.server": "",
+            "enterprise.is_testing": True,
+            **self.EXTRA_CHILD_PREFS,
+        }
+        self._check_prefs(self._child_driver, child_prefs, "child browser")
+
+
+class HarnessPrefsTest(HarnessPrefs):
+    # Verifies that prefs and environment variables set by the harness are
+    # correctly propagated to both the FELT UI browser and the child browser.
+    # Three sequential tests each inject a distinct environment variable so
+    # that the "no_leakage" tests can also assert that env vars from earlier
+    # test runs are absent, catching any cross-test contamination.
+    _ENV_BY_TEST = {
+        "test_1_harness_prefs": {"ENTERPRISE_HARNESS_TEST_1": "first"},
+        "test_2_harness_prefs_no_leakage": {"ENTERPRISE_HARNESS_TEST_2": "second"},
+        "test_3_harness_prefs_no_leakage": {"ENTERPRISE_HARNESS_TEST_3": "third"},
+    }
+
+    def setUp(self):
+        # Inject the env var for this test and exclude all env vars from other
+        # tests, so run_check_felt_prefs can assert presence and absence.
+        self.EXTRA_ENV = self._ENV_BY_TEST.get(self._testMethodName, {})
+        self.EXCLUDED_ENV = {
+            key
+            for test_name, env in self._ENV_BY_TEST.items()
+            if test_name != self._testMethodName
+            for key in env
+        }
+        super().setUp()
+
+    def _run(self):
+        self.run_felt_chrome_on_email_submit()
+        self.run_check_felt_prefs()
+        self.run_wait_until_sso_loaded()
+        self.run_felt_perform_sso_auth()
+        self.connect_child_browser(capabilities={"unhandledPromptBehavior": "ignore"})
+        self.run_check_child_prefs()
+        self._do_signout()
+
+    def test_1_harness_prefs(self):
+        self._run()
+
+    def test_2_harness_prefs_no_leakage(self):
+        self._run()
+
+    def test_3_harness_prefs_no_leakage(self):
+        self._run()


### PR DESCRIPTION

Issue:  Currently the managed firefox is instanted with its own prefs, which differ from the marionette setup. This is causing issues in some tests (mainly signout verify), so closing the browser might get stuck for 10-30 seconds due to glean as far as I understand

Proposal-solution, prepopulate the same prefs we have for marionette tests before FX child is spawned. 

This fixes mainly the following test, to proper shutdown
```
https://searchfox.org/enterprise-main/rev/74d9e8ce44e87b187286e3bae4ac60962218a497/testing/enterprise/test_felt_browser_signout_verify.py#14
```

