### PR TITLE
Bug 2030392: Trigger a fetch policies request with invalid tokens expecting a forced logout on test

### DIFF
--- a/testing/enterprise/test_felt_browser_token_refresh.py
+++ b/testing/enterprise/test_felt_browser_token_refresh.py
@@ -14,6 +14,9 @@ from marionette_driver.by import By
 
 
 class BrowserTokenRefresh(FeltTests):
+    # make explicit as it is used to trigger 401 to close the browser
+    EXTRA_CHILD_PREFS = {"browser.policies.live_polling.frequency": 500}
+
     def setup(self):
         super().setup()
         self.felt_logout_checker = FeltLogoutChecker(self)
@@ -34,24 +37,17 @@ class BrowserTokenRefresh(FeltTests):
     def assert_browser_closes_on_401(self):
         old_access_token = self.policy_access_token.value
         old_refresh_token = self.policy_refresh_token.value
-        self.policy_access_token.value = ""
-        self.policy_refresh_token.value = ""
-
-        # Trigger an auth request with invalid tokens, expecting a forced logout.
+        self._manually_closed_child = True
+        # waits until firefox exits and gives the proper logout type
         with self.felt_logout_checker.assert_browser_logouts_with(
             "console-forced-logout"
         ):
-            self._child_driver.set_context("chrome")
-            # Run synchronously without awaiting the promise — the only purpose is
-            # to trigger a 401/403 response which causes the browser to shut down.
-            self._child_driver.execute_script("""
-                const { ConsoleClient } = ChromeUtils.importESModule(
-                    "resource:///modules/enterprise/ConsoleClient.sys.mjs"
-                );
-                ConsoleClient.getLoggedInUserInfo();
-            """)
+            # The context manager is listening for logout events. Once we invalidate
+            # the tokens, the next remote policies fetch
+            # will fail and trigger a "console-forced-logout".
+            self.policy_refresh_token.value = ""
+            self.policy_access_token.value = ""
 
-        self._manually_closed_child = True
         self.assert_child_browser_closed()
 
         self.await_felt_auth_window()


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [x] Ensure the linked Bugzilla item is up to date
- [x] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description 

Bugzilla: Bug-2030392

The recurring remote fetch of policies that the felt browser has is currently affecting the test, as it can also get a 401 and close firefox when the tokens are invalidated. The changes remove the extra request that was used and uses directly the fetch remote policies request to trigger the browser forced signout


### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on:

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

---

### Testing <!-- OPTIONAL -->

* [x] Added tests
* [x] Manual testing performed

<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
