### PR TITLE
[DO NOT SUBMIT]

### DIFF
--- a/toolkit/crashreporter/client/app/src/net/http.rs
+++ b/toolkit/crashreporter/client/app/src/net/http.rs
@@ -262,6 +262,7 @@ impl<'a> RequestBuilder<'a> {
         let mut cmd = crate::process::background_command("curl");
         let mut stdin: Option<Box<dyn Read + Send + 'static>> = None;
 
+        cmd.arg("--fail-with-body");
         cmd.args(["--user-agent", user_agent()]);
 
         match self {


### PR DESCRIPTION
## Yes
d26806c7f1e9 Bug-2032516:  Fix crash when extracting filename from forward-slash paths on Windows (#741) r=lissyx
8e6c06bf3c57 Bug-2031236: fix double HTTP response when check_auth fails in mock console (#738) r=lissyx
c042a8f36d07 Bug-2031236: ensure child browser has harness prefs set before launch (#722) r=lissyx
e6be18755dc3 Bug-2032093 - Re-enable eslint rule no-console in browser/extensions/felt (#736)
9a3fd5b6eaad Bug-2032016 - Control enterprise log level via preference enterprise.logLevel (#733)
487158c278c9 Bug-2031933 - Fix lint regression on GitHub PR template
b4e77777fab2 Bug-2031742 - Set expected default theme in test when running in Enterprise
6e2c2173cbd8 Bug-2030392: handle exception if browser closes faster than marionette request (#718)
b20c03b01441 Bug-2030397: Do not use port 10080 for mock console as it is blocked by firefox (#719)
c7f384297c20 Bug-2028592: Use only enterprise on browser.toml (firefox not defined)(#658) r=jmendez
b2c066fd1c17 Bug-2031252: fix reload_chrome_window race condition with page marker (#721)
b02939a4a855 Bug-2013821, Bug-2013823 - Set expected default theme in test when running in Enterprise
eea7b4942cac NO BUG - Add PR template (#713)
143df683ce15 Bug-2031238:  Use about:buildconfig for restart checks and reduce connect_child_browser wait (#720)
15140a6d22ba Bug-2026130:  Add isEnterpriseManagedPrimaryPassword to LoginHelper mock in browser_primaryPassword test (#715)
8ad7bae3daf8 fix: set release_type parameter on enteprise-firefox-try
75d5dc702f2b fix: set default parameters according to enterprise
18fa12423c8d Bug-2030628: Do not put private properties in win + remove async from cmds (#701)
b75e0414a1ed Bug-2012442 - Basic signout prompt UX plus signout on exit
181674f1ed61 Revert "Bug-2028602 - Enterprise: ensure macOS reads MAR channel IDs correctly"
b863510303eb Bug-2030649: Fix BASE_CONSOLE_URI_PREFS test assertion to compare normalized URL (#703)
74dd8aad6262 Bug-2030737 - Simulate user signed out of enterprise account
ed07f36795a5 Bug-2030603: restore breakpad.reportURL for mochitests (#699)
f1803e33aa50 Bug-2030373: add alias for felt for static css checks browser_parsable_css.js (#694)
213e60e29881 Bug-2030065 - Clear RS_FALLBACK_BASE_URL (#686)
3825a769c221 Bug-2030258: Prevent css serialize issue by not passing event to done (#691)
10d314d5d4a5 Bug-2028565: Use overflows to make the test pass on html:link (#657)
e8c0742b4526 Bug-2006564: Put app as active on startup(macos) and focus email on windows focus (#687) r=lissyx
71be19d37320 Bug-2021009 - [ci] Include 'enterprise-firefox-try' in additional transform logic
cd416fdf44bf Bug-2021009 - [ci] Declare build secrets in enterprise-firefox-try as well
c0b3d2c9d454 Set dom.push.serverURL on test setup (#604)
a9ddc477333d Bug-2028563: Give expected schema on policy testutils when empty policies (#654)
a80337b9ab19 Bug-2029685 - Avoid removing random blocked about pages if desired unblocked page is not currently blocked
dc03c1a25837 Bug-2027104 - Fix more live policy application issues
0c6b19bddd0c Bug-2029233 - Add missing items of expected format for distribution.ini
f8a64f91b93a Cleanup unused FXA path entries in ConsoleClient (#663)
24447cb4a3ee Bug-2027104 - Enterprise: Fix Policies application
1bea131a5d29 Bug-2021009 - Add target_tasks and release_product params for enterprise-firefox-try
ecf4dc9d6193 Bug-2021009 - Setup proper Treeherder routes for enterprise-firefox-try tasks
a03fe6c8a3ea Bug-2021009 - Run tasks on all 'enterprise-firefox-try' branches
115d9154353a Bug-2021009 - Set MACH_TRY_REMOTE to mozilla/enteprise-firefox-try
79e70319b753 Bug-2021009 - [ci] Ensure graph generation can succeed without `release_product` or `release_partner_config`
b28e926b221f Bug-2021009 - [ci] Cleanup some repackage transform logic
1750a3291cb7 Bug-2012458 - Policies for AI Chat Sidebar (#623)

## LATER

[Wait for #740] 4de545993012 Bug-2029205 - Enterprise: remove default enterprise.console.address value and rely only on distribution.ini

## NO

[151] 99f45d110fc4 Fix changes from bug 1950203 on enterprise-main merge
[151] cd4f0b18e595 Fix merge conflict mistake
[will lint as needed] 77593990170c Fix lint
[will lint as needed] 080b53226256 Lint browser/components/ipprotection/content/ipprotection-content.mjs
[151] 6297434c61ac Add cateogry, description and examples for policy XSLTEnabled (#692)
[will lint as needed] ccc56c3822e3 Lint repackage_partner.py
[will lint as needed] 0d3058604ad4 Lint policies-schema.json
[already fixed in release via conflict resolution] fa76d3752eea Bug-2021009 - [ci] Remove 'gecko' hardcode in win11 25h2 pools
[151] 22f4b9954810 Bug-2021009 - [try] Ensure we push to enterprise-firefox-try by default
[151] a963c7ec8679 Fix indirect merge conflict
[151] f2586d2af794 Fix syntax in merge conflict resolution
[151] ba669adcb26e Bug-2028749 - Enterprise: unblock bootstrap
[151] 16d1c2ac812e Fix build: Add AppConstants import to IPPFxaAuthProvider.sys.mjs
[151] 4f771b1ffd53 Add pull_request_number to taskcluster docs
[151] aa97c0b8e602 Bug-2027836 - [ci] Add 'pull_request_number' to graph config schema, r?#taskgraph-reviewers
[151] 6a1363967985 Bug-2021009 - Enterprise: allow overriding 'mach try' push remote via env
[will lint as needed] 2dfd3cd70204 Fix lint
[151] e35e4d67b15b Fix treeherder_group definition
[conflict not present in release] 1494cc82a9b4 Fix merge conflict leftover
[151] 76bfbd08beab Bug-2026142 - Enterprise: avoid duplicated 'checks' routes
