### PR TITLE
Bug 2019348 - Enterprise: fix test_no_window_update_restart.py

### DIFF
--- a/toolkit/mozapps/update/UpdateService.sys.mjs
+++ b/toolkit/mozapps/update/UpdateService.sys.mjs
@@ -579,7 +579,7 @@ function areDirectoryEntriesWriteable(aDir) {
   let items = aDir.directoryEntries;
   while (items.hasMoreElements()) {
     let item = items.nextFile;
-    if (!item.isWritable()) {
+    if (item && item.exists() && !item.isWritable()) {
       LOG("areDirectoryEntriesWriteable - unable to write to " + item.path);
       return false;
     }

--- a/toolkit/mozapps/update/tests/marionette/manifest.toml
+++ b/toolkit/mozapps/update/tests/marionette/manifest.toml
@@ -4,6 +4,6 @@ tags = "os_integration"
 
 ["test_no_window_update_restart.py"]
 run-if = [
-  "os == 'mac' && !enterprise", # Bug 2019348 - Test is failing and there is a "profile missing" window visible
+  "os == 'mac'"
 ]
 reason = "Test of a mac only feature"


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2019348

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

This re-enables the test, which was likely fixed in fact by Bug-2024587: there in `AppShutdown::MaybeDoRestart` profile path was being saved to an environment variable, but we were not handling that right.

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

---

### Testing <!-- OPTIONAL -->

* [x] Added tests
* [x] Manual testing performed

<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
