### PR TITLE
Bug 2026004 - Add support for future SitePolicies in Lockdown Mode UX

### DIFF
--- a/browser/components/enterprise/EnterpriseHandler.sys.mjs
+++ b/browser/components/enterprise/EnterpriseHandler.sys.mjs
@@ -161,7 +161,7 @@ export const EnterpriseHandler = {
         }
         let isLockedDown = false;
         try {
-          isLockedDown = !Services.policies.isAllowedForURI("jit", location);
+          isLockedDown = Services.policies.hasSitePoliciesForURI(location);
         } catch (e) {
           lazy.log.warn("Failed to check lockdown state for URI: ", e);
         }

--- a/browser/components/enterprisepolicies/tests/xpcshell/test_sitepolicies.js
+++ b/browser/components/enterprisepolicies/tests/xpcshell/test_sitepolicies.js
@@ -35,6 +35,15 @@ function assertJitState(url, isAllowed) {
   );
 }
 
+function assertHasSitePolicy(url, expected) {
+  let uri = Services.io.newURI(url);
+  Assert.equal(
+    Services.policies.hasSitePoliciesForURI(uri),
+    expected,
+    `hasSitePoliciesForURI should return ${expected} for ${url}`
+  );
+}
+
 add_task(async function test_isAllowedForSite() {
   // Empty policies don't block anything
   await setupPolicyEngineWithJson({
@@ -264,4 +273,75 @@ add_task(async function test_isAllowedForSite() {
     "moz-nullprincipal:{56cac540-864d-47e7-8e25-1614eab5155e}",
     true
   );
+});
+
+add_task(async function test_hasSitePoliciesForURI() {
+  // No site policies → no URI matches
+  await setupPolicyEngineWithJson({
+    policies: {
+      SitePolicies: [],
+    },
+  });
+
+  assertHasSitePolicy("http://example.com/", false);
+  assertHasSitePolicy("http://example.net/", false);
+  assertHasSitePolicy(
+    "moz-nullprincipal:{56cac540-864d-47e7-8e25-1614eab5155e}",
+    false
+  );
+
+  // Simple match
+  await setupPolicyEngineWithJson({
+    policies: {
+      SitePolicies: [
+        {
+          Match: ["*.example.com"],
+          Policies: { DisableJit: true },
+        },
+      ],
+    },
+  });
+
+  assertHasSitePolicy("http://example.com/", true);
+  assertHasSitePolicy("http://www.example.com/", true);
+  assertHasSitePolicy("http://example.net/", false);
+  assertHasSitePolicy(
+    "moz-nullprincipal:{56cac540-864d-47e7-8e25-1614eab5155e}",
+    false
+  );
+
+  // URI in exceptions is not considered matched
+  await setupPolicyEngineWithJson({
+    policies: {
+      SitePolicies: [
+        {
+          Exceptions: ["*.example.com"],
+          Policies: { DisableJit: true },
+        },
+      ],
+    },
+  });
+
+  assertHasSitePolicy("http://example.com/", false);
+  assertHasSitePolicy("http://example.net/", true);
+  assertHasSitePolicy(
+    "moz-nullprincipal:{56cac540-864d-47e7-8e25-1614eab5155e}",
+    true
+  );
+
+  // A policy entry with no configured features still matches the URI.
+  // This differs from isAllowedForURI which falls through on empty features.
+  await setupPolicyEngineWithJson({
+    policies: {
+      SitePolicies: [
+        {
+          Match: ["*.example.com"],
+          Policies: {},
+        },
+      ],
+    },
+  });
+
+  assertHasSitePolicy("http://example.com/", true);
+  assertHasSitePolicy("http://example.net/", false);
 });

--- a/dom/ipc/gtest/ProcessIsolationTest.cpp
+++ b/dom/ipc/gtest/ProcessIsolationTest.cpp
@@ -93,6 +93,9 @@ class MockEnterprisePoliciesService final : public nsIEnterprisePolicies {
     *aRetVal = !gJitDisabled;
     return NS_OK;
   }
+  NS_IMETHOD HasSitePoliciesForURI(nsIURI*, bool* aRetVal) override {
+    return NS_ERROR_NOT_IMPLEMENTED;
+  }
   NS_IMETHOD GetActivePolicies(JS::MutableHandle<JS::Value>) override {
     return NS_ERROR_NOT_IMPLEMENTED;
   }

--- a/toolkit/components/enterprisepolicies/EnterprisePoliciesContent.sys.mjs
+++ b/toolkit/components/enterprisepolicies/EnterprisePoliciesContent.sys.mjs
@@ -69,6 +69,10 @@ export class EnterprisePoliciesManagerContent {
       uri
     );
   }
+
+  hasSitePoliciesForURI(uri) {
+    return lazy.SitePolicyUtils.hasSitePoliciesForURI(this.sitePolicies, uri);
+  }
 }
 
 EnterprisePoliciesManagerContent.prototype.QueryInterface =

--- a/toolkit/components/enterprisepolicies/EnterprisePoliciesParent.sys.mjs
+++ b/toolkit/components/enterprisepolicies/EnterprisePoliciesParent.sys.mjs
@@ -602,6 +602,10 @@ EnterprisePoliciesManager.prototype = {
     );
   },
 
