### PR TITLE
Bug 2031964 - Enterprise: consider sleep events for force restart policy

### DIFF
--- a/browser/modules/UpdatePolicyEnforcer.sys.mjs
+++ b/browser/modules/UpdatePolicyEnforcer.sys.mjs
@@ -5,6 +5,7 @@
 const lazy = {};
 const PREF_APP_UPDATE_COMPULSORY_RESTART = "app.update.compulsory_restart";
 let deferredRestartTasks = null;
+let notification = null;
 
 ChromeUtils.defineESModuleGetters(lazy, {
   DeferredTask: "resource://gre/modules/DeferredTask.sys.mjs",
@@ -19,6 +20,7 @@ function forceRestart() {
 }
 
 function infobarDispatchCallback(action, _selectedBrowser) {
+  notification = null;
   if (action?.type === "USER_ACTION" && action.data?.type === "RESTART_APP") {
     forceRestart();
   }
@@ -62,7 +64,12 @@ function showNotificationToolbar(restartZonedDateTime) {
   if (!win) {
     return;
   }
-  lazy.InfoBar.showInfoBarMessage(win, message, infobarDispatchCallback);
+
+  lazy.InfoBar.showInfoBarMessage(win, message, infobarDispatchCallback).then(
+    notif => {
+      notification = notif;
+    }
+  );
 }
 
 /**
@@ -102,6 +109,7 @@ export function testingOnly_getTaskStatus() {
  * now: A Temporal.ZonedDateTime object representing the current time.
  * notificationPeriodHours: The minimum amount of time in hours between when an update has been staged and when a warning will be displayed
  * restartTimeOfDay: The time of day, in local time, that the restart will take place
+ * restartWasMissed: Bypass the next day enforcement if restart was missed (device sleeping for example)
  *
  * Returns:
  * {
@@ -110,7 +118,12 @@ export function testingOnly_getTaskStatus() {
  *  restartTimeOfDay: the wall-clock time of day when restart will happen.
  * }
  */
-export function calculateDelay(now, notificationPeriodHours, restartTimeOfDay) {
+export function calculateDelay(
+  now,
+  notificationPeriodHours,
+  restartTimeOfDay,
+  restartWasMissed = false
+) {
   const delayBeforeNotification = Temporal.Duration.from({
     hours: notificationPeriodHours,
   });
@@ -127,11 +140,13 @@ export function calculateDelay(now, notificationPeriodHours, restartTimeOfDay) {
       restartTime
     );
   // if (restartTimeOnNotificationDay - notificationDateTime < 1 hour) then restartTimeOnNotificationDay += 1 day
+  // and it was not a missed restart due to e.g. device sleep
   if (
     Temporal.Duration.compare(
       notificationDateTime.until(scheduledRestartZonedDateTime),
       Temporal.Duration.from({ hours: 1 })
-    ) < 0
+    ) < 0 &&
+    !restartWasMissed
   ) {
     // it's less than 1 hour until the restart time.
     scheduledRestartZonedDateTime = scheduledRestartZonedDateTime.add(
@@ -184,7 +199,7 @@ export function getCompulsoryRestartPolicy() {
 // This is the main entry point into this module.
 // This function is called when an update is staged, to set timers for
 // when to show the notification and when to force a restart.
-export function handleCompulsoryUpdatePolicy() {
+export function handleCompulsoryUpdatePolicy(restartWasMissed) {
   if (!deferredRestartTasks) {
     const compulsoryRestartSetting = getCompulsoryRestartPolicy();
     if (compulsoryRestartSetting) {
@@ -193,7 +208,8 @@ export function handleCompulsoryUpdatePolicy() {
         calculateDelay(
           now,
           compulsoryRestartSetting.NotificationPeriodHours,
-          compulsoryRestartSetting.RestartTimeOfDay
+          compulsoryRestartSetting.RestartTimeOfDay,
+          restartWasMissed
         );
       deferredRestartTasks = createDeferredRestartTasks(
         restartDelay,
@@ -204,6 +220,33 @@ export function handleCompulsoryUpdatePolicy() {
   }
 }
 
+export function maybeUpdateCompulsoryUpdatePolicy() {
+  if (!deferredRestartTasks) {
+    return;
+  }
+
+  const now = Temporal.Now.zonedDateTimeISO();
+  // Set a new pref value, disable existing deferred task and re-do
+  const nextRestart = now.add(Temporal.Duration.from({ minutes: 5 }));
+  const nextPref = JSON.stringify({
+    NotificationPeriodHours: 0,
+    RestartTimeOfDay: {
+      Hour: nextRestart.hour,
+      Minute: nextRestart.minute,
+    },
+  });
+  Services.prefs.setStringPref(PREF_APP_UPDATE_COMPULSORY_RESTART, nextPref);
+
+  deferredRestartTasks.deferredNotificationTask?.disarm();
+  deferredRestartTasks.deferredRestartTask?.disarm();
+  deferredRestartTasks = null;
+
+  notification.removeUniversalInfobars();
+  notification = null;
+
+  handleCompulsoryUpdatePolicy(true /* restartWasMissed */);
+}
+
 const observer = {
   observe: (_subject, topic, _data) => {
     switch (topic) {
@@ -211,6 +254,10 @@ const observer = {
       case "update-staged":
       case "felt-update-ready":
         handleCompulsoryUpdatePolicy();
+        break;
+      case "wake_notification":
+        maybeUpdateCompulsoryUpdatePolicy();
+        break;
     }
   },
 };
@@ -220,5 +267,6 @@ export const UpdatePolicyEnforcer = {
     Services.obs.addObserver(observer, "update-downloaded");
     Services.obs.addObserver(observer, "update-staged");
     Services.obs.addObserver(observer, "felt-update-ready");
+    Services.obs.addObserver(observer, "wake_notification");
   },
 };

--- a/browser/modules/test/browser/browser_UpdatePolicyEnforcer.js
+++ b/browser/modules/test/browser/browser_UpdatePolicyEnforcer.js
@@ -90,3 +90,62 @@ add_task(async function test_compulsoryRestartNotificationFromFelt() {
     await popPrefs();
   }
 });
+
+/**
+ * TODO:
+ */
+add_task(async function test_compulsoryRestartNotificationWake() {
+  await pushPrefs([prefName, JSON.stringify(prefValue)]);
+  try {
+    testingOnly_resetTasks();
+
+    let win = Services.wm.getMostRecentBrowserWindow();
+    for (let n of [...win.gNotificationBox.allNotifications]) {
+      n.dismiss();
+    }
+    Assert.equal(0, win.gNotificationBox.allNotifications.length);
+    const notificationPromise = BrowserTestUtils.waitForGlobalNotificationBar(
+      win,
+      "COMPULSORY_RESTART_SCHEDULED"
+    );
+    Services.obs.notifyObservers(null, "update-downloaded");
+    await notificationPromise;
+    Assert.equal(1, win.gNotificationBox.allNotifications.length);
+    Assert.equal(
+      "COMPULSORY_RESTART_SCHEDULED",
+      win.gNotificationBox.allNotifications[0].getAttribute("value")
+    );
+
+    const oldValue = JSON.parse(Services.prefs.getStringPref(prefName));
+
+    const shadow = win.gNotificationBox.allNotifications[0].openOrClosedShadowRoot;
+    const fluentDatetime = shadow.querySelector("remote-text").getAttribute("fluent-variable-datetime");
+
+    // Simulate sleep
+    const updatedNotificationPromise = BrowserTestUtils.waitForGlobalNotificationBar(
+      win,
+      "COMPULSORY_RESTART_SCHEDULED"
+    );
+    Services.obs.notifyObservers(null, "wake_notification");
+    await updatedNotificationPromise;
+
+    const newValue = JSON.parse(Services.prefs.getStringPref(prefName));
+
+    Assert.equal(oldValue.RestartTimeOfDay.Hour, 0);
+    Assert.notEqual(newValue.RestartTimeOfDay.Hour, 0);
+    Assert.notEqual(oldValue.RestartTimeOfDay.Minute, newValue.RestartTimeOfDay.Minute);
+
+    Assert.equal(1, win.gNotificationBox.allNotifications.length);
+    Assert.equal(
+      "COMPULSORY_RESTART_SCHEDULED",
+      win.gNotificationBox.allNotifications[0].getAttribute("value")
+    );
+
+    const updatedShadow = win.gNotificationBox.allNotifications[0].openOrClosedShadowRoot;
+    const updatedFluentDatetime = updatedShadow.querySelector("remote-text").getAttribute("fluent-variable-datetime");
+    Assert.notEqual(fluentDatetime, updatedFluentDatetime);
+  } finally {
+    testingOnly_resetTasks();
+    await popPrefs();
+  }
+});


### PR DESCRIPTION
The scheduled time for a restart may happen during device sleep, in which case no restart at all will be performed. Monitoring the wake_notification observer to check when device resumes whether the scheduled restart should have been done, and if that is the case, cancel the deferred task, remove the notification and prepare for a new forced restart in a couple of minutes.

<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2031964

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->


---

### Testing <!-- OPTIONAL -->

* [x] Manual testing performed

Confere https://bugzilla.mozilla.org/show_bug.cgi?id=2028364#c0

<!-- 
**Steps to verify changes:**
1. Send force restart policy from console `RelaunchRequired` (at least 1h after the current time otherwise it will schedule next day)
2. Restart
3. In browser console, `Services.obs.notifyObservers(null, "update-staged")`
4. Notification shows
5. Put device to sleep to cover the restart time
6. Put device back from sleep

**Expected result:**

Notification should be updated, new scheduled time being now +5min