### PR TITLE
Bug 2032305 - Enterprise: wait for distribution completion before getting enterprise console address

### DIFF
--- a/browser/components/distribution.sys.mjs
+++ b/browser/components/distribution.sys.mjs
@@ -4,6 +4,8 @@
 
 const DISTRIBUTION_CUSTOMIZATION_COMPLETE_TOPIC =
   "distribution-customization-complete";
+const DISTRIBUTION_PREFERENCES_COMPLETE_TOPIC =
+  "distribution-preferences-complete";
 
 const PREF_CACHED_FILE_EXISTENCE = "distribution.iniFile.exists.value";
 const PREF_CACHED_FILE_APPVERSION = "distribution.iniFile.exists.appversion";
@@ -618,15 +620,18 @@ DistributionCustomizer.prototype = {
     }
 
     let prefDefaultsApplied = this._prefDefaultsApplied || !this._ini;
-    if (
-      this._customizationsApplied &&
-      this._bookmarksApplied &&
-      prefDefaultsApplied
-    ) {
+    if (this._customizationsApplied && prefDefaultsApplied) {
       Services.obs.notifyObservers(
         null,
-        DISTRIBUTION_CUSTOMIZATION_COMPLETE_TOPIC
+        DISTRIBUTION_PREFERENCES_COMPLETE_TOPIC
       );
+
+      if (this._bookmarksApplied) {
+        Services.obs.notifyObservers(
+          null,
+          DISTRIBUTION_CUSTOMIZATION_COMPLETE_TOPIC
+        );
+      }
     }
   },
 };

