### PR TITLE
Bug 2013821, Bug 2013823, Bug 2031742 - Set expected default theme in test when running in Enterprise

### DIFF
--- a/toolkit/mozapps/extensions/test/xpcshell/test_amo_stats_telemetry.js
+++ b/toolkit/mozapps/extensions/test/xpcshell/test_amo_stats_telemetry.js
@@ -40,7 +40,10 @@ add_setup(async () => {
   // xpcshell test environment and so here we force enable the default theme
   // (which is installed by disabled) to let this test to run across all builds
   // included the DevEdition beta builds.
-  if (AppConstants.MOZ_DEV_EDITION) {
+  // Similarly in Firefox Enterprise the default theme is expected to be
+  // firefox-enterprise-light@mozilla.org, but it isn't loaded in the minimal
+  // xpcshell test environment.
+  if (AppConstants.MOZ_DEV_EDITION || AppConstants.MOZ_ENTERPRISE) {
     const defaultTheme = await AddonManager.getAddonByID(
       "default-theme@mozilla.org"
     );

--- a/toolkit/mozapps/extensions/test/xpcshell/test_webextension_theme.js
+++ b/toolkit/mozapps/extensions/test/xpcshell/test_webextension_theme.js
@@ -48,8 +48,8 @@ add_task(async function setup_to_default_browserish_state() {
 
   await promiseStartupManager();
 
-  if (AppConstants.MOZ_DEV_EDITION) {
-    // Developer Edition selects the wrong theme by default.
+  if (AppConstants.MOZ_DEV_EDITION || AppConstants.MOZ_ENTERPRISE) {
+    // Developer Edition and Firefox Enterprise select the wrong theme by default.
     let defaultTheme = await AddonManager.getAddonByID(DEFAULT_THEME);
     await defaultTheme.enable();
   }


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla:
Bug-2013821
Bug-2013823
Bug-2031742

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->
The tests were failing because they expect the `default-theme@mozilla.org` to be installed. On Firefox Enterprise the default theme is instead `firefox-enterprise-light@mozilla.org`, but in the test environment the theme doesn't get loaded. This was apparently encountered also in Firefox Desktop DevEdition builds, in which case `default-theme@mozilla.org` is enabled for the tests. This change does the same for Enterprise builds.

Bug 2013823 captured a side effect of the failure in 2013821. When the test fails an assertion, the test is aborted and does not fully clean up. Fixing the assertion allows the cleanup to occur.

---

### Testing <!-- OPTIONAL -->

* [x] This is a fix to an existing test.

<!-- 
**Steps to verify changes:**
1. 
2. 
3. 

**Expected result:**
-->
