### PR TITLE
Bug 2031249: Move activate application on macos when the window is loaded (same pattern as nonbrowser-mac.js)

### DIFF
--- a/browser/base/content/nonbrowser-mac.js
+++ b/browser/base/content/nonbrowser-mac.js
@@ -157,11 +157,6 @@ var NonBrowserWindow = {
       privateWindowItem.setAttribute("disabled", "true");
     }
 
-    // bug 2006564
-    // make sure that when application starts from dock it enforces windows'focus via activateApplication
-    // https://searchfox.org/enterprise-main/rev/4b4e7c59db50500302fa0e437ee07a84d92aa076/widget/nsIMacDockSupport.idl#36-45
-    this.dockSupport.activateApplication(true);
-
     waitForFeltFirefoxWindowReady().then(() => {
       if (newWindowItem) {
         newWindowItem.removeAttribute("disabled");

--- a/browser/extensions/felt/content/window.js
+++ b/browser/extensions/felt/content/window.js
@@ -522,6 +522,17 @@ function setBuildVersion() {
   }
 }
 
+// bug 2006564
+// make sure that when application starts from dock it enforces windows' focus via activateApplication
+// https://searchfox.org/enterprise-main/rev/4b4e7c59db50500302fa0e437ee07a84d92aa076/widget/nsIMacDockSupport.idl#36-45
+function macosActivateApplication() {
+  if (lazy.AppConstants.platform === "macosx") {
+    Cc["@mozilla.org/widget/macdocksupport;1"]
+      .getService(Ci.nsIMacDockSupport)
+      .activateApplication(true);
+  }
+}
+
 window.addEventListener(
   "load",
   () => {
@@ -534,6 +545,7 @@ window.addEventListener(
     listenFormEmailSubmission();
     focusEmailOnLoginVisible();
     informAboutPotentialStartupFailure();
+    macosActivateApplication();
   },
   true
 );


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2031249

Currently activation is done outside of window.load and it potentially is creating an issue that is causing a crash. We follow t he same pattern than nonbrowser-mac.js to avoid issues

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on:

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

---

### Testing <!-- OPTIONAL -->

* [ ] Added tests
* [x] Manual testing performed

I did 1080(30x36) runs of testing/enterprise/test_felt_browser_rapid_new_windows_from_cli.py without showing the crash 

https://treeherder.mozilla.org/jobs?repo=enterprise-firefox-pr&selectedTaskRun=GZJzYnq4S1G5EWsRWVRmEw.0

<!-- 
**Steps to verify changes:**
1. 
2. 
3. 

**Expected result:**
-->