--- a/browser/components/enterprise/EnterpriseEndpoints.sys.mjs
+++ b/browser/components/enterprise/EnterpriseEndpoints.sys.mjs
@@ -53,10 +53,10 @@ export const BASE_CONSOLE_URI_PREFS = new Set([
 ]);
 
 export const EnterpriseEndpoints = {
-  init() {
+  async init() {
     lazy.log.info("Setting and locking enterprise endpoints");
 
-    const consoleBaseURI = lazy.ConsoleClient.consoleBaseURI;
+    const consoleBaseURI = await lazy.ConsoleClient.consoleBaseURI;
 
     const defaultBranch = Services.prefs.getDefaultBranch("");
 

--- a/browser/components/enterprise/modules/ConsoleClient.sys.mjs
+++ b/browser/components/enterprise/modules/ConsoleClient.sys.mjs
@@ -81,6 +81,7 @@ class InvalidAuthError extends Error {
  */
 export const ConsoleClient = {
   _refreshPromise: null,
+  _consoleUriReadyPromise: null,
 
   /**
    * This is Felt-specific: While the browser is running, it has ownership of the
@@ -94,17 +95,57 @@ export const ConsoleClient = {
   /**
    * Base URL of the remote enterprise console
    *
-   * @returns {URL}
+   * @throws {Error}
+   * @returns {Promise<URL>}
    */
   get consoleBaseURI() {
-    let consoleURI;
-    try {
-      consoleURI = Services.prefs.getStringPref(CONSOLE_ADDRESS_PREF);
-    } catch (e) {
-      lazy.log.error("Critial misconfiguration: Missing console URI.");
-      throw e;
+    if (!this._consoleUriReadyPromise) {
+      this._consoleUriReadyPromise = new Promise((resolve, reject) => {
+        try {
+          const consoleURI = Services.prefs.getStringPref(CONSOLE_ADDRESS_PREF);
+          resolve(consoleURI);
+        } catch (e) {
+          lazy.log.warn(
+            `Missing console URI. Waiting on distribution customization to complete.`
+          );
+          const kDistributionPreferencesCompleteTopic =
+            "distribution-preferences-complete";
+          const distributionCompleteObserver = {
+            observe(_aSubject, aTopic, _aData) {
+              Services.obs.removeObserver(
+                distributionCompleteObserver,
+                "xpcom-shutdown"
+              );
+              Services.obs.removeObserver(
+                distributionCompleteObserver,
+                kDistributionPreferencesCompleteTopic
+              );
+              if (aTopic === kDistributionPreferencesCompleteTopic) {
+                try {
+                  const consoleURI =
+                    Services.prefs.getStringPref(CONSOLE_ADDRESS_PREF);
+                  resolve(consoleURI);
+                } catch (ex) {
+                  lazy.log.error(
+                    `Critical misconfiguration: Missing console URI`
+                  );
+                  reject(ex);
+                }
+              }
+            },
+          };
+          Services.obs.addObserver(
+            distributionCompleteObserver,
+            kDistributionPreferencesCompleteTopic
+          );
+          Services.obs.addObserver(
+            distributionCompleteObserver,
+            "xpcom-shutdown"
+          );
+        }
+      });
     }
-    return new URL(consoleURI);
+    return this._consoleUriReadyPromise.then(url => new URL(url));
   },
 
   /**
@@ -131,8 +172,8 @@ export const ConsoleClient = {
    * @param {string} path
    * @returns {string} Absolute URL string.
    */
-  constructURI(path) {
-    const url = this.consoleBaseURI;
+  async constructURI(path) {
+    const url = await this.consoleBaseURI;
     url.pathname = path;
     return url.href;
   },
@@ -144,9 +185,9 @@ export const ConsoleClient = {
    * @param {string} devicePostureToken - Token received for device posture
    * @returns {nsIURI}
    */
-  constructSsoLoginURI(email, devicePostureToken) {
+  async constructSsoLoginURI(email, devicePostureToken) {
     const deviceId = lazy.FeltStorage.getDeviceId();
-    const url = this.consoleBaseURI;
+    const url = await this.consoleBaseURI;
     url.pathname = this._paths.SSO;
     url.searchParams.set("target", "browser");
     url.searchParams.set("email", email);
@@ -163,15 +204,19 @@ export const ConsoleClient = {
    * @returns {string}
    */
   get ssoCallbackUriMatchPattern() {
-    // Dropping the port is required here because the matcher being used by
-    // JSActors code relies on WebExtensions MatchPattern
-    // https://searchfox.org/firefox-main/source/toolkit/components/extensions/MatchPattern.cpp#370-384
-    // The match pattern should then NOT use any port otherwise matching would
-    // not happen.
-    const url = this.consoleBaseURI;
-    url.pathname = this._paths.SSO_CALLBACK;
-    url.port = "";
-    return url.href + "?*";
+    // This should be: await this.consoleBaseURI but the method being a getter
+    // it cannot be marked "async", and thus cannot have "await" in its body.
+    return this.consoleBaseURI.then(url => {
+      url.pathname = this._paths.SSO_CALLBACK;
+
+      // Dropping the port is required here because the matcher being used by
+      // JSActors code relies on WebExtensions MatchPattern
+      // https://searchfox.org/firefox-main/source/toolkit/components/extensions/MatchPattern.cpp#370-384
+      // The match pattern should then NOT use any port otherwise matching would
+      // not happen.
+      url.port = "";
+      return url.href + "?*";
+    });
   },
 
   /**
@@ -312,7 +357,7 @@ export const ConsoleClient = {
    */
   async sendDevicePosture() {
     const devicePosture = await this._collectDevicePosture();
-    const url = this.constructURI(this._paths.DEVICE_POSTURE);
+    const url = await this.constructURI(this._paths.DEVICE_POSTURE);
 
     const res = await this._xhrFetch(url, {
       method: "POST",
@@ -374,7 +419,7 @@ export const ConsoleClient = {
       headers.set("Content-Type", "application/json");
     }
 
-    const url = this.constructURI(path);
+    const url = await this.constructURI(path);
     const res = await this._xhrFetch(url, {
       method,
       headers,
@@ -510,7 +555,7 @@ export const ConsoleClient = {
       }
       let res;
       try {
-        const url = this.constructURI(this._paths.TOKEN);
+        const url = await this.constructURI(this._paths.TOKEN);
         res = await this._xhrFetch(url, {
           method: "POST",
           headers: {
@@ -698,6 +743,7 @@ export const ConsoleClient = {
    */
   init() {
     Services.obs.addObserver(this, "xpcom-shutdown");
+    Services.prefs.addObserver("enterprise.console.address", this);
 
     if (Services.felt.isFeltBrowser()) {
       lazy.AsyncShutdown.appShutdownConfirmed.addBlocker(
@@ -726,8 +772,14 @@ export const ConsoleClient = {
     switch (topic) {
       case "xpcom-shutdown": {
         Services.obs.removeObserver(this, "xpcom-shutdown");
+        Services.prefs.removebserver("enterprise.console.address", this);
         this.clearTokenData(false);
         this._refreshPromise = null;
+        break;
+      }
+      case "nsPref:changed": {
+        // Console pref was changed, make sure new callers gets a new promise
+        this._consoleUriReadyPromise = null;
         break;
       }
     }

--- a/browser/extensions/felt/api.js
+++ b/browser/extensions/felt/api.js
@@ -59,11 +59,11 @@ this.felt = class extends ExtensionAPI {
       ["content", "felt", "content/"],
     ]);
   }
-  registerActors() {
+  async registerActors() {
     const { ConsoleClient } = ChromeUtils.importESModule(
       "resource:///modules/enterprise/ConsoleClient.sys.mjs"
     );
-    const matches = [ConsoleClient.ssoCallbackUriMatchPattern];
+    const matches = [await ConsoleClient.ssoCallbackUriMatchPattern];
     ChromeUtils.registerWindowActor(this.FELT_WINDOW_ACTOR, {
       parent: {
         esModuleURI: "chrome://felt/content/FeltWindowParent.sys.mjs",
@@ -220,7 +220,7 @@ this.felt = class extends ExtensionAPI {
       // SSO callback's DOMContentLoaded event and prevent token extraction.
       Services.prefs.setBoolPref("threads.use_low_power.enabled", false);
       this.registerChrome();
-      this.registerActors();
+      await this.registerActors();
       await lazy.FeltStorage.init();
       this.showWindow();
       Services.ppmm.addMessageListener("FeltParent:FirefoxNormalExit", this);

--- a/browser/extensions/felt/content/FeltProcessParent.sys.mjs
+++ b/browser/extensions/felt/content/FeltProcessParent.sys.mjs
@@ -267,10 +267,10 @@ export class FeltProcessParent extends JSProcessActorParent {
     };
   }
 
-  sendPrefsToFirefox() {
+  async sendPrefsToFirefox() {
     Services.felt.sendStringPreference(
       lazy.CONSOLE_ADDRESS_PREF,
-      lazy.ConsoleClient.consoleBaseURI
+      await lazy.ConsoleClient.consoleBaseURI
     );
 
     // Enables remote policy polling
@@ -410,7 +410,7 @@ export class FeltProcessParent extends JSProcessActorParent {
     this.firefox = this.startFirefoxProcess();
     this.firefox
       .then(async () => {
-        this.sendPrefsToFirefox();
+        await this.sendPrefsToFirefox();
         Services.felt.sendTokens();
         lazy.ConsoleClient.isSessionRefreshBlocked = true;
 

--- a/browser/extensions/felt/content/window.js
+++ b/browser/extensions/felt/content/window.js
@@ -138,7 +138,7 @@ async function connectToConsole(email) {
   let oa = E10SUtils.predictOriginAttributes({ browser });
   browser.setAttribute("maychangeremoteness", "true");
 
-  const ssoLoginURI = lazy.ConsoleClient.constructSsoLoginURI(
+  const ssoLoginURI = await lazy.ConsoleClient.constructSsoLoginURI(
     email,
     posture.posture
   );
@@ -179,7 +179,7 @@ async function connectToConsole(email) {
     60000
   );
   const callbackPattern = new MatchPattern(
-    lazy.ConsoleClient.ssoCallbackUriMatchPattern
+    await lazy.ConsoleClient.ssoCallbackUriMatchPattern
   );
 
   let ssoCompleted = false;

--- a/testing/enterprise/base_test.py
+++ b/testing/enterprise/base_test.py
@@ -5,6 +5,8 @@
 
 
 import os
+import shutil
+import sys
 import tempfile
 import time
 from copy import deepcopy
@@ -33,16 +35,25 @@ class EnterpriseTestsBase(MarionetteTestCase):
 
         super().setUp()
 
+        # All this needs to happen before process is started to avoid race
+        # conditions, but requires self.marionette that is setup by
+        # super().setUp() right above.
+        self.overwrite_distribution_ini()
+
         if hasattr(self, "_extra_cli_args"):
             self._saved_cli_args = deepcopy(self.marionette.instance.app_args)
             self.marionette.instance.app_args += self._extra_cli_args
 
+        self._logger.info("Marionette force quit with cleanup.")
         self.marionette.quit(in_app=False, clean=True)
+        self._logger.info("Marionette start new session, new instance expected.")
         self.marionette.start_session(timeout=60)
 
         if hasattr(self, "_extra_prefs"):
+            self._logger.info("Marionette enforcing gecko prefs")
             self.marionette.enforce_gecko_prefs(self._extra_prefs)
 
+        self._logger.info("Marionette ready")
         self._driver = self.marionette
 
         if hasattr(self, "setup"):
@@ -62,9 +73,73 @@ class EnterpriseTestsBase(MarionetteTestCase):
             self.marionette.instance.app_args = deepcopy(self._saved_cli_args)
             del self._saved_cli_args
 
+        # If there were prefs forced during setUp(), marionette's geckoinstance
+        # does cache them and on the next execution of enforce_gecko_pref(), if
+        # those prefs are not there anymore in self._extra_prefs, marionette code
+        # will fail to detect that prefs have changed, and not properly update
+        # the profile, resulting in prefs leaking between tests
+        if hasattr(self, "_extra_prefs"):
+            self.marionette.instance.prefs = None
+
         del os.environ["MOZ_DISABLE_NONLOCAL_CONNECTIONS"]
 
         self.marionette.quit(in_app=False, clean=True)
+
+        self.restore_distribution_ini()
+
+    def overwrite_distribution_ini(self):
+        # Some test may need a non modified distribution.ini, so respect it and
+        # and do not overwrite it when requested.
+        # Also some tests may not define a console port, so skip this for them.
+        if hasattr(self, "console_port") and not hasattr(self, "KEEP_DISTRIBUTION_INI"):
+            self.distribution_ini_path = self.get_distribution_ini(self.marionette)
+            self.distribution_ini_orig_path = os.path.join(
+                os.path.dirname(self.distribution_ini_path), "distribution.ini.orig"
+            )
+            assert os.path.isfile(self.distribution_ini_path)
+            self._logger.info(
+                f"Backup {self.distribution_ini_path} as {self.distribution_ini_orig_path}"
+            )
+            shutil.copy(self.distribution_ini_path, self.distribution_ini_orig_path)
+
+            self._logger.info(f"Writing console pref in {self.distribution_ini_path}")
+            with open(self.distribution_ini_path, "w") as dist_ini:
+                dist_ini.write(f"""# Test specific distribution.ini file
+[Global]
+id=enterprise-test
+version=1.0
+about=Mozilla Firefox Enterprise Test Build
+
+[Preferences]
+enterprise.console.address=http://localhost:{self.console_port}
+""")
+
+    def restore_distribution_ini(self):
+        if hasattr(self, "console_port") and not hasattr(self, "KEEP_DISTRIBUTION_INI"):
+            if os.path.isfile(self.distribution_ini_path):
+                os.unlink(self.distribution_ini_path)
+
+            if os.path.isfile(self.distribution_ini_orig_path):
+                shutil.copy(self.distribution_ini_orig_path, self.distribution_ini_path)
+                os.unlink(self.distribution_ini_orig_path)
+
+    def get_distribution_ini(self, driver):
+        dist_root = os.path.dirname(driver.instance.binary)
+        if sys.platform == "darwin":
+            dist_root = os.path.join(
+                os.path.dirname(os.path.dirname(driver.instance.binary)),
+                "Resources",
+            )
+
+        dist_ini = os.path.join(
+            dist_root,
+            "distribution",
+            "distribution.ini",
+        )
+        if not os.path.isfile(dist_ini):
+            raise ValueError(f"Missing {dist_ini}")
+
+        return dist_ini
 
     def get_profile_path(self, name):
         return tempfile.mkdtemp(

--- a/testing/enterprise/felt_tests.py
+++ b/testing/enterprise/felt_tests.py
@@ -631,7 +631,6 @@ class FeltTestsBase(EnterpriseTestsBase):
         """
 
         self._extra_prefs = {
-            "enterprise.console.address": f"http://localhost:{self.console_port}",
             "enterprise.is_testing": True,
             "enterprise.log_level": "Debug",
         }  # + test_prefs

--- a/testing/enterprise/test_felt_browser_console_error.py
+++ b/testing/enterprise/test_felt_browser_console_error.py
@@ -25,28 +25,32 @@ class FeltConsoleError(FeltTestsBase):
         error_msg=None,
         error_msg_contains=None,
     ):
-        self.set_string_pref("enterprise.console.address", console_addr)
 
-        self.submit_email()
+        with self._driver.using_prefs(
+            {"enterprise.console.address": console_addr}, default_branch=True
+        ):
+            self.submit_email()
 
-        self._driver.set_context("chrome")
-        error = self.get_elem(selector)
-        message = error.get_attribute("heading").strip()
-        assert expected_heading in message, f"Unexpected error message: {message}"
+            self._driver.set_context("chrome")
+            error = self.get_elem(selector)
+            message = error.get_attribute("heading").strip()
+            assert expected_heading in message, f"Unexpected error message: {message}"
 
-        if error_msg is not None:
-            details = self.get_elem(f"{selector} .felt-browser-error-details")
-            details_text = details.get_property("textContent").strip()
-            assert details_text == error_msg, f"Correct error message: '{details_text}'"
+            if error_msg is not None:
+                details = self.get_elem(f"{selector} .felt-browser-error-details")
+                details_text = details.get_property("textContent").strip()
+                assert details_text == error_msg, (
+                    f"Correct error message: '{details_text}'"
+                )
 
-        if error_msg_contains is not None:
-            details = self.get_elem(f"{selector} .felt-browser-error-details")
-            details_text = details.get_property("textContent").strip()
-            assert error_msg_contains in details_text, (
-                f"Expected '{error_msg_contains}' in error details: '{details_text}'"
-            )
+            if error_msg_contains is not None:
+                details = self.get_elem(f"{selector} .felt-browser-error-details")
+                details_text = details.get_property("textContent").strip()
+                assert error_msg_contains in details_text, (
+                    f"Expected '{error_msg_contains}' in error details: '{details_text}'"
+                )
 
-        self._driver.set_context("content")
+            self._driver.set_context("content")
 
     def test_felt_unreachable_ip_shows_connection_error(self):
         # Port 1 is on Firefox's blocked-port list, producing a generic "network"

--- a/testing/enterprise/test_felt_browser_updates_distIni.py
+++ b/testing/enterprise/test_felt_browser_updates_distIni.py
@@ -14,6 +14,8 @@ from felt_tests import FeltTests
 
 
 class FeltUpdatesDistIni(FeltTests):
+    KEEP_DISTRIBUTION_INI = True
+
     def test_felt_updates_dist_ini(self):
         self.run_verify_felt_app_update_url()
         # Browser is not being started in this test, so there is no need to
@@ -21,24 +23,9 @@ class FeltUpdatesDistIni(FeltTests):
         self._manually_closed_child = True
 
     def get_distribution_ini_console_address(self):
-        dist_root = os.path.dirname(self._driver.instance.binary)
-        if sys.platform == "darwin":
-            dist_root = os.path.join(
-                os.path.dirname(os.path.dirname(self._driver.instance.binary)),
-                "Resources",
-            )
-
-        dist_ini = os.path.join(
-            dist_root,
-            "distribution",
-            "distribution.ini",
-        )
-        if not os.path.isfile(dist_ini):
-            raise ValueError(f"Missing {dist_ini}")
-
+        dist_ini = self.get_distribution_ini(self._driver)
         ini = configparser.ConfigParser()
         ini.read(dist_ini)
-
         return ini["Preferences"]["enterprise.console.address"]
 
     def get_app_update_url(self, env):
@@ -52,7 +39,7 @@ class FeltUpdatesDistIni(FeltTests):
         test_pref = self._driver.get_pref(
             "enterprise.felt_tests.read_update_url_from_prefs"
         )
-        assert not test_pref, "Test perf for update url is not set"
+        assert not test_pref, "Test pref for update url is not set"
 
         update_url = self.get_app_update_url(Environment.FELT)
         update_url_end = "api/browser/updates/%PRODUCT%/%VERSION%/%BUILD_ID%/%BUILD_TARGET%/%LOCALE%/%CHANNEL%/%OS_VERSION%/%SYSTEM_CAPABILITIES%/%DISTRIBUTION%/%DISTRIBUTION_VERSION%/update.xml"


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2032305

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

### Summary

Expecting preferences from `distribution.ini` to be populated in time without any further verification is wrong as of now, we need to observe the `DistributionCustomizer` if the preference value does not exists.

Follow up have been filed:
 - improving this dependency: Bug-2032453
 - adding the pref specific observer topic: Bug-2032453