### PR TITLE
Bug 2005719 - Enterprise: Force Felt window focus when queueing pending links

### DIFF
--- a/browser/components/FeltURLHandler.sys.mjs
+++ b/browser/components/FeltURLHandler.sys.mjs
@@ -83,6 +83,7 @@ export function queueFeltURL(payload) {
       e
     );
     gFeltPendingURLs.push(payload);
+    Services.cpmm.sendAsyncMessage("FeltParent:ForceFeltFocus", {});
   }
 
   // On Linux (and as fallback for other platforms), show a notification

--- a/browser/extensions/felt/api.js
+++ b/browser/extensions/felt/api.js
@@ -234,6 +234,7 @@ this.felt = class extends ExtensionAPI {
         "FeltParent:TransitionFeltToBackground",
         this
       );
+      Services.ppmm.addMessageListener("FeltParent:ForceFeltFocus", this);
     } else if (Services.felt.isFeltBrowser()) {
       // In the real Firefox, register observer to handle URLs
       Services.obs.addObserver(this.urlObserver, "felt-open-url");
@@ -313,6 +314,16 @@ this.felt = class extends ExtensionAPI {
         this.closeWindow();
         const success = Services.felt.makeBackgroundProcess(true);
         lazy.log.debug(`FeltExtension: makeBackgroundProcess? ${success}`);
+        break;
+      }
+
+      case "FeltParent:ForceFeltFocus": {
+        lazy.log.debug(
+          `FeltExtension: forcing window focus: this._win=${this._win}`
+        );
+        if (this._win) {
+          this._win.focus();
+        }
         break;
       }
 

--- a/browser/extensions/felt/content/FeltProcessParent.sys.mjs
+++ b/browser/extensions/felt/content/FeltProcessParent.sys.mjs
@@ -44,6 +44,7 @@ export function queueURL(payload) {
   } else {
     // Queue at module level until ready
     gFeltPendingURLs.push(payload);
+    Services.cpmm.sendAsyncMessage("FeltParent:ForceFeltFocus", {});
   }
 }
 

--- a/testing/enterprise/manifest.toml
+++ b/testing/enterprise/manifest.toml
@@ -70,6 +70,8 @@ run-if = [
 
 ["test_felt_email_input_focus.py"]
 
+["test_felt_external_link.py"]
+
 ["test_felt_harness_prefs.py"]
 
 ["test_felt_version.py"]

--- a/testing/enterprise/test_felt_external_link.py
+++ b/testing/enterprise/test_felt_external_link.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import os
+import subprocess
+import sys
+
+sys.path.append(os.path.dirname(__file__))
+
+from felt_tests import FeltTests
+
+
+class FeltQueuesExternalLink(FeltTests):
+    def test_self_external_link(self):
+        # We do not start a browser
+        self._manually_closed_child = True
+        self._external_link = f"http://localhost:{self.console_port}/ping"
+        self.run_felt_open_external_link()
+
+    def get_focus_was_requested(self):
+        return self._driver.execute_script(
+            """
+            return window.focusWasRequested;
+            """
+        )
+
+    def run_felt_open_external_link(self):
+        self._driver.set_context("chrome")
+        self._driver.execute_script(
+            """
+            console.debug(`FeltTests: run_felt_open_external_link(): originalFocus`);
+            const originalFocus = window.focus.bind(window);
+            window.focusWasRequested = false;
+
+            console.debug(`FeltTests: run_felt_open_external_link(): window.focus() override`);
+            window.focus = function(...args) {
+              console.debug(`FeltTests: run_felt_open_external_link(): window.focus() override calls original`);
+              window.focusWasRequested = true;
+              return originalFocus(...args);
+            };
+            """
+        )
+        assert not self.get_focus_was_requested(), "Window requested focus"
+        self._logger.info(
+            "Window did not request focus, trying to open link from external app"
+        )
+
+        args = [
+            f"{self._driver.instance.binary}",
+            "-profile",
+            self._driver.profile,
+            self._external_link,
+        ]
+        subprocess.check_call(args, shell=False)
+
+        self._wait.until(lambda mn: self.get_focus_was_requested() is True)
+        self._logger.info("Window did request focus")


### PR DESCRIPTION
When the user triggers a new start of FELT by opening a link from a third party application, make sure to force focusing the FELT window for UX awareness of the action.

<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2005719

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Testing <!-- OPTIONAL -->

* [x] Added tests
* [x] Manual testing performed


**Steps to verify changes:**
1. Start Felt
2. Make sure it is not foreground
3. Open link from external application

**Expected result:**
Felt gets the focus
