### PR TITLE
Bug 2032093 - Re-enable eslint rule no-console in felt

### DIFF
--- a/browser/extensions/felt/.eslintrc.mjs
+++ b/browser/extensions/felt/.eslintrc.mjs
@@ -4,11 +4,6 @@
 
 export default [
   {
-    rules: {
-      "no-console": "off",
-    },
-  },
-  {
     files: ["content/window.js"],
     languageOptions: {
       globals: {


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2032093

Bug-2032016 converted all direct usages of the console Web API to instead create and use custom enterprise logger that is controlled by the pref `enterprise.log_level`. Hence we can re-enable the eslint rule no-console.
