### PR TITLE
Bug 2032516:  Fix crash when extracting filename from forward-slash paths on Windows

### DIFF
--- a/browser/components/downloads/DownloadsTelemetry.enterprise.sys.mjs
+++ b/browser/components/downloads/DownloadsTelemetry.enterprise.sys.mjs
@@ -187,17 +187,10 @@ export const DownloadsTelemetryEnterprise = {
       let filename = null;
       let file_path = download.target?.path;
       if (file_path) {
-        try {
-          // PathUtils is available as a global WebIDL binding in this context.
-          filename = PathUtils.filename(file_path);
-        } catch (pathErr) {
-          console.warn(
-            `[DownloadsTelemetryEnterprise] PathUtils failed, falling back to split:`,
-            pathErr
-          );
-          const parts = file_path.split(/[/\\]/);
-          filename = parts[parts.length - 1] || "";
-        }
+        // PathUtils.filename() uses MOZ_RELEASE_ASSERT on Windows for forward
+        // slashes, causing a hard process crash not catchable from JS. Use
+        // cross-platform splitting to handle both separators safely.
+        filename = file_path.split(/[/\\]/).pop() || "";
       }
 
       // Extract file extension

--- a/browser/components/downloads/test/unit/test_DownloadsTelemetry_enterprise.js
+++ b/browser/components/downloads/test/unit/test_DownloadsTelemetry_enterprise.js
@@ -202,6 +202,38 @@ add_task(async function test_enterprise_data_parsing() {
       "Should record private browsing status"
     );
 
+    // Verify filename extraction works with Windows-style backslash paths
+    Services.fog.testResetFOG();
+
+    DownloadsTelemetryEnterprise.recordFileDownloaded({
+      target: {
+        path: "C:\\Users\\user\\Downloads\\document.pdf",
+        size: 12345,
+      },
+      source: { url: "https://example.com/document.pdf", isPrivate: false },
+      contentType: "application/pdf",
+      saver: mockDownload.saver,
+    });
+
+    const windowsEvents =
+      Glean.downloads.downloadCompleted.testGetValue("enterprise");
+    Assert.ok(windowsEvents, "Should have recorded events for Windows path");
+    Assert.equal(
+      windowsEvents[0].extra.filename,
+      "document.pdf",
+      "Should extract filename from Windows path"
+    );
+    Assert.equal(
+      windowsEvents[0].extra.extension,
+      "pdf",
+      "Should extract extension from Windows path"
+    );
+    Assert.equal(
+      windowsEvents[0].extra.file_path,
+      "C:\\Users\\user\\Downloads\\document.pdf",
+      "Should record Windows path as-is"
+    );
+
     // Test with edge cases - they should be handled gracefully
     Services.fog.testResetFOG();
 


### PR DESCRIPTION

<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [x] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2032516

An assert is firing and crashing the app ```MOZ_RELEASE_ASSERT(!aPath.Contains(u'/'))```

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on:

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

---

### Testing <!-- OPTIONAL -->

* [x] Added tests
* [x] Manual testing performed


See the runs
[Linux](https://treeherder.mozilla.org/logviewer?job_id=560629489&repo=enterprise-firefox-pr&task=RRmBjzcCSii-J0HNo0p3dQ.0&lineNumber=2167) 
[Windows](https://treeherder.mozilla.org/logviewer?job_id=560629572&repo=enterprise-firefox-pr&task=Ix-eja6QQqWvTPKGvCY2Dw.0&lineNumber=3843)
[MacOS](https://treeherder.mozilla.org/logviewer?job_id=560629580&repo=enterprise-firefox-pr&task=coI-4VBcR5a6BmsOKnk2RA.0&lineNumber=1651)