+  hasSitePoliciesForURI(uri) {
+    return lazy.SitePolicyUtils.hasSitePoliciesForURI(SitePolicies, uri);
+  },
+
   getActivePolicies() {
     return this._parsedPolicies;
   },

--- a/toolkit/components/enterprisepolicies/SitePolicyUtils.sys.mjs
+++ b/toolkit/components/enterprisepolicies/SitePolicyUtils.sys.mjs
@@ -43,9 +43,10 @@ export const SitePolicyUtils = {
       }
 
       if (
-        policies.match.matches(uri) ||
-        // This is necessary to correctly match moz-nullprincipal URIs.
-        policies.match.matchesAllWebUrls
+        (policies.match.matches(uri) ||
+          // This is necessary to correctly match moz-nullprincipal URIs.
+          policies.match.matchesAllWebUrls) &&
+        Object.keys(policies.features).length
       ) {
         return true;
       }

--- a/toolkit/components/enterprisepolicies/SitePolicyUtils.sys.mjs
+++ b/toolkit/components/enterprisepolicies/SitePolicyUtils.sys.mjs
@@ -31,4 +31,26 @@ export const SitePolicyUtils = {
     // No site specific setting, fall back to the global setting.
     return manager.isAllowed(feature);
   },
+
+  hasSitePoliciesForURI(sitePolicies, uri) {
+    for (let policies of sitePolicies) {
+      if (
+        policies.exceptions.matches(uri) ||
+        // This is necessary to correctly match moz-nullprincipal URIs.
+        policies.exceptions.matchesAllWebUrls
+      ) {
+        continue;
+      }
+
+      if (
+        policies.match.matches(uri) ||
+        // This is necessary to correctly match moz-nullprincipal URIs.
+        policies.match.matchesAllWebUrls
+      ) {
+        return true;
+      }
+    }
+
+    return false;
+  },
 };

--- a/toolkit/components/enterprisepolicies/nsIEnterprisePolicies.idl
+++ b/toolkit/components/enterprisepolicies/nsIEnterprisePolicies.idl
@@ -39,6 +39,14 @@ interface nsIEnterprisePolicies : nsISupports
   boolean isAllowedForURI(in ACString feature, in nsIURI uri);
 
   /**
+   * Checks if any site policy applies to the given URI.
+   *
+   * @param uri The URI to check against.
+   * @returns A boolean - true if any site policy matches the URI.
+   */
+  boolean hasSitePoliciesForURI(in nsIURI uri);
+
+  /**
    * Get the active policies that have been successfully parsed.
    *
    * @returns A JS object that contains the policies names and


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [x] Ensure the linked Bugzilla item is up to date
- [x] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

This PR builds upon #554 which relied on the JIT-related policy check to toggle the Lockdown Mode urlbar button using `isAllowedForURI("jit")` which will not work as additional policies are added. The addition of `hasSitePoliciesForURI` checks for the existence of any policy on the given URI independent of which features are configured. 

Bugzilla: Bug-2026004

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on: #554 

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

No visual changes, screenshots should appear identical as they are on #554.

---

### Testing <!-- OPTIONAL -->

* [x] Added tests
* [x] Manual testing performed

**Steps to verify changes:**

1. `mach build`
2. Ensure policy is set with `SitePolicies`

```json
{
  "policies": {
    "SitePolicies": [
      {
        "Match": ["*.mozilla.org"],
        "Policies": {
          "DisableJit": true
        }
      }
    ]
  }
}
```

3. `mach run`
4. Verify policy is applied `about:policies`
5. Navigate to https://mozilla.org
6. Observe icon in URL bar and click for subpanel
7. Navigate to any other page or tab for icon to be removed

**Expected result:**

Lockdown mode UI displays for configured url patterns, and does not display for others.
