### PR TITLE
Enterprise uplift 2026041700

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -31,11 +31,11 @@ Bugzilla: Bug-<BUG_ID>
 * [ ] Added tests
 * [ ] Manual testing performed
 
-<!-- 
+<!--
 **Steps to verify changes:**
-1. 
-2. 
-3. 
+1.
+2.
+3.
 
 **Expected result:**
 -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,41 @@
+<!-- Nice PR, thanks for the work!
+
+## Checklist for the author (in addition to filling out the template)
+- [ ] Ensure the linked Bugzilla item is up to date
+- [ ] Provide sufficient implementation details in commit messages when necessary
+
+This helps reviewers quickly understand your changes. -->
+
+### Description <!-- REQUIRED -->
+
+Bugzilla: Bug-<BUG_ID>
+
+<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->
+
+---
+
+### Dependencies / Related Issues <!-- OPTIONAL -->
+
+* Depends on:
+
+---
+
+### Screenshots <!-- REQUIRED (if applicable) -->
+
+<!-- Please provide screenshots of UI changes (before/after if applicable). -->
+
+---
+
+### Testing <!-- OPTIONAL -->
+
+* [ ] Added tests
+* [ ] Manual testing performed
+
+<!-- 
+**Steps to verify changes:**
+1. 
+2. 
+3. 
+
+**Expected result:**
+-->

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -476,7 +476,9 @@ tasks:
                                                 - "tc-treeherder.v2.${project}-pr.${headRev}"
                                                 - "index.${trustDomain}.v2.${project}-pr.revision.${headRev}.taskgraph.decision"
                                             'eventType == "push"':
-                                                - "tc-treeherder.v2.${shortRef}.${headRev}"
+                                                - $switch:
+                                                      'project == "enterprise-firefox"': "tc-treeherder.v2.${shortRef}.${headRev}"
+                                                      $default: "tc-treeherder.v2.${project}.${headRev}"
                                                 - "index.${trustDomain}.v2.${project}.latest.taskgraph.decision"
                                                 - "index.${trustDomain}.v2.${project}.revision.${headRev}.taskgraph.decision"
                                             'tasks_for == "action"':

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -412,6 +412,7 @@ tasks:
                       $if: >
                         eventType in ["action", "cron"]
                         || (eventType == "push" && shortRef == "enterprise-release")
+                        || (eventType == "push" && project == "enterprise-firefox-try")
                         || (isPullRequest && eventAction in ["opened", "reopened", "synchronize"])
                       then:
                           $let:

--- a/browser/base/content/browser-sets.js
+++ b/browser/base/content/browser-sets.js
@@ -10,7 +10,7 @@ document.addEventListener(
     document
       .getElementById("mainCommandSet")
       // eslint-disable-next-line complexity
-      .addEventListener("command", async event => {
+      .addEventListener("command", event => {
         switch (event.target.id) {
           case "cmd_newNavigator":
             OpenBrowserWindow();
@@ -191,7 +191,7 @@ document.addEventListener(
             gGestureSupport.rotateEnd();
             break;
           case "cmd_signoutEnterpriseUser":
-            await EnterpriseHandler.onSignOut(window);
+            EnterpriseHandler.onSignOut(window).catch(console.error);
             break;
           case "Browser:OpenLocation":
             openLocation(event);

--- a/browser/base/content/nonbrowser-mac.js
+++ b/browser/base/content/nonbrowser-mac.js
@@ -157,6 +157,11 @@ var NonBrowserWindow = {
       privateWindowItem.setAttribute("disabled", "true");
     }
 
+    // bug 2006564
+    // make sure that when application starts from dock it enforces windows'focus via activateApplication
+    // https://searchfox.org/enterprise-main/rev/4b4e7c59db50500302fa0e437ee07a84d92aa076/widget/nsIMacDockSupport.idl#36-45
+    this.dockSupport.activateApplication(true);
+
     waitForFeltFirefoxWindowReady().then(() => {
       if (newWindowItem) {
         newWindowItem.removeAttribute("disabled");

--- a/browser/branding/enterprise/distribution.ini
+++ b/browser/branding/enterprise/distribution.ini
@@ -1,5 +1,10 @@
 # Default partner distribution configuration file
 # Must be replaced as part of a repack for Enterprise builds
 
+[Global]
+id=enterprise-local
+version=1.0
+about=Enterprise Local
+
 [Preferences]
 enterprise.console.address=https://stage.fx-enterprise.nonprod.webservices.mozgcp.net

--- a/browser/branding/enterprise/pref/firefox-enterprise.js
+++ b/browser/branding/enterprise/pref/firefox-enterprise.js
@@ -12,7 +12,7 @@ pref(
 pref("browser.profiles.enabled", false);
 pref("extensions.activeThemeID", "firefox-enterprise-light@mozilla.org");
 
-pref("enterprise.loglevel", "Error");
+pref("enterprise.log_level", "Error");
 
 pref("browser.newtabpage.activity-stream.feeds.section.topstories", false);
 

--- a/browser/components/BrowserGlue.sys.mjs
+++ b/browser/components/BrowserGlue.sys.mjs
@@ -79,6 +79,13 @@ ChromeUtils.defineESModuleGetters(lazy, {
   setTimeout: "resource://gre/modules/Timer.sys.mjs",
 });
 
+if (AppConstants.MOZ_ENTERPRISE) {
+  ChromeUtils.defineESModuleGetters(lazy, {
+    EnterpriseHandler:
+      "resource:///modules/enterprise/EnterpriseHandler.sys.mjs",
+  });
+}
+
 XPCOMUtils.defineLazyServiceGetters(lazy, {
   BrowserHandler: ["@mozilla.org/browser/clh;1", Ci.nsIBrowserHandler],
   PushService: ["@mozilla.org/push/Service;1", Ci.nsIPushService],
@@ -1539,6 +1546,23 @@ BrowserGlue.prototype = {
     // and also "we're quitting by closing the last window".
 
     if (aQuitType == "restart" || aQuitType == "os-restart") {
+      return;
+    }
+
+    // When Firefox was launched by FELT, show a signout confirmation prompt
+    // instead of the standard quit dialog.
+    if (
+      AppConstants.MOZ_ENTERPRISE &&
+      Services.felt?.isFeltBrowser() &&
+      lazy.EnterpriseHandler.isSignoutPromptEnabled()
+    ) {
+      const promptWindow = lazy.BrowserWindowTracker.getTopWindow({
+        allowFromInactiveWorkspace: true,
+      });
+      if (!lazy.EnterpriseHandler.showSignoutPrompt(promptWindow)) {
+        aCancelQuit.QueryInterface(Ci.nsISupportsPRBool).data = true;
+        this._quitSource = "unknown";
+      }
       return;
     }
 

--- a/browser/components/aboutwelcome/content-src/components/SingleSelect.jsx
+++ b/browser/components/aboutwelcome/content-src/components/SingleSelect.jsx
@@ -74,6 +74,7 @@ export const SingleSelect = ({
 
   const CONFIGURABLE_STYLES = [
     "background",
+    "backgroundImage",
     "borderRadius",
     "height",
     "marginBlock",

--- a/browser/components/aboutwelcome/content/aboutwelcome.bundle.js
+++ b/browser/components/aboutwelcome/content/aboutwelcome.bundle.js
@@ -3132,7 +3132,7 @@ const SingleSelect = ({
     }
   }, [activeSingleSelectSelections]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const CONFIGURABLE_STYLES = ["background", "borderRadius", "height", "marginBlock", "marginBlockStart", "marginBlockEnd", "marginInline", "paddingBlock", "paddingBlockStart", "paddingBlockEnd", "paddingInline", "paddingInlineStart", "paddingInlineEnd", "width"];
+  const CONFIGURABLE_STYLES = ["background", "backgroundImage", "borderRadius", "height", "marginBlock", "marginBlockStart", "marginBlockEnd", "marginInline", "paddingBlock", "paddingBlockStart", "paddingBlockEnd", "paddingInline", "paddingInlineStart", "paddingInlineEnd", "width"];
   return /*#__PURE__*/react__WEBPACK_IMPORTED_MODULE_0___default().createElement("div", {
     className: `tiles-single-select-container`
   }, /*#__PURE__*/react__WEBPACK_IMPORTED_MODULE_0___default().createElement("div", null, /*#__PURE__*/react__WEBPACK_IMPORTED_MODULE_0___default().createElement("fieldset", {

--- a/browser/components/downloads/DownloadsTelemetry.enterprise.sys.mjs
+++ b/browser/components/downloads/DownloadsTelemetry.enterprise.sys.mjs
@@ -187,17 +187,10 @@ export const DownloadsTelemetryEnterprise = {
       let filename = null;
       let file_path = download.target?.path;
       if (file_path) {
-        try {
-          // PathUtils is available as a global WebIDL binding in this context.
-          filename = PathUtils.filename(file_path);
-        } catch (pathErr) {
-          console.warn(
-            `[DownloadsTelemetryEnterprise] PathUtils failed, falling back to split:`,
-            pathErr
-          );
-          const parts = file_path.split(/[/\\]/);
-          filename = parts[parts.length - 1] || "";
-        }
+        // PathUtils.filename() uses MOZ_RELEASE_ASSERT on Windows for forward
+        // slashes, causing a hard process crash not catchable from JS. Use
+        // cross-platform splitting to handle both separators safely.
+        filename = file_path.split(/[/\\]/).pop() || "";
       }
 
       // Extract file extension

--- a/browser/components/downloads/test/unit/test_DownloadsTelemetry_enterprise.js
+++ b/browser/components/downloads/test/unit/test_DownloadsTelemetry_enterprise.js
@@ -202,6 +202,38 @@ add_task(async function test_enterprise_data_parsing() {
       "Should record private browsing status"
     );
 
+    // Verify filename extraction works with Windows-style backslash paths
+    Services.fog.testResetFOG();
+
+    DownloadsTelemetryEnterprise.recordFileDownloaded({
+      target: {
+        path: "C:\\Users\\user\\Downloads\\document.pdf",
+        size: 12345,
+      },
+      source: { url: "https://example.com/document.pdf", isPrivate: false },
+      contentType: "application/pdf",
+      saver: mockDownload.saver,
+    });
+
+    const windowsEvents =
+      Glean.downloads.downloadCompleted.testGetValue("enterprise");
+    Assert.ok(windowsEvents, "Should have recorded events for Windows path");
+    Assert.equal(
+      windowsEvents[0].extra.filename,
+      "document.pdf",
+      "Should extract filename from Windows path"
+    );
+    Assert.equal(
+      windowsEvents[0].extra.extension,
+      "pdf",
+      "Should extract extension from Windows path"
+    );
+    Assert.equal(
+      windowsEvents[0].extra.file_path,
+      "C:\\Users\\user\\Downloads\\document.pdf",
+      "Should record Windows path as-is"
+    );
+
     // Test with edge cases - they should be handled gracefully
     Services.fog.testResetFOG();
 

--- a/browser/components/downloads/test/unit/xpcshell.toml
+++ b/browser/components/downloads/test/unit/xpcshell.toml
@@ -15,9 +15,6 @@ firefox-appdir = "browser"
 
 ["test_DownloadsTelemetry_enterprise.js"]
 # Only run in MOZ_ENTERPRISE builds
-skip-if = [
-  "buildapp != 'firefox'",
-  "!enterprise",
-]
+run-if = ["enterprise"]
 
 ["test_DownloadsViewableInternally.js"]

--- a/browser/components/enterprise/EnterpriseCommon.sys.mjs
+++ b/browser/components/enterprise/EnterpriseCommon.sys.mjs
@@ -23,7 +23,15 @@ export const shouldNotCloseWindow = () => {
   return Services.prefs.getBoolPref(SHOULD_NOT_CLOSE_WINDOW, false);
 };
 
+const ENTERPRISE_LOG_LEVEL_PREF = "enterprise.log_level";
+
 export const EnterpriseCommon = {
   ENTERPRISE_DEVICE_ID_PREF: "enterprise.sync.device_id",
-  ENTERPRISE_LOGLEVEL_PREF: "enterprise.loglevel",
 };
+
+export function createEnterpriseLogger(logPrefix) {
+  return console.createInstance({
+    prefix: logPrefix,
+    maxLogLevelPref: ENTERPRISE_LOG_LEVEL_PREF,
+  });
+}

--- a/browser/components/enterprise/EnterpriseEndpoints.sys.mjs
+++ b/browser/components/enterprise/EnterpriseEndpoints.sys.mjs
@@ -6,14 +6,12 @@ const lazy = {};
 
 ChromeUtils.defineESModuleGetters(lazy, {
   ConsoleClient: "resource:///modules/enterprise/ConsoleClient.sys.mjs",
-  EnterpriseCommon: "resource:///modules/enterprise/EnterpriseCommon.sys.mjs",
+  createEnterpriseLogger:
+    "resource:///modules/enterprise/EnterpriseCommon.sys.mjs",
 });
 
 ChromeUtils.defineLazyGetter(lazy, "log", () => {
-  return console.createInstance({
-    prefix: "EnterpriseEndpoints",
-    maxLogLevelPref: lazy.EnterpriseCommon.ENTERPRISE_LOGLEVEL_PREF,
-  });
+  return lazy.createEnterpriseLogger("EnterpriseEndpoints");
 });
 
 // Todo: Bug 2024702

--- a/browser/components/enterprise/EnterpriseHandler.sys.mjs
+++ b/browser/components/enterprise/EnterpriseHandler.sys.mjs
@@ -260,7 +260,6 @@ export const EnterpriseHandler = {
     lazy.log.debug(`Setting learn more uri to ${validLearnMoreUrl.href}`);
     learnMoreLink.setAttribute("href", validLearnMoreUrl.href);
 
-    win._isEnterpriseLearnMoreLinkConfigured = true;
     learnMoreLink.addEventListener("click", e => {
       let where = lazy.BrowserUtils.whereToOpenLink(e, false, false);
       if (where == "current") {
@@ -281,8 +280,9 @@ export const EnterpriseHandler = {
     win.PanelUI.showSubView("panelUI-enterprise", element, event);
     const document = element.ownerDocument;
 
-    if (!win._isEnterpriseLearnMoreLinkConfigured) {
+    if (!element._isEnterpriseLearnMoreLinkConfigured) {
       this._setupLearnMoreLink(win);
+      element._isEnterpriseLearnMoreLinkConfigured = true;
     }
 
     const email = document.querySelector(".panelUI-enterprise__email");

--- a/browser/components/enterprise/EnterpriseHandler.sys.mjs
+++ b/browser/components/enterprise/EnterpriseHandler.sys.mjs
@@ -14,15 +14,13 @@ ChromeUtils.defineLazyGetter(lazy, "localization", () => {
 ChromeUtils.defineESModuleGetters(lazy, {
   BrowserUtils: "resource://gre/modules/BrowserUtils.sys.mjs",
   ConsoleClient: "resource:///modules/enterprise/ConsoleClient.sys.mjs",
-  EnterpriseCommon: "resource:///modules/enterprise/EnterpriseCommon.sys.mjs",
   isTesting: "resource:///modules/enterprise/EnterpriseCommon.sys.mjs",
+  createEnterpriseLogger:
+    "resource:///modules/enterprise/EnterpriseCommon.sys.mjs",
 });
 
 ChromeUtils.defineLazyGetter(lazy, "log", () => {
-  return console.createInstance({
-    prefix: "EnterpriseHandler",
-    maxLogLevelPref: lazy.EnterpriseCommon.ENTERPRISE_LOGLEVEL_PREF,
-  });
+  return lazy.createEnterpriseLogger("EnterpriseHandler");
 });
 
 const PROMPT_ON_SIGNOUT_PREF = "enterprise.prompt_on_signout";
@@ -142,7 +140,7 @@ export const EnterpriseHandler = {
       this._signedInUser = { name, email, pictureUrl: picture };
     } catch (e) {
       // TODO: Bug 2000864 - Handle unsuccessful GET /WHOAMI
-      console.warn(
+      lazy.log.warn(
         "EnterpriseHandler: Unable to initialize enterprise user: ",
         e
       );
@@ -290,7 +288,7 @@ export const EnterpriseHandler = {
       email.hidden = true;
       document.querySelector("#PanelUI-enterprise-email-separator").hidden =
         true;
-      console.warn(
+      lazy.log.warn(
         "Unable to update email in enterprise panel without user information"
       );
       return;
@@ -442,7 +440,7 @@ export const EnterpriseHandler = {
     try {
       await lazy.ConsoleClient.signoutUser();
     } catch (e) {
-      console.error(`Unable to signout the user: ${e}`);
+      lazy.log.error(`Unable to signout the user: ${e}`);
     } finally {
       Services.startup.quit(Ci.nsIAppStartup.eForceQuit);
     }

--- a/browser/components/enterprise/EnterpriseHandler.sys.mjs
+++ b/browser/components/enterprise/EnterpriseHandler.sys.mjs
@@ -5,10 +5,10 @@
 const lazy = {};
 
 ChromeUtils.defineLazyGetter(lazy, "localization", () => {
-  return new Localization([
-    "browser/enterprise/enterprise.ftl",
-    "branding/brand.ftl",
-  ]);
+  return new Localization(
+    ["browser/enterprise/enterprise.ftl", "branding/brand.ftl"],
+    true
+  );
 });
 
 ChromeUtils.defineESModuleGetters(lazy, {
@@ -25,7 +25,7 @@ ChromeUtils.defineLazyGetter(lazy, "log", () => {
   });
 });
 
-const PROMPT_ON_SIGNOUT_PREF = "enterprise.promptOnSignout";
+const PROMPT_ON_SIGNOUT_PREF = "enterprise.prompt_on_signout";
 const COMPANY_LOGO_URL_PREF = "enterprise.configs.company_logo_url";
 const LEARN_MORE_URL_PREF = "enterprise.configs.learn_more_url";
 
@@ -314,52 +314,123 @@ export const EnterpriseHandler = {
     window.PanelUI.mainView.setAttribute("restricted-enterprise-view", true);
   },
 
-  async onSignOut(window) {
-    const shouldInformOnSignout = Services.prefs.getBoolPref(
-      PROMPT_ON_SIGNOUT_PREF,
-      true
+  _getSignoutPromptParams() {
+    let tabCount = 0;
+    for (let win of Services.wm.getEnumerator("navigator:browser")) {
+      if (!win.closed && win.gBrowser) {
+        tabCount += win.gBrowser.openTabs.length;
+      }
+    }
+
+    const titleId = {
+      id: "enterprise-signout-prompt-title2",
+      args: { tabCount },
+    };
+
+    return {
+      titleId,
+      messageId: { id: "enterprise-signout-prompt-message" },
+      checkLabelId: { id: "enterprise-signout-prompt-checkbox-label" },
+      signoutBtnLabelId: { id: "enterprise-signout-prompt-primary-btn-label" },
+      flags:
+        Services.prompt.BUTTON_TITLE_IS_STRING * Services.prompt.BUTTON_POS_0 +
+        Services.prompt.BUTTON_TITLE_CANCEL * Services.prompt.BUTTON_POS_1 +
+        Services.prompt.BUTTON_POS_0_DEFAULT,
+    };
+  },
+
+  _handleSignoutPromptResult(buttonPressed, checked) {
+    if (buttonPressed === 1) {
+      return false;
+    }
+    if (!checked) {
+      Services.prefs.setBoolPref(PROMPT_ON_SIGNOUT_PREF, false);
+    }
+    return true;
+  },
+
+  isSignoutPromptEnabled() {
+    return Services.prefs.getBoolPref(PROMPT_ON_SIGNOUT_PREF, true);
+  },
+
+  /**
+   * Synchronous signout prompt for the quit-application-requested observer,
+   * which must return a result before the quit proceeds.
+   *
+   * @param {Window} window
+   * @returns {boolean} true if quit should proceed, false if cancelled.
+   */
+  showSignoutPrompt(window) {
+    if (!this.isSignoutPromptEnabled()) {
+      return true;
+    }
+
+    const params = this._getSignoutPromptParams();
+    const [title, message, checkLabel, signoutBtnLabel] =
+      lazy.localization.formatValuesSync([
+        params.titleId,
+        params.messageId,
+        params.checkLabelId,
+        params.signoutBtnLabelId,
+      ]);
+
+    const checkState = { value: true };
+    const buttonPressed = Services.prompt.confirmEx(
+      window,
+      title,
+      message,
+      params.flags,
+      signoutBtnLabel,
+      null,
+      null,
+      checkLabel,
+      checkState
     );
 
-    if (!shouldInformOnSignout) {
+    return this._handleSignoutPromptResult(buttonPressed, checkState.value);
+  },
+
+  /**
+   * Handles the signout button in the enterprise panel. Shows an async
+   * in-content dialog that does not block the parent process, then quits.
+   *
+   * @param {Window} window
+   */
+  async onSignOut(window) {
+    if (!Services.prefs.getBoolPref(PROMPT_ON_SIGNOUT_PREF, true)) {
       await this.initiateShutdown();
       return;
     }
 
+    const params = this._getSignoutPromptParams();
     const [title, message, checkLabel, signoutBtnLabel] =
       await lazy.localization.formatValues([
-        { id: "enterprise-signout-prompt-title" },
-        { id: "enterprise-signout-prompt-message" },
-        { id: "enterprise-signout-prompt-checkbox-label" },
-        { id: "enterprise-signout-prompt-primary-btn-label" },
+        params.titleId,
+        params.messageId,
+        params.checkLabelId,
+        params.signoutBtnLabelId,
       ]);
 
-    const flags =
-      Services.prompt.BUTTON_TITLE_IS_STRING * Services.prompt.BUTTON_POS_0 +
-      Services.prompt.BUTTON_TITLE_CANCEL * Services.prompt.BUTTON_POS_1 +
-      Services.prompt.BUTTON_POS_0_DEFAULT;
-
-    // buttonPressed will be 0 for Signout and 1 for Cancel
     const result = await Services.prompt.asyncConfirmEx(
       window.browsingContext,
       Services.prompt.MODAL_TYPE_INTERNAL_WINDOW,
       title,
       message,
-      flags,
+      params.flags,
       signoutBtnLabel,
       null,
       null,
       checkLabel,
-      true // checkbox checked
+      true
     );
 
-    if (result.get("buttonNumClicked") === 1) {
-      // User canceled signout. Also ignore any checkbox toggling.
+    if (
+      !this._handleSignoutPromptResult(
+        result.get("buttonNumClicked"),
+        result.get("checked")
+      )
+    ) {
       return;
-    }
-
-    if (!result.get("checked")) {
-      // User unchecked the option to be prompted before signout
-      Services.prefs.setBoolPref(PROMPT_ON_SIGNOUT_PREF, result.get("checked"));
     }
 
     await this.initiateShutdown();

--- a/browser/components/enterprise/content/enterprise-badge.inc.xhtml
+++ b/browser/components/enterprise/content/enterprise-badge.inc.xhtml
@@ -2,8 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-<html:link rel="stylesheet" href="chrome://browser/content/enterprise/enterprise-badge.css" />
-<html:link rel="localization" href="browser/enterprise/enterprise.ftl" />
+<html:link rel="stylesheet" href="chrome://browser/content/enterprise/enterprise-badge.css" overflows="false"/>
+<html:link rel="localization" href="browser/enterprise/enterprise.ftl" overflows="false"/>
 
 <toolbarbutton id="enterprise-badge-toolbar-button" class="toolbarbutton-1" delegatesanchor="true" data-l10n-id="enterprise-toolbar-button" removable="false">
   <hbox>

--- a/browser/components/enterprise/modules/ConsoleClient.sys.mjs
+++ b/browser/components/enterprise/modules/ConsoleClient.sys.mjs
@@ -123,9 +123,6 @@ export const ConsoleClient = {
       DEVICE_POSTURE: "/sso/device_posture",
       WHOAMI: "/api/browser/whoami",
       FXACCOUNT: "/api/browser/account",
-      FXACCOUNTS_OAUTH: "/api/fxa/oauth/v1",
-      FXACCOUNTS_PROFILE: "/api/fxa/profile/v1",
-      FXACCOUNTS_AUTH: "/api/fxa/api/v1",
     };
   },
 

--- a/browser/components/enterprise/modules/ConsoleClient.sys.mjs
+++ b/browser/components/enterprise/modules/ConsoleClient.sys.mjs
@@ -7,16 +7,15 @@ const lazy = {};
 ChromeUtils.defineESModuleGetters(lazy, {
   TelemetryEnvironment: "resource://gre/modules/TelemetryEnvironment.sys.mjs",
   EnterpriseCommon: "resource:///modules/enterprise/EnterpriseCommon.sys.mjs",
+  createEnterpriseLogger:
+    "resource:///modules/enterprise/EnterpriseCommon.sys.mjs",
   AsyncShutdown: "resource://gre/modules/AsyncShutdown.sys.mjs",
   FeltStorage: "resource:///modules/FeltStorage.sys.mjs",
   composeOSNames: "resource:///modules/enterprise/EnterpriseOSInfo.sys.mjs",
 });
 
 ChromeUtils.defineLazyGetter(lazy, "log", () => {
-  return console.createInstance({
-    prefix: "ConsoleClient",
-    maxLogLevelPref: lazy.EnterpriseCommon.ENTERPRISE_LOGLEVEL_PREF,
-  });
+  return lazy.createEnterpriseLogger("ConsoleClient");
 });
 
 /**
@@ -102,7 +101,7 @@ export const ConsoleClient = {
     try {
       consoleURI = Services.prefs.getStringPref(CONSOLE_ADDRESS_PREF);
     } catch (e) {
-      console.error("Critial misconfiguration: Missing console URI.");
+      lazy.log.error("Critial misconfiguration: Missing console URI.");
       throw e;
     }
     return new URL(consoleURI);
@@ -712,7 +711,7 @@ export const ConsoleClient = {
           try {
             Services.felt.sendTokens();
           } catch (ex) {
-            console.error(
+            lazy.log.error(
               `ConsoleClient: Failed to send back tokens to felt on shutdown: ${ex}`
             );
           }

--- a/browser/components/enterprise/modules/EnterpriseAccountsStorage.sys.mjs
+++ b/browser/components/enterprise/modules/EnterpriseAccountsStorage.sys.mjs
@@ -7,13 +7,12 @@ const lazy = {};
 ChromeUtils.defineESModuleGetters(lazy, {
   ConsoleClient: "resource:///modules/enterprise/ConsoleClient.sys.mjs",
   EnterpriseCommon: "resource:///modules/enterprise/EnterpriseCommon.sys.mjs",
+  createEnterpriseLogger:
+    "resource:///modules/enterprise/EnterpriseCommon.sys.mjs",
 });
 
 ChromeUtils.defineLazyGetter(lazy, "log", () => {
-  return console.createInstance({
-    prefix: "EnterpriseAccountStorage",
-    maxLogLevelPref: lazy.EnterpriseCommon.ENTERPRISE_LOGLEVEL_PREF,
-  });
+  return lazy.createEnterpriseLogger("EnterpriseAccountStorage");
 });
 
 /**

--- a/browser/components/enterprise/modules/EnterpriseAccountsStorage.sys.mjs
+++ b/browser/components/enterprise/modules/EnterpriseAccountsStorage.sys.mjs
@@ -43,9 +43,7 @@ export class EnterpriseStorageManager {
     // unhandled exception when it is GCd - so add an empty .catch handler here
     // to prevent this.
     this.#getAccountDataPromise.catch(() => {});
-    this.#getAccountDataPromise = Services.felt.isFeltUI()
-      ? Promise.resolve(null) // Felt has no signed-in user on startup; avoid guaranteed 401 from FxA
-      : lazy.ConsoleClient.getFxAccountData();
+    this.#getAccountDataPromise = lazy.ConsoleClient.getFxAccountData();
   }
 
   /**
@@ -61,7 +59,18 @@ export class EnterpriseStorageManager {
    * @returns {Promise<object|null>} Promise which resolves to the cached account data.
    */
   async getAccountData(fieldNames = null) {
-    const data = await this.#getAccountDataPromise;
+    let data;
+    try {
+      data = await this.#getAccountDataPromise;
+    } catch (e) {
+      if (Services.felt.isFeltBrowser()) {
+        lazy.log.error("Critical! We're not signed into the console?");
+      } else {
+        // We're in felt or we're running m-c tests,
+        // hence we expect to not be signed-in to the console
+      }
+      return null;
+    }
 
     if (fieldNames) {
       if (!Array.isArray(fieldNames)) {

--- a/browser/components/enterprise/modules/EnterpriseOSInfo.sys.mjs
+++ b/browser/components/enterprise/modules/EnterpriseOSInfo.sys.mjs
@@ -7,7 +7,13 @@ import { AppConstants } from "resource://gre/modules/AppConstants.sys.mjs";
 const lazy = {};
 
 ChromeUtils.defineESModuleGetters(lazy, {
+  createEnterpriseLogger:
+    "resource:///modules/enterprise/EnterpriseCommon.sys.mjs",
   WindowsRegistry: "resource://gre/modules/WindowsRegistry.sys.mjs",
+});
+
+ChromeUtils.defineLazyGetter(lazy, "log", () => {
+  return lazy.createEnterpriseLogger("EnterpriseOSInfo");
 });
 
 const WINDOWS_CURRENT_VERSION_KEY =
@@ -38,7 +44,7 @@ async function getMacOSVersion() {
         }
       }
     } catch (e) {
-      console.error("getMacOSVersion: failed to read SystemVersion.plist", e);
+      lazy.log.error("getMacOSVersion: failed to read SystemVersion.plist", e);
     }
     return null;
   })();
@@ -174,7 +180,7 @@ async function composeShortOSName(os) {
   if (os.distro && os.distroVersion) {
     return `${os.distro} ${os.distroVersion}`;
   }
-  console.error("composeShortOSName: unable to identify OS from", os);
+  lazy.log.error("composeShortOSName: unable to identify OS from", os);
   return null;
 }
 
@@ -220,6 +226,6 @@ async function composeOSName(os) {
   if (os.distro && os.distroVersion && os.version) {
     return `${os.distro} ${os.distroVersion} (${os.version})`;
   }
-  console.error("composeOSName: unable to identify OS from", os);
+  lazy.log.error("composeOSName: unable to identify OS from", os);
   return null;
 }

--- a/browser/components/enterprise/modules/Updates.sys.mjs
+++ b/browser/components/enterprise/modules/Updates.sys.mjs
@@ -7,8 +7,14 @@ const lazy = {};
 ChromeUtils.defineESModuleGetters(lazy, {
   AppUpdater: "resource://gre/modules/AppUpdater.sys.mjs",
   isUpdatesTesting: "resource:///modules/enterprise/EnterpriseCommon.sys.mjs",
+  createEnterpriseLogger:
+    "resource:///modules/enterprise/EnterpriseCommon.sys.mjs",
   setTimeout: "resource://gre/modules/Timer.sys.mjs",
   clearTimeout: "resource://gre/modules/Timer.sys.mjs",
+});
+
+ChromeUtils.defineLazyGetter(lazy, "log", () => {
+  return lazy.createEnterpriseLogger("Updates");
 });
 
 const FELT_UPDATE_APPLY_PERCENT_INIT = 10;
@@ -91,7 +97,7 @@ export const Updates = {
     );
     // History is limited to 10 items, each install attempt should report a failure
     const history = await UM.getHistory().catch(ex => {
-      console.error(`FeltUpdates: updateCheckingAllowed failed`, ex);
+      lazy.log.error(`FeltUpdates: updateCheckingAllowed failed`, ex);
       return null;
     });
     if (history) {
@@ -108,11 +114,11 @@ export const Updates = {
       );
       const consecutiveUpdateFailures =
         firstNonFailed === -1 ? history.length : firstNonFailed;
-      console.warn(
+      lazy.log.warn(
         `FeltUpdates: updateCheckingAllowed: ${consecutiveUpdateFailures}, max ${maxConsecutiveUpdateFailures}`
       );
       if (consecutiveUpdateFailures > maxConsecutiveUpdateFailures) {
-        console.warn(
+        lazy.log.warn(
           `FeltUpdates: updateCheckingAllowed: skip startup update check because consecutive update failures: ${consecutiveUpdateFailures}, max ${maxConsecutiveUpdateFailures}`
         );
         this._canDoUpdateChecking = false;
@@ -134,7 +140,7 @@ export const Updates = {
 
   forceUpdateCheck() {
     if (this._canDoUpdateChecking !== true) {
-      console.warn(
+      lazy.log.warn(
         `FeltUpdates: forceUpdateCheck(): skip because previous updates failures`
       );
       this.displayLoginStateWithUpdateError("contact-admin");
@@ -144,7 +150,7 @@ export const Updates = {
     this._appUpdater
       .check()
       .catch(err => {
-        console.error(
+        lazy.log.error(
           `Felt: forceUpdateCheck(): AppUpdater failure: ${err}`,
           err
         );
@@ -157,7 +163,7 @@ export const Updates = {
 
   // Similar to browser/base/content/aboutDialog-appUpdater.js:_onAppUpdateStatus
   appUpdaterCallback(status, downloadedBytes, totalBytes) {
-    console.warn(`FeltUpdates: appUpdaterCallback: status:${status}`);
+    lazy.log.warn(`FeltUpdates: appUpdaterCallback: status:${status}`);
     switch (status) {
       case lazy.AppUpdater.STATUS.CHECKING:
         this.scheduleDelayedUpdateCheckUI();
@@ -234,7 +240,7 @@ export const Updates = {
         // DOWNLOAD_FAILED after STAGING => MAR signature error.
         // During tests, this is expected
         if (this._receivedStaging && lazy.isUpdatesTesting()) {
-          console.warn(
+          lazy.log.warn(
             `DOWNLOAD_FAILED after STAGING during tests, likely unsigned MAR`
           );
           this.hideUpdateState();
@@ -371,11 +377,11 @@ export const Updates = {
       Services.felt?.sendUpdateReady();
     } catch (ex) {
       if (ex.result === Cr.NS_ERROR_NOT_CONNECTED) {
-        console.warn(
+        lazy.log.warn(
           `FeltUpdates: sendUpdateReady() failed because not connected: no browser ?`
         );
       } else if (ex.result === Cr.NS_ERROR_CONNECTION_REFUSED) {
-        console.warn(`FeltUpdates: sendUpdateReady() failed to send`);
+        lazy.log.warn(`FeltUpdates: sendUpdateReady() failed to send`);
       } else {
         throw ex;
       }
@@ -387,7 +393,7 @@ export const Updates = {
     //   update = subject && subject.QueryInterface(Ci.nsIUpdate);
     // but it looks like any notifyObserver() that triggers this anyway
     // passes us a "state" directly?
-    console.warn(`FeltUpdates: observer: topic:${topic} state:${state}`);
+    lazy.log.warn(`FeltUpdates: observer: topic:${topic} state:${state}`);
     switch (topic) {
       case "xpcom-shutdown":
         this.unobserve();
@@ -405,7 +411,7 @@ export const Updates = {
                   this.sendUpdateReady();
                 },
                 err => {
-                  console.error(
+                  lazy.log.error(
                     `FeltUpdates: elevationOptedIn failed for pending-elevate`,
                     err
                   );
@@ -418,7 +424,7 @@ export const Updates = {
             this.sendUpdateReady();
             break;
           default:
-            console.warn(`FeltUpdates: unhandled nsIUpdate state: ${state}`);
+            lazy.log.warn(`FeltUpdates: unhandled nsIUpdate state: ${state}`);
             break;
         }
         break;
@@ -444,7 +450,7 @@ export const Updates = {
           case "download-attempts-exceeded":
           case "elevation-attempts-exceeded":
           default:
-            console.warn(
+            lazy.log.warn(
               `FeltUpdates: unhandled nsIUpdateService error: ${state}`
             );
             break;
@@ -452,7 +458,7 @@ export const Updates = {
         break;
 
       default:
-        console.warn(`FeltUpdates: unhandled update topic: ${topic}`);
+        lazy.log.warn(`FeltUpdates: unhandled update topic: ${topic}`);
         break;
     }
   },

--- a/browser/components/enterprise/tests/browser/browser.toml
+++ b/browser/components/enterprise/tests/browser/browser.toml
@@ -2,6 +2,7 @@
 environment = ["MOZ_BYPASS_FELT=1"]
 prefs = [
   "enterprise.console.address=https://console.example.com/",
+  "enterprise.log_level=Debug",
 ]
 
 ["browser_enterprise_endpoints.js"]

--- a/browser/components/enterprise/tests/browser/browser_enterprise_endpoints.js
+++ b/browser/components/enterprise/tests/browser/browser_enterprise_endpoints.js
@@ -36,7 +36,7 @@ add_task(async function test_endpoints_derived_from_console_address() {
   for (const pref of BASE_CONSOLE_URI_PREFS) {
     Assert.equal(
       Services.prefs.getStringPref(pref),
-      CONSOLE_ADDRESS_PREF_VALUE,
+      new URL(CONSOLE_ADDRESS_PREF_VALUE).href,
       `Expected ${pref} to be set to the console address`
     );
     Assert.ok(

--- a/browser/components/enterprisepolicies/Policies.sys.mjs
+++ b/browser/components/enterprisepolicies/Policies.sys.mjs
@@ -296,12 +296,16 @@ export var Policies = {
       // true, we disallow turning off auto updating, and visa versa.
       if (param) {
         manager.disallowFeature("app-auto-updates-off");
+        manager.allowFeature("app-auto-updates-on");
       } else {
         manager.disallowFeature("app-auto-updates-on");
+        manager.allowFeature("app-auto-updates-off");
       }
     },
     onRemove(manager, _oldParams) {
+      // In a default unpolicied state, it is allowed to turn auto updating on or off
       manager.allowFeature("app-auto-updates-on");
+      manager.allowFeature("app-auto-updates-off");
     },
   },
 
@@ -506,14 +510,20 @@ export var Policies = {
 
   BackgroundAppUpdate: {
     onBeforeAddons(manager, param) {
+      // Logic feels a bit reversed here, but it's correct. If BackgroundAppUpdate is
+      // true, we disallow turning off background updating, and visa versa.
       if (param) {
         manager.disallowFeature("app-background-update-off");
+        manager.allowFeature("app-background-update-on");
       } else {
         manager.disallowFeature("app-background-update-on");
+        manager.allowFeature("app-background-update-off");
       }
     },
     onRemove(manager, _oldParams) {
+      // In a default unpolicied state, it is allowed to turn background updating on or off
       manager.allowFeature("app-background-update-on");
+      manager.allowFeature("app-background-update-off");
     },
   },
 
@@ -570,6 +580,7 @@ export var Policies = {
       }
     },
     onRemove(manager, _oldParams) {
+      manager.allowFeature("profileManagement");
       unblockAboutPage(manager, "about:profiles");
       unblockAboutPage(manager, "about:profilemanager");
       unblockAboutPage(manager, "about:editprofile");
@@ -603,6 +614,10 @@ export var Policies = {
             "browser.policies.enterprise.telemetry.blocklistDomainBrowsed.enabled",
             param.Enabled
           );
+        } else {
+          unsetAndUnlockPref(
+            "browser.policies.enterprise.telemetry.blocklistDomainBrowsed.enabled"
+          );
         }
 
         // Set URL logging level
@@ -614,23 +629,20 @@ export var Policies = {
             "browser.policies.enterprise.telemetry.blocklistDomainBrowsed.urlLogging",
             param.UrlLogging
           );
-        }
-      }
-    },
-    onRemove(manager, oldParams) {
-      // TODO: Is this OK ?
-      if (oldParams && typeof oldParams === "object") {
-        if ("Enabled" in oldParams) {
-          unsetAndUnlockPref(
-            "browser.policies.enterprise.telemetry.blocklistDomainBrowsed.enabled"
-          );
-        }
-        if ("UrlLogging" in oldParams) {
+        } else {
           unsetAndUnlockPref(
             "browser.policies.enterprise.telemetry.blocklistDomainBrowsed.urlLogging"
           );
         }
       }
+    },
+    onRemove(_manager, _oldParams) {
+      unsetAndUnlockPref(
+        "browser.policies.enterprise.telemetry.blocklistDomainBrowsed.enabled"
+      );
+      unsetAndUnlockPref(
+        "browser.policies.enterprise.telemetry.blocklistDomainBrowsed.urlLogging"
+      );
     },
   },
 
@@ -2017,7 +2029,7 @@ export var Policies = {
 
   ExtensionUpdate: {
     onBeforeAddons(manager, param) {
-      setAndLockPref("extensions.update.enabled", !param);
+      setAndLockPref("extensions.update.enabled", param);
     },
   },
 

--- a/browser/components/enterprisepolicies/Policies.sys.mjs
+++ b/browser/components/enterprisepolicies/Policies.sys.mjs
@@ -277,14 +277,16 @@ export var Policies = {
         setAndLockPref("widget.disable_file_pickers", true);
         setAndLockPref("browser.download.useDownloadDir", true);
         manager.disallowFeature("filepickers");
-      }
-    },
-    onRemove(manager, oldParams) {
-      if (!oldParams) {
-        unsetAndUnlockPref("widget.disable_file_pickers");
-        unsetAndUnlockPref("browser.download.useDownloadDir");
+      } else {
+        setAndLockPref("widget.disable_file_pickers", false);
+        setAndLockPref("browser.download.useDownloadDir", false);
         manager.allowFeature("filepickers");
       }
+    },
+    onRemove(manager, _oldParams) {
+      unsetAndUnlockPref("widget.disable_file_pickers");
+      unsetAndUnlockPref("browser.download.useDownloadDir");
+      manager.allowFeature("filepickers");
     },
   },
 
@@ -298,12 +300,8 @@ export var Policies = {
         manager.disallowFeature("app-auto-updates-on");
       }
     },
-    onRemove(manager, oldParams) {
-      if (!oldParams) {
-        manager.allowFeature("app-auto-updates-off");
-      } else {
-        manager.allowFeature("app-auto-updates-on");
-      }
+    onRemove(manager, _oldParams) {
+      manager.allowFeature("app-auto-updates-on");
     },
   },
 
@@ -514,12 +512,8 @@ export var Policies = {
         manager.disallowFeature("app-background-update-on");
       }
     },
-    onRemove(manager, oldParams) {
-      if (oldParams) {
-        manager.allowFeature("app-background-update-off");
-      } else {
-        manager.allowFeature("app-background-update-on");
-      }
+    onRemove(manager, _oldParams) {
+      manager.allowFeature("app-background-update-on");
     },
   },
 
@@ -527,12 +521,12 @@ export var Policies = {
     onBeforeUIStartup(manager, param) {
       if (param) {
         blockAboutPage(manager, "about:addons", true);
-      }
-    },
-    onRemove(manager, oldParams) {
-      if (oldParams) {
+      } else {
         unblockAboutPage(manager, "about:addons");
       }
+    },
+    onRemove(manager, _oldParams) {
+      unblockAboutPage(manager, "about:addons");
     },
   },
 
@@ -556,6 +550,8 @@ export var Policies = {
     onBeforeAddons(manager, param) {
       if (param) {
         manager.disallowFeature("profileManagement");
+      } else {
+        manager.allowFeature("profileManagement");
       }
     },
     onBeforeUIStartup(manager, param) {
@@ -565,16 +561,20 @@ export var Policies = {
         blockAboutPage(manager, "about:editprofile");
         blockAboutPage(manager, "about:deleteprofile");
         blockAboutPage(manager, "about:newprofile");
-      }
-    },
-    onRemove(manager, oldParams) {
-      if (oldParams) {
+      } else {
         unblockAboutPage(manager, "about:profiles");
         unblockAboutPage(manager, "about:profilemanager");
         unblockAboutPage(manager, "about:editprofile");
         unblockAboutPage(manager, "about:deleteprofile");
         unblockAboutPage(manager, "about:newprofile");
       }
+    },
+    onRemove(manager, _oldParams) {
+      unblockAboutPage(manager, "about:profiles");
+      unblockAboutPage(manager, "about:profilemanager");
+      unblockAboutPage(manager, "about:editprofile");
+      unblockAboutPage(manager, "about:deleteprofile");
+      unblockAboutPage(manager, "about:newprofile");
     },
   },
 
@@ -583,13 +583,14 @@ export var Policies = {
       if (param) {
         blockAboutPage(manager, "about:support");
         manager.disallowFeature("aboutSupport");
-      }
-    },
-    onRemove(manager, oldParams) {
-      if (oldParams) {
+      } else {
         unblockAboutPage(manager, "about:support");
         manager.allowFeature("aboutSupport");
       }
+    },
+    onRemove(manager, _oldParams) {
+      unblockAboutPage(manager, "about:support");
+      manager.allowFeature("aboutSupport");
     },
   },
 
@@ -617,6 +618,7 @@ export var Policies = {
       }
     },
     onRemove(manager, oldParams) {
+      // TODO: Is this OK ?
       if (oldParams && typeof oldParams === "object") {
         if ("Enabled" in oldParams) {
           unsetAndUnlockPref(
@@ -1097,14 +1099,12 @@ export var Policies = {
         Services.env.set("MOZ_CRASHREPORTER_POLICY_AUTO_SUBMIT", "");
       }
     },
-    onRemove(_manager, oldParam) {
-      if (oldParam.ForceAutoSubmit) {
-        unsetAndUnlockPref("browser.crashReports.unsubmittedCheck.enabled");
-        unsetAndUnlockPref("browser.crashReports.unsubmittedCheck.autoSubmit2");
-        unsetAndUnlockPref("browser.tabs.crashReporting.sendReport");
-        unsetAndUnlockPref("browser.tabs.crashReporting.includeURL");
-        Services.env.set("MOZ_CRASHREPORTER_POLICY_AUTO_SUBMIT", "");
-      }
+    onRemove(_manager, _oldParams) {
+      unsetAndUnlockPref("browser.crashReports.unsubmittedCheck.enabled");
+      unsetAndUnlockPref("browser.crashReports.unsubmittedCheck.autoSubmit2");
+      unsetAndUnlockPref("browser.tabs.crashReporting.sendReport");
+      unsetAndUnlockPref("browser.tabs.crashReporting.includeURL");
+      Services.env.set("MOZ_CRASHREPORTER_POLICY_AUTO_SUBMIT", "");
     },
   },
 
@@ -1122,13 +1122,14 @@ export var Policies = {
       if (param) {
         setAndLockPref("identity.fxaccounts.enabled", false);
         setAndLockPref("browser.aboutwelcome.enabled", false);
-      }
-    },
-    onRemove(manager, oldParams) {
-      if (oldParams) {
+      } else {
         unsetAndUnlockPref("identity.fxaccounts.enabled");
         unsetAndUnlockPref("browser.aboutwelcome.enabled");
       }
+    },
+    onRemove(_manager, _oldParams) {
+      unsetAndUnlockPref("identity.fxaccounts.enabled");
+      unsetAndUnlockPref("browser.aboutwelcome.enabled");
     },
   },
 
@@ -1136,12 +1137,12 @@ export var Policies = {
     onBeforeAddons(manager, param) {
       if (param) {
         manager.disallowFeature("appUpdate");
-      }
-    },
-    onRemove(manager, oldParams) {
-      if (oldParams) {
+      } else {
         manager.allowFeature("appUpdate");
       }
+    },
+    onRemove(manager, _oldParams) {
+      manager.allowFeature("appUpdate");
     },
   },
 
@@ -1251,13 +1252,14 @@ export var Policies = {
       if (param) {
         setAndLockPref("network.dns.echconfig.enabled", false);
         setAndLockPref("network.dns.http3_echconfig.enabled", false);
-      }
-    },
-    onRemove(manager, oldParams) {
-      if (oldParams) {
+      } else {
         unsetAndUnlockPref("network.dns.echconfig.enabled");
         unsetAndUnlockPref("network.dns.http3_echconfig.enabled");
       }
+    },
+    onRemove(_manager, _oldParams) {
+      unsetAndUnlockPref("network.dns.echconfig.enabled");
+      unsetAndUnlockPref("network.dns.http3_echconfig.enabled");
     },
   },
 
@@ -1265,12 +1267,12 @@ export var Policies = {
     onBeforeUIStartup(manager, param) {
       if (param) {
         manager.disallowFeature("feedbackCommands");
-      }
-    },
-    onRemove(manager, oldParams) {
-      if (oldParams) {
+      } else {
         manager.allowFeature("feedbackCommands");
       }
+    },
+    onRemove(manager, _oldParams) {
+      manager.allowFeature("feedbackCommands");
     },
   },
 
@@ -1284,19 +1286,20 @@ export var Policies = {
       if (param) {
         setAndLockPref("identity.fxaccounts.enabled", false);
         setAndLockPref("browser.aboutwelcome.enabled", false);
+      } else {
+        setAndLockPref("identity.fxaccounts.enabled", true);
+        setAndLockPref("browser.aboutwelcome.enabled", true);
       }
     },
-    onRemove(manager, oldParams) {
+    onRemove(manager, _oldParams) {
       // If DisableAccounts is set, let it take precedence.
       // TODO: true for onRemove as well?
       if ("DisableAccounts" in manager.getActivePolicies()) {
         return;
       }
 
-      if (oldParams) {
-        unsetAndUnlockPref("identity.fxaccounts.enabled");
-        unsetAndUnlockPref("browser.aboutwelcome.enabled");
-      }
+      unsetAndUnlockPref("identity.fxaccounts.enabled");
+      unsetAndUnlockPref("browser.aboutwelcome.enabled");
     },
   },
 
@@ -1304,12 +1307,12 @@ export var Policies = {
     onBeforeUIStartup(manager, param) {
       if (param) {
         setAndLockPref("screenshots.browser.component.enabled", false);
+      } else {
+        setAndLockPref("screenshots.browser.component.enabled", true);
       }
     },
-    onRemove(manager, oldParams) {
-      if (oldParams) {
-        unsetAndUnlockPref("screenshots.browser.component.enabled");
-      }
+    onRemove(_manager, _oldParams) {
+      unsetAndUnlockPref("screenshots.browser.component.enabled");
     },
   },
 
@@ -1325,18 +1328,26 @@ export var Policies = {
           "browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features",
           false
         );
+      } else {
+        manager.allowFeature("Shield");
+        setAndLockPref(
+          "browser.newtabpage.activity-stream.asrouter.userprefs.cfr.addons",
+          true
+        );
+        setAndLockPref(
+          "browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features",
+          true
+        );
       }
     },
-    onRemove(manager, oldParams) {
-      if (oldParams) {
-        manager.allowFeature("Shield");
-        unsetAndUnlockPref(
-          "browser.newtabpage.activity-stream.asrouter.userprefs.cfr.addons"
-        );
-        unsetAndUnlockPref(
-          "browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features"
-        );
-      }
+    onRemove(manager, _oldParams) {
+      manager.allowFeature("Shield");
+      unsetAndUnlockPref(
+        "browser.newtabpage.activity-stream.asrouter.userprefs.cfr.addons"
+      );
+      unsetAndUnlockPref(
+        "browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features"
+      );
     },
   },
 
@@ -1344,6 +1355,8 @@ export var Policies = {
     onProfileAfterChange(manager, param) {
       if (param) {
         setAndLockPref("privacy.panicButton.enabled", false);
+      } else {
+        setAndLockPref("privacy.panicButton.enabled", true);
       }
     },
   },
@@ -1352,6 +1365,8 @@ export var Policies = {
     onBeforeUIStartup(manager, param) {
       if (param) {
         setAndLockPref("browser.formfill.enable", false);
+      } else {
+        setAndLockPref("browser.formfill.enable", true);
       }
     },
   },
@@ -1360,6 +1375,8 @@ export var Policies = {
     onBeforeUIStartup(manager, param) {
       if (param) {
         manager.disallowFeature("createMasterPassword");
+      } else {
+        manager.allowFeature("createMasterPassword");
       }
     },
   },
@@ -1368,6 +1385,8 @@ export var Policies = {
     onBeforeUIStartup(manager, param) {
       if (param) {
         manager.disallowFeature("passwordReveal");
+      } else {
+        manager.allowFeature("passwordReveal");
       }
     },
   },
@@ -1378,14 +1397,16 @@ export var Policies = {
         manager.disallowFeature("privatebrowsing");
         blockAboutPage(manager, "about:privatebrowsing", true);
         setAndLockPref("browser.privatebrowsing.autostart", false);
-      }
-    },
-    onRemove(manager, oldParams) {
-      if (oldParams) {
+      } else {
         manager.allowFeature("privatebrowsing");
         unblockAboutPage(manager, "about:privatebrowsing");
-        unsetAndUnlockPref("browser.privatebrowsing.autostart");
+        setAndLockPref("browser.privatebrowsing.autostart", true);
       }
+    },
+    onRemove(manager, _oldParams) {
+      manager.allowFeature("privatebrowsing");
+      unblockAboutPage(manager, "about:privatebrowsing");
+      unsetAndUnlockPref("browser.privatebrowsing.autostart");
     },
   },
 
@@ -1397,6 +1418,12 @@ export var Policies = {
           "browser.newtabpage.activity-stream.migrationExpired",
           true
         );
+      } else {
+        manager.allowFeature("profileImport");
+        setAndLockPref(
+          "browser.newtabpage.activity-stream.migrationExpired",
+          false
+        );
       }
     },
   },
@@ -1406,6 +1433,9 @@ export var Policies = {
       if (param) {
         manager.disallowFeature("profileRefresh");
         setAndLockPref("browser.disableResetPrompt", true);
+      } else {
+        manager.allowFeature("profileRefresh");
+        setAndLockPref("browser.disableResetPrompt", false);
       }
     },
   },
@@ -1414,6 +1444,8 @@ export var Policies = {
     onBeforeAddons(manager, param) {
       if (param) {
         manager.disallowFeature("NimbusRollouts");
+      } else {
+        manager.allowFeature("NimbusRollouts");
       }
     },
   },
@@ -1422,6 +1454,8 @@ export var Policies = {
     onBeforeUIStartup(manager, param) {
       if (param) {
         manager.disallowFeature("safeMode");
+      } else {
+        manager.allowFeature("safeMode");
       }
     },
   },
@@ -1448,6 +1482,8 @@ export var Policies = {
     onBeforeUIStartup(manager, param) {
       if (param) {
         manager.disallowFeature("setDesktopBackground");
+      } else {
+        manager.allowFeature("setDesktopBackground");
       }
     },
   },
@@ -1456,6 +1492,8 @@ export var Policies = {
     onBeforeAddons(manager, param) {
       if (param) {
         manager.disallowFeature("SysAddonUpdate");
+      } else {
+        manager.allowFeature("SysAddonUpdate");
       }
     },
   },
@@ -1468,16 +1506,20 @@ export var Policies = {
         setAndLockPref("toolkit.telemetry.archive.enabled", false);
         setAndLockPref("datareporting.usage.uploadEnabled", false);
         blockAboutPage(manager, "about:telemetry");
-      }
-    },
-    onRemove(manager, oldParams) {
-      if (oldParams) {
-        unsetAndUnlockPref("datareporting.healthreport.uploadEnabled");
-        unsetAndUnlockPref("datareporting.policy.dataSubmissionEnabled");
-        unsetAndUnlockPref("toolkit.telemetry.archive.enabled");
-        unsetAndUnlockPref("datareporting.usage.uploadEnabled");
+      } else {
+        setAndLockPref("datareporting.healthreport.uploadEnabled", true);
+        setAndLockPref("datareporting.policy.dataSubmissionEnabled", true);
+        setAndLockPref("toolkit.telemetry.archive.enabled", true);
+        setAndLockPref("datareporting.usage.uploadEnabled", true);
         unblockAboutPage(manager, "about:telemetry");
       }
+    },
+    onRemove(manager, _oldParams) {
+      unsetAndUnlockPref("datareporting.healthreport.uploadEnabled");
+      unsetAndUnlockPref("datareporting.policy.dataSubmissionEnabled");
+      unsetAndUnlockPref("toolkit.telemetry.archive.enabled");
+      unsetAndUnlockPref("datareporting.usage.uploadEnabled");
+      unblockAboutPage(manager, "about:telemetry");
     },
   },
 
@@ -1485,6 +1527,8 @@ export var Policies = {
     onBeforeUIStartup(manager, param) {
       if (param) {
         manager.disallowFeature("thirdPartyModuleBlocking");
+      } else {
+        manager.allowFeature("thirdPartyModuleBlocking");
       }
     },
   },
@@ -1973,9 +2017,7 @@ export var Policies = {
 
   ExtensionUpdate: {
     onBeforeAddons(manager, param) {
-      if (!param) {
-        setAndLockPref("extensions.update.enabled", param);
-      }
+      setAndLockPref("extensions.update.enabled", !param);
     },
   },
 
@@ -2176,6 +2218,8 @@ export var Policies = {
     onBeforeAddons(manager, param) {
       if (!param) {
         setAndLockPref("layers.acceleration.disabled", true);
+      } else {
+        setAndLockPref("layers.acceleration.disabled", false);
       }
     },
   },
@@ -2295,6 +2339,8 @@ export var Policies = {
     onBeforeAddons(manager, param) {
       if (!param) {
         setAndLockPref("browser.ipProtection.enabled", false);
+      } else {
+        setAndLockPref("browser.ipProtection.enabled", true);
       }
     },
   },
@@ -2401,6 +2447,8 @@ export var Policies = {
     onBeforeAddons(manager, param) {
       if (param) {
         manager.disallowFeature("autoAppUpdateChecking");
+      } else {
+        manager.allowFeature("autoAppUpdateChecking");
       }
     },
   },
@@ -2428,6 +2476,8 @@ export var Policies = {
     onProfileAfterChange(manager, param) {
       if (param) {
         manager.disallowFeature("defaultBookmarks");
+      } else {
+        manager.allowFeature("defaultBookmarks");
       }
     },
   },
@@ -2476,14 +2526,15 @@ export var Policies = {
       if (!param) {
         blockAboutPage(manager, "about:logins", true);
         setAndLockPref("pref.privacy.disable_button.view_passwords", true);
+      } else {
+        unblockAboutPage(manager, "about:logins");
+        setAndLockPref("pref.privacy.disable_button.view_passwords", false);
       }
       setAndLockPref("signon.rememberSignons", param);
     },
-    onRemove(manager, oldParams) {
-      if (!oldParams) {
-        unblockAboutPage(manager, "about:logins");
-        unsetAndUnlockPref("pref.privacy.disable_button.view_passwords", true);
-      }
+    onRemove(manager, _oldParams) {
+      unblockAboutPage(manager, "about:logins");
+      unsetAndUnlockPref("pref.privacy.disable_button.view_passwords", true);
       unsetAndUnlockPref("signon.rememberSignons");
     },
   },
@@ -3376,6 +3427,8 @@ export var Policies = {
     onBeforeAddons(manager, param) {
       if (param) {
         manager.disallowFeature("removeHomeButtonByDefault");
+      } else {
+        manager.allowFeature("removeHomeButtonByDefault");
       }
     },
     onAllWindowsRestored(manager, param) {
@@ -3506,6 +3559,9 @@ export var Policies = {
       if (param) {
         setAndLockPref("termsofuse.acceptedVersion", 999);
         setAndLockPref("termsofuse.acceptedDate", Date.now().toString());
+      } else {
+        unsetAndUnlockPref("termsofuse.acceptedVersion");
+        unsetAndUnlockPref("termsofuse.acceptedDate");
       }
     },
   },

--- a/browser/components/enterprisepolicies/Policies.sys.mjs
+++ b/browser/components/enterprisepolicies/Policies.sys.mjs
@@ -29,6 +29,7 @@ ChromeUtils.defineESModuleGetters(lazy, {
   FileUtils: "resource://gre/modules/FileUtils.sys.mjs",
   ProxyPolicies: "resource:///modules/policies/ProxyPolicies.sys.mjs",
   SearchService: "moz-src:///toolkit/components/search/SearchService.sys.mjs",
+  AIChatbotPolicies: "resource:///modules/policies/AIChatbotPolicies.sys.mjs",
   QuickSuggest: "moz-src:///browser/components/urlbar/QuickSuggest.sys.mjs",
   WebsiteFilter: "resource:///modules/policies/WebsiteFilter.sys.mjs",
   SyncPolicy: "resource:///modules/policies/SyncPolicy.sys.mjs",
@@ -190,6 +191,15 @@ export var Policies = {
       if ("MatchPatterns" in oldParams) {
         unsetAndUnlockPref("browser.ipProtection.inclusion.match_patterns");
       }
+    },
+  },
+
+  AIChatbot: {
+    onBeforeAddons(manager, param) {
+      lazy.AIChatbotPolicies.applyAIChatbotPolicy(param);
+    },
+    onRemove(_manager, _oldParams) {
+      lazy.AIChatbotPolicies.unapplyAIChatbotPolicy();
     },
   },
 

--- a/browser/components/enterprisepolicies/Policies.sys.mjs
+++ b/browser/components/enterprisepolicies/Policies.sys.mjs
@@ -4218,7 +4218,9 @@ function blockAboutPage(manager, feature) {
 function unblockAboutPage(manager, feature) {
   addChromeURLBlocker();
   let idx = gBlockedAboutPages.indexOf(feature);
-  gBlockedAboutPages.splice(idx, 1);
+  if (idx !== -1) {
+    gBlockedAboutPages.splice(idx, 1);
+  }
 
   try {
     let aboutModule = Cc[ABOUT_CONTRACT + feature.split(":")[1]].getService(
@@ -4226,7 +4228,9 @@ function unblockAboutPage(manager, feature) {
     );
     let chromeURL = aboutModule.getChromeURI(Services.io.newURI(feature)).spec;
     let idxChrome = gBlockedAboutPages.indexOf(chromeURL);
-    gBlockedAboutPages.splice(idxChrome, 1);
+    if (idxChrome !== -1) {
+      gBlockedAboutPages.splice(idxChrome, 1);
+    }
   } catch (e) {
     // Some about pages don't have chrome URLS (compat)
   }

--- a/browser/components/enterprisepolicies/helpers/AIChatbotPolicies.sys.mjs
+++ b/browser/components/enterprisepolicies/helpers/AIChatbotPolicies.sys.mjs
@@ -1,0 +1,213 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import {
+  setAndLockPref,
+  unsetAndUnlockPref,
+  PoliciesUtils,
+} from "resource:///modules/policies/Policies.sys.mjs";
+import {
+  CHAT_PROVIDERS_DEFAULT,
+  GenAI,
+} from "resource:///modules/GenAI.sys.mjs";
+import { getMozRemoteImageURL } from "moz-src:///toolkit/modules/FaviconUtils.sys.mjs";
+
+export const AIChatbotPolicies = {
+  /**
+   * Configure available chat providers based on policy.
+   *
+   * Filters built-in providers, adds custom providers, and updates the
+   * `browser.ml.chat.providers` pref. If no providers remain after filtering,
+   * the chat sidebar is disabled entirely.
+   *
+   * @param {object} providers - The Providers policy object.
+   * @param {object} [providers.BuiltIn] - Map of built-in provider names to
+   *   booleans. Set a provider to `false` to exclude it.
+   * @param {Array<object>} [providers.Add] - Custom providers to add. Each entry
+   *   must have `id`, `name`, and `url` properties, and may include
+   *   `iconUrl` and `queryParam`.
+   */
+  configureProviders(providers) {
+    const idToName = new Map(
+      [...GenAI.chatProviders.values()].map(c => [c.id, c.name])
+    );
+
+    let providerIds = CHAT_PROVIDERS_DEFAULT.split(",");
+    if (providers.BuiltIn) {
+      providerIds = providerIds.filter(
+        id => providers.BuiltIn[idToName.get(id)] !== false
+      );
+      // Unset current chat provider if it was removed.
+      const currentProviderURL = Services.prefs.getStringPref(
+        "browser.ml.chat.provider"
+      );
+      const currentConfig = GenAI.chatProviders.get(currentProviderURL);
+      if (currentConfig && providers.BuiltIn[currentConfig.name] === false) {
+        Services.prefs.clearUserPref("browser.ml.chat.provider");
+      }
+    }
+
+    providers.Add?.forEach(engine => {
+      const url = engine.url.href || engine.url;
+      const engineConfig = { id: engine.id, name: engine.name };
+      if (engine.iconUrl !== undefined) {
+        const iconURL = URL.parse(engine.iconUrl);
+        engineConfig.iconUrl =
+          iconURL &&
+          iconURL.protocol !== "chrome:" &&
+          iconURL.protocol !== "data:"
+            ? getMozRemoteImageURL(engine.iconUrl, { size: 32 })
+            : engine.iconUrl;
+      }
+      if (engine.queryParam !== undefined) {
+        engineConfig.queryParam = engine.queryParam;
+      }
+      GenAI.chatProviders.set(url, engineConfig);
+      providerIds.push(engine.id);
+    });
+
+    if (providers.BuiltIn || providers.Add?.length) {
+      PoliciesUtils.setDefaultPref(
+        "browser.ml.chat.providers",
+        providerIds.join(",")
+      );
+    }
+
+    // If there are no providers, disable the chat sidebar
+    if (!providerIds.length) {
+      setAndLockPref("browser.ml.chat.enabled", false);
+    }
+  },
+
+  /**
+   * Configure available chat prompts based on policy.
+   *
+   * If `Enabled` is `false`, clears all prompt prefs and disables the
+   * shortcuts feature. Otherwise, removes individual built-in prompts whose
+   * names are mapped to `false` in `prompts.BuiltIn`.
+   *
+   * @param {object} prompts - The Prompts policy object.
+   * @param {boolean} [prompts.Enabled] - Set to `false` to disable all prompts
+   *   and shortcuts.
+   * @param {object} [prompts.BuiltIn] - Map of built-in prompt names
+   *   (Summarize, Explain, Quiz, Proofread) to booleans. Set to `false` to
+   *   remove the prompt.
+   */
+  configurePrompts(prompts) {
+    if (prompts.Enabled === false) {
+      for (const pref of Services.prefs.getChildList(
+        "browser.ml.chat.prompts."
+      )) {
+        PoliciesUtils.setDefaultPref(pref, "");
+      }
+      PoliciesUtils.setDefaultPref("browser.ml.chat.shortcuts", false);
+      return;
+    }
+
+    if (!prompts.BuiltIn) {
+      return;
+    }
+
+    const PROMPT_NAME_TO_ID = {
+      Summarize: "summarize",
+      Explain: "explain",
+      Quiz: "quiz",
+      Proofread: "proofread",
+    };
+
+    const disabledIds = new Set();
+    for (const [name, enabled] of Object.entries(prompts.BuiltIn)) {
+      if (enabled === false) {
+        const id = PROMPT_NAME_TO_ID[name];
+        if (id) {
+          disabledIds.add(id);
+        }
+      }
+    }
+
+    if (!disabledIds.size) {
+      return;
+    }
+
+    for (const pref of Services.prefs.getChildList(
+      "browser.ml.chat.prompts."
+    )) {
+      const value = Services.prefs.getStringPref(pref, "");
+      if (!value) {
+        continue;
+      }
+      let promptObj;
+      try {
+        promptObj = JSON.parse(value);
+      } catch (e) {
+        continue;
+      }
+      if (disabledIds.has(promptObj.id)) {
+        PoliciesUtils.setDefaultPref(pref, "");
+      }
+    }
+  },
+
+  /**
+   * Set the default chat provider by looking up its URL in `GenAI.chatProviders`
+   * and writing it to `browser.ml.chat.provider`.
+   *
+   * @param {string} defaultProvider - Display name of the provider to set as
+   *   default. Must match the `name` of an entry in `GenAI.chatProviders`.
+   */
+  setDefaultProvider(defaultProvider) {
+    // Find URL for this provider ID
+    for (const [url, config] of GenAI.chatProviders) {
+      if (config.name === defaultProvider) {
+        PoliciesUtils.setDefaultPref("browser.ml.chat.provider", url);
+        break;
+      }
+    }
+  },
+
+  /**
+   * Entry point for applying the AIChatbot enterprise policy.
+   *
+   * Delegates to `configureProviders`/`setDefaultProvider` when
+   * `param.Providers` is present, and to `configurePrompts` when
+   * `param.Prompts` is present.
+   *
+   * @param {object} param - The top-level AIChatbot policy object.
+   * @param {object} [param.Providers] - Passed to `configureProviders`.
+   *   `param.Providers.Default` is passed to `setDefaultProvider` if present.
+   * @param {object} [param.Prompts] - Passed to `configurePrompts`.
+   */
+  applyAIChatbotPolicy(param) {
+    if (param.Providers) {
+      this.configureProviders(param.Providers);
+      if (param.Providers.Default) {
+        this.setDefaultProvider(param.Providers.Default);
+      }
+    }
+    if (param.Prompts) {
+      this.configurePrompts(param.Prompts);
+    }
+  },
+
+  /**
+   * Revert all prefs set by the AIChatbot policy back to their defaults.
+   *
+   * Called when the policy is removed or the browser is reset to an
+   * unenrolled state.
+   */
+  unapplyAIChatbotPolicy() {
+    // Can't use unsetDefaultPref for this one because it's empty by default.
+    PoliciesUtils.setDefaultPref(
+      "browser.ml.chat.providers",
+      CHAT_PROVIDERS_DEFAULT
+    );
+    PoliciesUtils.unsetDefaultPref("browser.ml.chat.provider");
+    PoliciesUtils.unsetDefaultPref("browser.ml.chat.prompts.0");
+    PoliciesUtils.unsetDefaultPref("browser.ml.chat.prompts.1");
+    PoliciesUtils.unsetDefaultPref("browser.ml.chat.prompts.2");
+    PoliciesUtils.unsetDefaultPref("browser.ml.chat.prompts.3");
+    PoliciesUtils.unsetDefaultPref("browser.ml.chat.shortcuts");
+    unsetAndUnlockPref("browser.ml.chat.enabled");
+  },
+};

--- a/browser/components/enterprisepolicies/helpers/moz.build
+++ b/browser/components/enterprisepolicies/helpers/moz.build
@@ -8,6 +8,7 @@ with Files("**"):
     BUG_COMPONENT = ("Firefox", "Enterprise Policies")
 
 EXTRA_JS_MODULES.policies += [
+    "AIChatbotPolicies.sys.mjs",
     "BookmarksPolicies.sys.mjs",
     "ProxyPolicies.sys.mjs",
 ]

--- a/browser/components/enterprisepolicies/schemas/policies-schema.json
+++ b/browser/components/enterprisepolicies/schemas/policies-schema.json
@@ -73,6 +73,121 @@
       },
       "required": ["Host", "Port"]
     },
+    "AIChatbot": {
+      "type": "object",
+      "x-category": "Content settings",
+      "description": "Controls access to AI chat services. The built-in providers are Anthropic Claude, ChatGPT, Copilot, Google Gemini, HuggingChat, Le Chat Mistral, and a locally running AI chatbot. These can be enabled individually. For custom providers, add them to the 'Add' array. The 'Default' field specifies which provider is used by default.",
+      "examples": [
+        {
+          "Providers": {
+            "Builtin": {
+              "Anthropic Claude": true,
+              "ChatGPT": false,
+              "Copilot": false,
+              "Google Gemini": false,
+              "HuggingChat": true,
+              "Le Chat Mistral": true,
+              "localhost": true
+            },
+            "Default": "Anthropic Claude",
+            "Add": [
+              {
+                "url": "https://ai.example.com",
+                "name": "Example AI",
+                "id": "exampleai",
+                "iconUrl": "https://ai.example.com/icon.png",
+                "queryParam": "someparam"
+              }
+            ]
+          }
+        }
+      ],
+      "properties": {
+        "Providers": {
+          "type": "object",
+          "properties": {
+            "Add": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "url": {
+                    "type": "URL"
+                  },
+                  "name": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "iconUrl": {
+                    "type": "string"
+                  },
+                  "queryParam": {
+                    "type": "string"
+                  }
+                },
+                "required": ["url", "name", "id"]
+              }
+            },
+            "BuiltIn": {
+              "type": "object",
+              "properties": {
+                "Anthropic Claude": {
+                  "type": "boolean"
+                },
+                "ChatGPT": {
+                  "type": "boolean"
+                },
+                "Copilot": {
+                  "type": "boolean"
+                },
+                "Google Gemini": {
+                  "type": "boolean"
+                },
+                "HuggingChat": {
+                  "type": "boolean"
+                },
+                "Le Chat Mistral": {
+                  "type": "boolean"
+                },
+                "localhost": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "Default": {
+              "type": "string"
+            }
+          }
+        },
+        "Prompts": {
+          "type": "object",
+          "properties": {
+            "Enabled": {
+              "type": "boolean"
+            },
+            "BuiltIn": {
+              "type": "object",
+              "properties": {
+                "Summarize": {
+                  "type": "boolean"
+                },
+                "Explain": {
+                  "type": "boolean"
+                },
+                "Quiz": {
+                  "type": "boolean"
+                },
+                "Proofread": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "AIControls": {
       "type": "object",
       "x-category": "Content settings",

--- a/browser/components/enterprisepolicies/tests/browser/browser.toml
+++ b/browser/components/enterprisepolicies/tests/browser/browser.toml
@@ -145,7 +145,4 @@ support-files = [
 
 ["browser_policy_websitefilter_telemetry.js"]
 # Only run in MOZ_ENTERPRISE builds
-skip-if = [
-  "buildapp != firefox",
-  "!enterprise",
-]
+run-if = ["enterprise"]

--- a/browser/components/enterprisepolicies/tests/browser/head.js
+++ b/browser/components/enterprisepolicies/tests/browser/head.js
@@ -37,12 +37,12 @@ async function setupPolicyEngineWithJson(json, customSchema, shutdown = false) {
   if (JSON.stringify(json) === "{}") {
     if (!shutdown) {
       return EnterprisePolicyTesting.servePolicyWithJson(
-        {},
+        { policies: {} },
         {},
         registerCleanupFunction
       );
     }
-    return EnterprisePolicyTesting.servePolicyWithJson({}, {});
+    return EnterprisePolicyTesting.servePolicyWithJson({ policies: {} }, {});
   }
   return EnterprisePolicyTesting.servePolicyWithJson(
     json,

--- a/browser/components/genai/GenAI.sys.mjs
+++ b/browser/components/genai/GenAI.sys.mjs
@@ -76,11 +76,13 @@ XPCOMUtils.defineLazyPreferenceGetter(
   null,
   (_pref, _old, val) => onChatProviderChange(val)
 );
+export const CHAT_PROVIDERS_DEFAULT = "claude,chatgpt,copilot,gemini,lechat";
+
 XPCOMUtils.defineLazyPreferenceGetter(
   lazy,
   "chatProviders",
   "browser.ml.chat.providers",
-  "claude,chatgpt,copilot,gemini,lechat",
+  CHAT_PROVIDERS_DEFAULT,
   reorderChatProviders
 );
 XPCOMUtils.defineLazyPreferenceGetter(
@@ -854,6 +856,11 @@ export const GenAI = {
 
     // Add remove provider option
     const popup = source === "tool" ? menu : menu.menupopup;
+    // Hide the menu item entirely if there is no popup to attach items to.
+    if (!popup) {
+      showItem(menu, false);
+      return;
+    }
     popup.appendChild(doc.createXULElement("menuseparator"));
     const removeItem = addItem();
     doc.l10n.setAttributes(
@@ -931,6 +938,11 @@ export const GenAI = {
           targeting: "true",
           value: "",
         };
+        if (!promptObj.label.length) {
+          // Because these are default preferences, the only way to change
+          // them is to set them to an empty string.
+          return;
+        }
         try {
           // Prompts can be JSON with label, value, targeting and other keys
           Object.assign(promptObj, JSON.parse(promptObj.label));
@@ -940,6 +952,9 @@ export const GenAI = {
             promptObj.id = null;
           }
         } catch (ex) {}
+        if (!promptObj.label && !promptObj.l10nId) {
+          return;
+        }
         messages.push(promptObj);
         if (promptObj.l10nId) {
           toFormat.push(promptObj);

--- a/browser/components/genai/chat.css
+++ b/browser/components/genai/chat.css
@@ -189,27 +189,6 @@ browser {
     max-width: var(--icon-size);
     min-width: var(--icon-size);
     outline: none;
-
-    &.claude {
-      background-image: url(assets/brands/claude.svg);
-    }
-    &.chatgpt {
-      background-image: url(assets/brands/chatgpt.svg);
-      -moz-context-properties: fill;
-      fill: var(--text-color);
-    }
-    &.copilot {
-      background-image: url(assets/brands/copilot.svg);
-    }
-    &.gemini {
-      background-image: url(assets/brands/gemini.svg);
-    }
-    &.huggingchat {
-      background-image: url(assets/brands/huggingchat.svg);
-    }
-    &.lechat {
-      background-image: url(assets/brands/lechat.svg);
-    }
   }
 
   .text {

--- a/browser/components/genai/chat.html
+++ b/browser/components/genai/chat.html
@@ -7,7 +7,7 @@
     <meta charset="utf-8" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src resource: chrome:; object-src 'none'; img-src data: chrome:;"
+      content="default-src resource: chrome:; object-src 'none'; img-src data: chrome: moz-remote-image:;"
     />
     <meta name="color-scheme" content="light dark" />
     <title data-l10n-id="genai-chatbot-title"></title>

--- a/browser/components/genai/chat.js
+++ b/browser/components/genai/chat.js
@@ -403,6 +403,9 @@ function showOnboarding(length) {
         action: { picker: "<event>" },
         data: [...providerConfigs.values()].map(config => ({
           action: { type: ACTIONS.CHATBOT_SELECT, config },
+          icon: config.iconUrl
+            ? { backgroundImage: `url(${config.iconUrl})` }
+            : undefined,
           id: config.id,
           label: config.name,
           tooltip: { string_id: config.tooltipId },

--- a/browser/components/preferences/tests/browser_primaryPassword.js
+++ b/browser/components/preferences/tests/browser_primaryPassword.js
@@ -42,6 +42,10 @@ add_task(async function () {
     getOSAuthEnabled() {
       return true; // Since enabled by default.
     },
+    // Simulate non-enterprise-managed browser
+    isEnterpriseManagedPrimaryPassword() {
+      return false;
+    },
   };
 
   let checkbox = doc.querySelector("#useMasterPassword");
@@ -171,6 +175,10 @@ add_task(async function () {
     },
     getOSAuthEnabled() {
       return true; // Since enabled by default.
+    },
+    // Simulate non-enterprise-managed browser
+    isEnterpriseManagedPrimaryPassword() {
+      return false;
     },
   };
 

--- a/browser/extensions/felt/.eslintrc.mjs
+++ b/browser/extensions/felt/.eslintrc.mjs
@@ -4,11 +4,6 @@
 
 export default [
   {
-    rules: {
-      "no-console": "off",
-    },
-  },
-  {
     files: ["content/window.js"],
     languageOptions: {
       globals: {

--- a/browser/extensions/felt/api.js
+++ b/browser/extensions/felt/api.js
@@ -32,6 +32,12 @@ ChromeUtils.defineESModuleGetters(lazy, {
   isBlockingShutdown: "resource:///modules/enterprise/EnterpriseCommon.sys.mjs",
   shouldNotCloseWindow:
     "resource:///modules/enterprise/EnterpriseCommon.sys.mjs",
+  createEnterpriseLogger:
+    "resource:///modules/enterprise/EnterpriseCommon.sys.mjs",
+});
+
+ChromeUtils.defineLazyGetter(lazy, "log", () => {
+  return lazy.createEnterpriseLogger("Felt");
 });
 
 this.felt = class extends ExtensionAPI {
@@ -145,7 +151,9 @@ this.felt = class extends ExtensionAPI {
       }
 
       if (!win) {
-        console.error("FeltExtension: No browser window available to open URL");
+        lazy.log.error(
+          "FeltExtension: No browser window available to open URL"
+        );
         return;
       }
 
@@ -153,7 +161,7 @@ this.felt = class extends ExtensionAPI {
         win.openTrustedLinkIn(url, "tab");
         win.focus();
       } catch (err) {
-        console.error("FeltExtension: Failed to open forwarded URL", url, err);
+        lazy.log.error("FeltExtension: Failed to open forwarded URL", url, err);
       }
     },
 
@@ -185,7 +193,7 @@ this.felt = class extends ExtensionAPI {
           args,
         });
       } catch (err) {
-        console.error("FeltExtension: Failed to open forwarded window", err);
+        lazy.log.error("FeltExtension: Failed to open forwarded window", err);
       }
     },
   };
@@ -234,13 +242,13 @@ this.felt = class extends ExtensionAPI {
       try {
         Services.felt.sendExtensionReady();
       } catch (e) {
-        console.error("FeltExtension: Failed to send extension ready:", e);
+        lazy.log.error("FeltExtension: Failed to send extension ready:", e);
       }
     }
   }
 
   receiveMessage(message) {
-    console.debug(`FeltExtension: ${message.name} handling ...`);
+    lazy.log.debug(`FeltExtension: ${message.name} handling ...`);
     switch (message.name) {
       case "FeltParent:FirefoxNormalExit": {
         Services.ppmm.removeMessageListener(
@@ -264,7 +272,7 @@ this.felt = class extends ExtensionAPI {
         if (message.data?.performLogout === true) {
           lazy.ConsoleClient._post(lazy.ConsoleClient._paths.SIGNOUT)
             .catch(e => {
-              console.error(`FeltExtension: Failed to post signout: ${e}`);
+              lazy.log.error(`FeltExtension: Failed to post signout: ${e}`);
             })
             .then(doShutdown);
         } else {
@@ -286,14 +294,14 @@ this.felt = class extends ExtensionAPI {
 
       case "FeltParent:FirefoxAbnormalExit": {
         const success = Services.felt.makeBackgroundProcess(false);
-        console.debug(`FeltExtension: makeBackgroundProcess? ${success}`);
+        lazy.log.debug(`FeltExtension: makeBackgroundProcess? ${success}`);
         this.showWindow("felt-browser-error-multiple-crashes");
         break;
       }
 
       case "FeltParent:FirefoxLogoutExit": {
         const success = Services.felt.makeBackgroundProcess(false);
-        console.debug(`FeltExtension: makeBackgroundProcess? ${success}`);
+        lazy.log.debug(`FeltExtension: makeBackgroundProcess? ${success}`);
         this.showWindow(
           lazy.logoutTypeMessageClass.get(message.data.logoutType) ?? ""
         );
@@ -304,18 +312,18 @@ this.felt = class extends ExtensionAPI {
         Services.startup.enterLastWindowClosingSurvivalArea();
         this.closeWindow();
         const success = Services.felt.makeBackgroundProcess(true);
-        console.debug(`FeltExtension: makeBackgroundProcess? ${success}`);
+        lazy.log.debug(`FeltExtension: makeBackgroundProcess? ${success}`);
         break;
       }
 
       default:
-        console.debug(`FeltExtension: ${message.name} NOT HANDLED`);
+        lazy.log.debug(`FeltExtension: ${message.name} NOT HANDLED`);
         break;
     }
   }
 
   windowObserver(subject, topic) {
-    console.debug(`FeltExtension: topic=${topic}`);
+    lazy.log.debug(`FeltExtension: topic=${topic}`);
     if (topic === "domwindowopened") {
       Services.startup.exitLastWindowClosingSurvivalArea();
     }
@@ -329,7 +337,7 @@ this.felt = class extends ExtensionAPI {
   }
 
   closeWindow() {
-    console.debug(`FeltExtension: closeWindow: this._win=${this._win}`);
+    lazy.log.debug(`FeltExtension: closeWindow: this._win=${this._win}`);
     if (lazy.shouldNotCloseWindow()) {
       // Some tests needs to run code on FELT while Browser is running, and
       // this requires the window to be kept alive.
@@ -342,7 +350,7 @@ this.felt = class extends ExtensionAPI {
   }
 
   showWindow(errorMessage = "") {
-    console.debug(`FeltExtension: showWindow: this._win=${this._win}`);
+    lazy.log.debug(`FeltExtension: showWindow: this._win=${this._win}`);
 
     // Height and width are for now set to fit the sso.mozilla.com without the need to resize the window
     let flags =
@@ -368,7 +376,7 @@ this.felt = class extends ExtensionAPI {
   }
 
   onShutdown(isAppShutdown) {
-    console.debug(`FeltExtension: onShutdown: ${isAppShutdown}`);
+    lazy.log.debug(`FeltExtension: onShutdown: ${isAppShutdown}`);
 
     if (isAppShutdown) {
       return;

--- a/browser/extensions/felt/content/ContextMenuChild.sys.mjs
+++ b/browser/extensions/felt/content/ContextMenuChild.sys.mjs
@@ -6,8 +6,13 @@ const lazy = {};
 
 ChromeUtils.defineESModuleGetters(lazy, {
   SpellCheckHelper: "resource://gre/modules/InlineSpellChecker.sys.mjs",
+  createEnterpriseLogger:
+    "resource:///modules/enterprise/EnterpriseCommon.sys.mjs",
 });
 
+ChromeUtils.defineLazyGetter(lazy, "log", () => {
+  return lazy.createEnterpriseLogger("FeltContextMenuChild");
+});
 /**
  * Gathers the data required to display the context menu from the content process.
  */
@@ -18,7 +23,7 @@ export class ContextMenuChild extends JSWindowActorChild {
         this.#onContextMenu(event);
         break;
       default:
-        console.error(`ContextMenuChild: Unexpected event.type=${event.type}`);
+        lazy.log.error(`ContextMenuChild: Unexpected event.type=${event.type}`);
         break;
     }
   }

--- a/browser/extensions/felt/content/FeltProcessParent.sys.mjs
+++ b/browser/extensions/felt/content/FeltProcessParent.sys.mjs
@@ -9,11 +9,15 @@ ChromeUtils.defineESModuleGetters(lazy, {
   ConsoleClient: "resource:///modules/enterprise/ConsoleClient.sys.mjs",
   CONSOLE_ADDRESS_PREF: "resource:///modules/enterprise/ConsoleClient.sys.mjs",
   isTesting: "resource:///modules/enterprise/EnterpriseCommon.sys.mjs",
+  createEnterpriseLogger:
+    "resource:///modules/enterprise/EnterpriseCommon.sys.mjs",
   FeltCommon: "chrome://felt/content/FeltCommon.sys.mjs",
   FeltStorage: "resource:///modules/FeltStorage.sys.mjs",
 });
 
-console.debug(`FeltExtension: FeltParentProcess.sys.mjs`);
+ChromeUtils.defineLazyGetter(lazy, "log", () => {
+  return lazy.createEnterpriseLogger("FeltProcessParent");
+});
 
 const PROCESS_START_REASON = {
   INITIAL_START: "initial-start",
@@ -69,7 +73,7 @@ function notifyFirefoxReady() {
     return;
   }
   gFeltFirefoxReadyNotified = true;
-  console.debug("FeltExtension: Notifying felt-firefox-window-ready");
+  lazy.log.debug("FeltExtension: Notifying felt-firefox-window-ready");
   Services.obs.notifyObservers(null, "felt-firefox-window-ready");
 }
 
@@ -98,7 +102,7 @@ let gObserversRegistered = false;
  */
 export class FeltProcessParent extends JSProcessActorParent {
   constructor() {
-    console.debug(
+    lazy.log.debug(
       `FeltExtension: FeltParentProcess.sys.mjs: FeltProcessParent`
     );
     super();
@@ -135,7 +139,7 @@ export class FeltProcessParent extends JSProcessActorParent {
 
     this.browserObserver = {
       observe(aSubject, aTopic, aData) {
-        console.debug(`FeltExtension: ParentProcess: Received ${aTopic}`);
+        lazy.log.debug(`FeltExtension: ParentProcess: Received ${aTopic}`);
         switch (aTopic) {
           case "felt-firefox-exiting": {
             gFeltProcessParentInstance.exitReported = true;
@@ -168,12 +172,12 @@ export class FeltProcessParent extends JSProcessActorParent {
                 return pendingUpdate;
               })
               .catch(err => {
-                console.debug(
+                lazy.log.debug(
                   `FeltExtension: ParentProcess: getReadyUpdate failed: ${err}`
                 );
               })
               .then(pendingUpdate => {
-                console.debug(
+                lazy.log.debug(
                   `FeltExtension: ParentProcess: restart notification, restartDisabled=${restartDisabled}`
                 );
                 // Kill Firefox directly instead of broadcasting to receiveMessage()
@@ -181,25 +185,25 @@ export class FeltProcessParent extends JSProcessActorParent {
                 if (gFeltProcessParentInstance?.proc) {
                   gFeltProcessParentInstance.restartReported = true;
                   gFeltProcessParentInstance.firefox = null;
-                  console.debug(
+                  lazy.log.debug(
                     `FeltExtension: ParentProcess: Killing Firefox PID=${gFeltProcessParentInstance.proc.pid}`
                   );
                   gFeltProcessParentInstance.proc
                     .kill()
                     .then(() => {
-                      console.debug(
+                      lazy.log.debug(
                         `FeltExtension: ParentProcess: Killed Firefox, restartDisabled=${restartDisabled}`
                       );
 
                       if (!restartDisabled && !pendingUpdate) {
-                        console.debug(
+                        lazy.log.debug(
                           `FeltExtension: ParentProcess: Starting new Firefox`
                         );
                         gFeltProcessParentInstance.startFirefox(
                           PROCESS_START_REASON.RESTART
                         );
                       } else if (pendingUpdate) {
-                        console.debug(
+                        lazy.log.debug(
                           `FeltExtension: ParentProcess: Restart requested and pending update, restarting FELT UI`
                         );
                         Services.cpmm.sendAsyncMessage(
@@ -207,7 +211,7 @@ export class FeltProcessParent extends JSProcessActorParent {
                           {}
                         );
                       } else {
-                        console.debug(
+                        lazy.log.debug(
                           `FeltExtension: ParentProcess: Restart disabled, sending normal exit to restore FELT UI`
                         );
                         Services.cpmm.sendAsyncMessage(
@@ -217,12 +221,12 @@ export class FeltProcessParent extends JSProcessActorParent {
                       }
                     })
                     .catch(err => {
-                      console.debug(
+                      lazy.log.debug(
                         `FeltExtension: ParentProcess: Kill failed: ${err}`
                       );
                     });
                 } else {
-                  console.debug(
+                  lazy.log.debug(
                     `FeltExtension: ParentProcess: No proc to kill!`
                   );
                 }
@@ -243,7 +247,7 @@ export class FeltProcessParent extends JSProcessActorParent {
             break;
 
           case "felt-firefox-tokens": {
-            console.debug(
+            lazy.log.debug(
               `FeltExtension: ParentProcess: Update tokens from browser to FELT`
             );
             const data = JSON.parse(aData);
@@ -256,7 +260,7 @@ export class FeltProcessParent extends JSProcessActorParent {
           }
 
           default:
-            console.debug(`FeltExtension: ParentProcess: Unhandled ${aTopic}`);
+            lazy.log.debug(`FeltExtension: ParentProcess: Unhandled ${aTopic}`);
             break;
         }
       },
@@ -290,7 +294,7 @@ export class FeltProcessParent extends JSProcessActorParent {
     } = await lazy.ConsoleClient.getFirefoxConfigs();
 
     if (learn_more_url === null) {
-      console.error("No learn_more_url in Firefox configuration");
+      lazy.log.error("No learn_more_url in Firefox configuration");
     } else {
       Services.felt.sendStringPreference(
         "enterprise.configs.learn_more_url",
@@ -299,7 +303,7 @@ export class FeltProcessParent extends JSProcessActorParent {
     }
 
     if (company_logo_url === null) {
-      console.error("No company_logo_url in Firefox configuration");
+      lazy.log.error("No company_logo_url in Firefox configuration");
     } else {
       Services.felt.sendStringPreference(
         "enterprise.configs.company_logo_url",
@@ -308,7 +312,7 @@ export class FeltProcessParent extends JSProcessActorParent {
     }
 
     if (polling_frequency === null) {
-      console.error("No polling_frequency in Firefox configuration");
+      lazy.log.error("No polling_frequency in Firefox configuration");
     } else {
       Services.felt.sendIntPreference(
         "browser.policies.live_polling.frequency",
@@ -317,7 +321,7 @@ export class FeltProcessParent extends JSProcessActorParent {
     }
 
     if (tokenserver_url === null) {
-      console.error("No tokenserver_url in Firefox configuration");
+      lazy.log.error("No tokenserver_url in Firefox configuration");
     } else {
       Services.felt.sendStringPreference(
         "identity.sync.tokenserver.uri",
@@ -326,7 +330,7 @@ export class FeltProcessParent extends JSProcessActorParent {
     }
 
     if (remote_settings_url === null) {
-      console.error("No remote_settings_url in Firefox configuration");
+      lazy.log.error("No remote_settings_url in Firefox configuration");
     } else {
       Services.felt.sendStringPreference(
         "services.settings.server",
@@ -335,7 +339,7 @@ export class FeltProcessParent extends JSProcessActorParent {
     }
 
     if (push_url === null) {
-      console.error("No push_url in Firefox configuration");
+      lazy.log.error("No push_url in Firefox configuration");
     } else {
       Services.felt.sendStringPreference("dom.push.serverURL", push_url);
     }
@@ -353,7 +357,7 @@ export class FeltProcessParent extends JSProcessActorParent {
   _setPrefInFirefox(pref) {
     const name = pref[0];
     const value = pref[1];
-    console.debug(
+    lazy.log.debug(
       `Sending preference ${name} with value ${value} from Felt to Firefox`
     );
 
@@ -371,7 +375,7 @@ export class FeltProcessParent extends JSProcessActorParent {
         break;
 
       default:
-        console.warn(`Unsupported pref type for ${name}:`, value);
+        lazy.log.warn(`Unsupported pref type for ${name}:`, value);
     }
   }
 
@@ -421,7 +425,7 @@ export class FeltProcessParent extends JSProcessActorParent {
         notifyFirefoxReady();
       })
       .then(() => {
-        console.debug(
+        lazy.log.debug(
           `firefox: waiting on proc PID ${this.proc.pid}`,
           this.proc
         );
@@ -429,8 +433,8 @@ export class FeltProcessParent extends JSProcessActorParent {
         this.proc.exitPromise
           .then(ev => {
             lazy.ConsoleClient.isSessionRefreshBlocked = false;
-            console.debug(`firefox exit: ev`, JSON.stringify(ev));
-            console.debug(
+            lazy.log.debug(`firefox exit: ev`, JSON.stringify(ev));
+            lazy.log.debug(
               `firefox exit: PID:${this.proc.pid} exitCode:${JSON.stringify(this.proc.exitCode)}`
             );
 
@@ -461,11 +465,11 @@ export class FeltProcessParent extends JSProcessActorParent {
    * again or to inform the user of the set of crashes.
    */
   handleRestartAfterAbnormalExit() {
-    console.debug(
+    lazy.log.debug(
       `Firefox: handleRestartAfterAbnormalExit: this.exitReported=${this.exitReported}`
     );
     if (this.exitReported) {
-      console.debug("Abort restarting Firefox, crash was shutdown crash.");
+      lazy.log.debug("Abort restarting Firefox, crash was shutdown crash.");
       Services.cpmm.sendAsyncMessage("FeltParent:FirefoxNormalExit", {});
       return;
     }
@@ -477,12 +481,12 @@ export class FeltProcessParent extends JSProcessActorParent {
     this.abnormalExitCounter += 1;
 
     if (this.shouldAbortRestarting()) {
-      console.debug(
+      lazy.log.debug(
         "Abort restarting Firefox and inform the user of the crashes."
       );
       Services.cpmm.sendAsyncMessage("FeltParent:FirefoxAbnormalExit", {});
     } else {
-      console.debug("Trying to restart Firefox again.");
+      lazy.log.debug("Trying to restart Firefox again.");
       this.startFirefox(PROCESS_START_REASON.CRASH);
     }
   }
@@ -494,7 +498,7 @@ export class FeltProcessParent extends JSProcessActorParent {
    * @returns {boolean} Whether these "abnormal" thresholds are exceeded.
    */
   shouldAbortRestarting() {
-    console.debug(
+    lazy.log.debug(
       `Firefox AbnormalExit abnormalExitLimit=${this.abnormalExitLimit} abnormalExitCounter=${this.abnormalExitCounter} ; firstTime=${this.abnormalExitFirstTime} abnormalExitPeriod=${this.abnormalExitPeriod}`
     );
     // Have we reached the limit of allowed crashes ?
@@ -506,7 +510,7 @@ export class FeltProcessParent extends JSProcessActorParent {
       this.abnormalExitFirstTime;
     // Is the time since first crash too recent ?
     const isWithinCrashPeriod = timeSinceFirstCrash <= this.abnormalExitPeriod;
-    console.debug(
+    lazy.log.debug(
       `Firefox AbnormalExit crashLimitHit=${isExceedingCrashCounterLimit} timeSinceFirstCrash=${timeSinceFirstCrash} crashedNotLongAgoEnough=${isWithinCrashPeriod}`
     );
     return isExceedingCrashCounterLimit && isWithinCrashPeriod;
@@ -543,14 +547,14 @@ export class FeltProcessParent extends JSProcessActorParent {
         for (let profile of profileService.profiles) {
           if (profile.name === legacyProfileName) {
             foundProfile = profile;
-            console.warn("using legacy profile");
+            lazy.log.warn("using legacy profile");
             break;
           }
         }
       }
 
       if (!foundProfile) {
-        console.debug(`FeltExtension: creating new ${profileName} profile`);
+        lazy.log.debug(`FeltExtension: creating new ${profileName} profile`);
         foundProfile = profileService.createProfile(null, profileName);
 
         await profileService.asyncFlush();
@@ -606,7 +610,7 @@ export class FeltProcessParent extends JSProcessActorParent {
     try {
       this.proc = await lazy.Subprocess.call(firefoxRun);
     } catch (e) {
-      console.error("Failed to launch Firefox: ", e.message);
+      lazy.log.error("Failed to launch Firefox: ", e.message);
       throw e;
     }
 
@@ -620,7 +624,7 @@ export class FeltProcessParent extends JSProcessActorParent {
    */
   sendURLToFirefox(payload) {
     if (!this.firefoxReady || !Services.felt) {
-      console.error(`FeltExtension: Cannot send URL, Firefox not ready`);
+      lazy.log.error(`FeltExtension: Cannot send URL, Firefox not ready`);
       return;
     }
 
@@ -628,7 +632,7 @@ export class FeltProcessParent extends JSProcessActorParent {
       let { url, disposition } = extractURLPayload(payload);
       Services.felt.openURL(url, disposition);
     } catch (err) {
-      console.error(`FeltExtension: Failed to forward URL: ${err}`);
+      lazy.log.error(`FeltExtension: Failed to forward URL: ${err}`);
     }
   }
 
@@ -642,14 +646,14 @@ export class FeltProcessParent extends JSProcessActorParent {
 
     // Wait for both Firefox (prefs/cookies) AND extension (observer) to be ready
     if (!this.firefoxReady || !this.extensionReady) {
-      console.debug(
+      lazy.log.debug(
         `FeltExtension: Not ready to forward URLs (firefoxReady=${this.firefoxReady}, extensionReady=${this.extensionReady})`
       );
       return;
     }
 
     if (!Services.felt) {
-      console.error(
+      lazy.log.error(
         `FeltExtension: Services.felt not available, cannot forward URLs`
       );
       return;
@@ -661,7 +665,7 @@ export class FeltProcessParent extends JSProcessActorParent {
         let { url, disposition } = extractURLPayload(payload);
         Services.felt.openURL(url, disposition);
       } catch (err) {
-        console.error(`FeltExtension: Failed to forward URL: ${err}`);
+        lazy.log.error(`FeltExtension: Failed to forward URL: ${err}`);
       }
     }
 
@@ -679,7 +683,7 @@ export class FeltProcessParent extends JSProcessActorParent {
       throw new Error("Logout handling should only happen on FELT side.");
     }
 
-    console.debug(
+    lazy.log.debug(
       `FeltExtension: Logout (${logoutType}), waiting on ${gFeltProcessParentInstance.proc.pid}`
     );
     gFeltProcessParentInstance.logoutReported = true;
@@ -699,7 +703,7 @@ export class FeltProcessParent extends JSProcessActorParent {
   }
 
   async receiveMessage(message) {
-    console.debug(
+    lazy.log.debug(
       `FeltExtension: ParentProcess: Received message ${message.name} => ${message.data}`
     );
     switch (message.name) {
@@ -721,7 +725,7 @@ export class FeltProcessParent extends JSProcessActorParent {
           );
 
           const ssoCollectedCookies = this.getAllCookies();
-          console.debug(`Collected cookies: ${ssoCollectedCookies.length}`);
+          lazy.log.debug(`Collected cookies: ${ssoCollectedCookies.length}`);
           // When a restart was reported we assume cookies were stored properly on the
           // browser side?
           if (!ssoCollectedCookies.length) {
@@ -741,7 +745,7 @@ export class FeltProcessParent extends JSProcessActorParent {
   }
 
   getAllCookies() {
-    console.debug(
+    lazy.log.debug(
       `FeltExtension: collecting cookies from privateBrowsingId=${lazy.FeltCommon.PRIVATE_BROWSING_ID}`
     );
     return Services.cookies.getCookiesWithOriginAttributes(
@@ -755,7 +759,7 @@ export class FeltProcessParent extends JSProcessActorParent {
     if (this.loggedInUserInfo !== null) {
       return `${lazy.FeltCommon.ENTERPRISE_PROFILE}-${await hashTo40bits(this.loggedInUserInfo.id)}`;
     }
-    console.error(`FeltExtension: loggedInUserInfo not set`);
+    lazy.log.error(`FeltExtension: loggedInUserInfo not set`);
     return lazy.FeltCommon.ENTERPRISE_PROFILE;
   }
 }

--- a/browser/extensions/felt/content/FeltWindowChild.sys.mjs
+++ b/browser/extensions/felt/content/FeltWindowChild.sys.mjs
@@ -2,7 +2,16 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-console.debug(`FeltExtension: FeltWindowChild.sys.mjs`);
+const lazy = {};
+
+ChromeUtils.defineESModuleGetters(lazy, {
+  createEnterpriseLogger:
+    "resource:///modules/enterprise/EnterpriseCommon.sys.mjs",
+});
+
+ChromeUtils.defineLazyGetter(lazy, "log", () => {
+  return lazy.createEnterpriseLogger("FeltWindowChild");
+});
 
 /**
  *
@@ -38,14 +47,14 @@ export class FeltWindowChild extends JSWindowActorChild {
       return false;
     }
 
-    console.debug("FeltWindowChild: Extracting token data");
+    lazy.log.debug("FeltWindowChild: Extracting token data");
     const consoleTokenData = JSON.parse(tokenData.textContent);
     if (
       consoleTokenData &&
       "access_token" in consoleTokenData &&
       consoleTokenData.access_token !== ""
     ) {
-      console.debug("FeltWindowChild: Sending token data to start Firefox");
+      lazy.log.debug("FeltWindowChild: Sending token data to start Firefox");
       this.#tokensSent = true;
       this.processActor.sendAsyncMessage(
         "FeltChild:StartFirefox",

--- a/browser/extensions/felt/content/window.js
+++ b/browser/extensions/felt/content/window.js
@@ -480,15 +480,19 @@ function focusEmailOnLoginVisible() {
   const loginPane = document.querySelector(".felt-login");
   const emailInput = document.getElementById("felt-form__email");
 
-  new MutationObserver(() => {
+  function maybeFocusEmail() {
     if (!loginPane.classList.contains("is-hidden")) {
       emailInput?.focus();
     }
-  }).observe(loginPane, { attributeFilter: ["class"] });
-
-  if (!loginPane.classList.contains("is-hidden")) {
-    emailInput?.focus();
   }
+
+  new MutationObserver(maybeFocusEmail).observe(loginPane, {
+    attributeFilter: ["class"],
+  });
+
+  window.addEventListener("focus", maybeFocusEmail);
+
+  maybeFocusEmail();
 }
 
 /**

--- a/browser/extensions/felt/content/window.js
+++ b/browser/extensions/felt/content/window.js
@@ -17,6 +17,12 @@ ChromeUtils.defineESModuleGetters(lazy, {
   FeltStorage: "resource:///modules/FeltStorage.sys.mjs",
   PopupNotifications: "resource://gre/modules/PopupNotifications.sys.mjs",
   Updates: "resource:///modules/enterprise/Updates.sys.mjs",
+  createEnterpriseLogger:
+    "resource:///modules/enterprise/EnterpriseCommon.sys.mjs",
+});
+
+ChromeUtils.defineLazyGetter(lazy, "log", () => {
+  return lazy.createEnterpriseLogger("Felt");
 });
 
 // Will at least make move forward marionette
@@ -89,7 +95,7 @@ const ErrorReport = {
     try {
       return this._stringBundles.app.formatStringFromName(msgId, [cause?.host]);
     } catch (ex) {
-      console.error(
+      lazy.log.error(
         `FELT error localization failed for '${msgId}'. Expected for NSS errors.`
       );
       return null;
@@ -102,7 +108,7 @@ async function connectToConsole(email) {
   try {
     posture = await lazy.ConsoleClient.sendDevicePosture();
   } catch (err) {
-    console.error(`FeltExtension: Failed to connect to console: ${err}`);
+    lazy.log.error(`FeltExtension: Failed to connect to console: ${err}`);
 
     // Show simpler "No Network Connection" only for truly offline scenarios
     // netOffline for offline mode, dnsNotFound2 for actual network disconnect
@@ -148,17 +154,17 @@ async function connectToConsole(email) {
       oa
     )
   );
-  console.debug(
+  lazy.log.debug(
     `FeltExtension: creating contentPrincipal with privateBrowsingId=${lazy.FeltCommon.PRIVATE_BROWSING_ID}`
   );
   const contentPrincipal =
     Services.scriptSecurityManager.createContentPrincipal(ssoLoginURI, {
       privateBrowsingId: lazy.FeltCommon.PRIVATE_BROWSING_ID,
     });
-  console.debug(
+  lazy.log.debug(
     `FeltExtension: created contentPrincipal with privateBrowsingId=${contentPrincipal.privateBrowsingId}`
   );
-  console.debug("Load SSO URI: ", ssoLoginURI);
+  lazy.log.debug("Load SSO URI: ", ssoLoginURI);
   browser.fixupAndLoadURIString(ssoLoginURI.spec, {
     triggeringPrincipal: contentPrincipal,
   });
@@ -194,7 +200,7 @@ async function connectToConsole(email) {
   }
 
   let ssoTimeout = setTimeout(() => {
-    console.error("FeltExtension: SSO login timed out");
+    lazy.log.error("FeltExtension: SSO login timed out");
     resetToLoginPage("felt-browser-error-sso-timeout");
   }, SSO_TIMEOUT_MS);
 
@@ -222,7 +228,7 @@ async function connectToConsole(email) {
       ssoCompleted = true;
 
       if (!Components.isSuccessCode(status)) {
-        console.error(
+        lazy.log.error(
           `FeltExtension: SSO callback page failed to load: 0x${status.toString(16)}`
         );
         resetToLoginPage(
@@ -235,7 +241,7 @@ async function connectToConsole(email) {
 
       const windowGlobal = browser.browsingContext?.currentWindowGlobal;
       if (!windowGlobal) {
-        console.error("FeltExtension: No WindowGlobal for SSO callback page");
+        lazy.log.error("FeltExtension: No WindowGlobal for SSO callback page");
         resetToLoginPage("felt-browser-error-connection");
         return;
       }
@@ -249,20 +255,20 @@ async function connectToConsole(email) {
           .sendQuery("ExtractTokens")
           .then(sent => {
             if (!sent) {
-              console.error(
+              lazy.log.error(
                 "FeltExtension: Fallback token extraction found no token data"
               );
               resetToLoginPage("felt-browser-error-connection");
             }
           })
           .catch(err => {
-            console.error(
+            lazy.log.error(
               `FeltExtension: Fallback token extraction failed: ${err}`
             );
             resetToLoginPage("felt-browser-error-connection");
           });
       } catch (err) {
-        console.error(
+        lazy.log.error(
           `FeltExtension: Could not reach FeltWindow actor: ${err}`
         );
         resetToLoginPage("felt-browser-error-connection");
@@ -280,7 +286,7 @@ async function connectToConsole(email) {
       // MFA prompts, etc.).
       clearTimeout(ssoTimeout);
       ssoTimeout = setTimeout(() => {
-        console.error("FeltExtension: SSO login timed out");
+        lazy.log.error("FeltExtension: SSO login timed out");
         resetToLoginPage("felt-browser-error-sso-timeout");
       }, SSO_TIMEOUT_MS);
     },
@@ -466,7 +472,7 @@ function setupPopupNotifications() {
     try {
       return new lazy.PopupNotifications(window.gBrowser, panel, anchor, {});
     } catch (ex) {
-      console.error(ex);
+      lazy.log.error(ex);
       return null;
     }
   });

--- a/browser/extensions/felt/jar.mn
+++ b/browser/extensions/felt/jar.mn
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 browser.jar:
+% content felt %builtin-addons/felt/content/
     builtin-addons/felt/api.js (api.js)
     builtin-addons/felt/background.js (background.js)
     builtin-addons/felt/content/ (content/*)

--- a/browser/extensions/newtab/lib/FrecencyBoostProvider/FrecencyBoostProvider.mjs
+++ b/browser/extensions/newtab/lib/FrecencyBoostProvider/FrecencyBoostProvider.mjs
@@ -2,6 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
+const { AppConstants } = ChromeUtils.importESModule(
+  "resource://gre/modules/AppConstants.sys.mjs"
+);
+
 const lazy = {};
 
 ChromeUtils.defineESModuleGetters(lazy, {
@@ -21,8 +25,9 @@ ChromeUtils.defineLazyGetter(lazy, "log", () => {
 });
 
 const CACHE_KEY = "frecency_boost_cache";
-const RS_FALLBACK_BASE_URL =
-  "https://firefox-settings-attachments.cdn.mozilla.net/";
+const RS_FALLBACK_BASE_URL = AppConstants.MOZ_ENTERPRISE
+  ? ""
+  : "https://firefox-settings-attachments.cdn.mozilla.net/";
 const SPONSORED_TILE_PARTNER_FREC_BOOST = "frec-boost";
 const DEFAULT_SOV_NUM_ITEMS = 200;
 

--- a/browser/extensions/newtab/lib/Wallpapers/WallpaperFeed.sys.mjs
+++ b/browser/extensions/newtab/lib/Wallpapers/WallpaperFeed.sys.mjs
@@ -9,6 +9,8 @@ ChromeUtils.defineESModuleGetters(lazy, {
   Utils: "resource://services-settings/Utils.sys.mjs",
 });
 
+import { AppConstants } from "resource://gre/modules/AppConstants.sys.mjs";
+
 import {
   actionTypes as at,
   actionCreators as ac,
@@ -31,9 +33,9 @@ const PREF_WALLPAPERS_CUSTOM_WALLPAPER_UUID =
 const PREF_SELECTED_WALLPAPER =
   "browser.newtabpage.activity-stream.newtabWallpapers.wallpaper";
 
-const RS_FALLBACK_BASE_URL =
-  "https://firefox-settings-attachments.cdn.mozilla.net/";
-
+const RS_FALLBACK_BASE_URL = AppConstants.MOZ_ENTERPRISE
+  ? ""
+  : "https://firefox-settings-attachments.cdn.mozilla.net/";
 export class WallpaperFeed {
   constructor() {
     this.loaded = false;

--- a/browser/locales/en-US/browser/enterprise/enterprise-policies-descriptions.ftl
+++ b/browser/locales/en-US/browser/enterprise/enterprise-policies-descriptions.ftl
@@ -3,6 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 policy-AccessConnector = Configure an access connector for proxying web traffic.
+policy-AIChatbot = Configure available AI chatbot providers, default provider, and prompt features.
 policy-BlocklistDomainBrowsedTelemetry = Enable and configure security logging/telemetry when { -brand-short-name } blocks a visit to a blocklisted domain.
 policy-DownloadTelemetry = Enable and configure security logging/telemetry when a download is triggered.
 policy-EnterpriseStorageEncryption = Enable enterprise-managed primary password for encrypted storage.

--- a/browser/locales/en-US/browser/enterprise/enterprise.ftl
+++ b/browser/locales/en-US/browser/enterprise/enterprise.ftl
@@ -15,7 +15,13 @@ enterprise-panel-learn-more = Learn more
 enterprise-panel-sign-out-btn =
     .label = Sign out…
 
-enterprise-signout-prompt-title = Sign out of { -brand-short-name }?
+# $tabCount (Number) - the number of open tabs
+enterprise-signout-prompt-title2 =
+    { $tabCount ->
+        [0] Sign out of { -brand-short-name }?
+        [one] Sign out of { -brand-short-name }?
+       *[other] Sign out and close { $tabCount } tabs?
+    }
 enterprise-signout-prompt-message = You’re signing out of your { -brand-short-name } browser. To use it again, you’ll need to re-authenticate through your company’s SSO provider.
 enterprise-signout-prompt-checkbox-label = Show this message when signing out.
 enterprise-signout-prompt-primary-btn-label = Sign out

--- a/dom/security/nsContentSecurityUtils.cpp
+++ b/dom/security/nsContentSecurityUtils.cpp
@@ -1329,6 +1329,7 @@ static nsLiteralCString sImgSrcMozRemoteImageAllowList[] = {
     "about:settings"_ns,
     "chrome://browser/content/aiwindow/aiWindow.html"_ns,
     "chrome://browser/content/firefoxview/firefoxview.html"_ns,
+    "chrome://browser/content/genai/chat.html"_ns,
     "chrome://browser/content/preferences/dialogs/applicationManager.xhtml"_ns,
     "chrome://browser/content/sidebar/sidebar-syncedtabs.html"_ns,
     "chrome://global/content/aboutProcesses.html"_ns,

--- a/taskcluster/config.yml
+++ b/taskcluster/config.yml
@@ -7,8 +7,12 @@ project-repo-param-prefix: ''
 product-dir: 'browser'
 treeherder:
     branch-map:
-        enterprise-main: enterprise-main
-        enterprise-release: enterprise-release
+        by-project:
+            enterprise-firefox-try:
+                default: enterprise-firefox-try
+            default:
+                enterprise-main: enterprise-main
+                enterprise-release: enterprise-release
     group-names:
         'js-bench-sm': 'JavaScript shell benchmarks with Spidermonkey'
         'js-bench-v8': 'JavaScript shell benchmarks with Google V8'

--- a/taskcluster/gecko_taskgraph/decision.py
+++ b/taskcluster/gecko_taskgraph/decision.py
@@ -135,6 +135,11 @@ PER_PROJECT_PARAMETERS = {
         "target_tasks_method": "enterprise_firefox_with_tests_tasks",
         "release_product": "firefox-enterprise",
     },
+    "enterprise-firefox-try": {
+        "enable_always_target": True,
+        "release_product": "firefox-enterprise",
+        "target_tasks_method": "try_tasks",
+    },
     # the default parameters are used for projects that do not match above.
     "default": {
         "target_tasks_method": "default",

--- a/taskcluster/gecko_taskgraph/parameters.py
+++ b/taskcluster/gecko_taskgraph/parameters.py
@@ -125,13 +125,7 @@ def get_app_version(product_dir="browser"):
 
 
 def get_release_type(parameters):
-    if parameters["project"] != "enterprise-firefox":
-        return ""
-
-    if (
-        not parameters["base_repository"]
-        == "https://github.com/mozilla/enterprise-firefox"
-    ):
+    if parameters["project"] not in ("enterprise-firefox", "enterprise-firefox-try"):
         return ""
 
     if parameters["head_ref"] == "refs/heads/enterprise-release":

--- a/taskcluster/gecko_taskgraph/parameters.py
+++ b/taskcluster/gecko_taskgraph/parameters.py
@@ -156,7 +156,7 @@ def get_defaults(repo_root=None):
         "next_version": None,
         "optimize_strategies": None,
         "phabricator_diff": None,
-        "project": "mozilla-central",
+        "project": "enterprise-firefox",
         "release_enable_emefree": False,
         "release_enable_partner_repack": False,
         "release_enable_partner_attribution": False,

--- a/taskcluster/gecko_taskgraph/transforms/build.py
+++ b/taskcluster/gecko_taskgraph/transforms/build.py
@@ -323,7 +323,7 @@ def add_enterprise_secret_scopes(config, jobs):
     """Enterprise builds re-use some secrets from the Gecko trust domain."""
     level = config.params["level"]
     for job in jobs:
-        if config.params["project"] == "enterprise-firefox":
+        if config.params["project"] in ("enterprise-firefox", "enterprise-firefox-try"):
             job.setdefault("scopes", []).extend([
                 f"secrets:get:project/releng/gecko/build/level-{level}/gls-gapi.data",
                 f"secrets:get:project/releng/gecko/build/level-{level}/sb-gapi.data",

--- a/taskcluster/gecko_taskgraph/transforms/build.py
+++ b/taskcluster/gecko_taskgraph/transforms/build.py
@@ -219,6 +219,7 @@ def enable_full_crashsymbols(config, jobs):
         "try",
         "try-comm-central",
         "enterprise-firefox",
+        "enterprise-firefox-try",
     }
     for job in jobs:
         enable_full_crashsymbols = job["attributes"].get("enable-full-crashsymbols")

--- a/taskcluster/gecko_taskgraph/transforms/hardened_signing.py
+++ b/taskcluster/gecko_taskgraph/transforms/hardened_signing.py
@@ -110,7 +110,10 @@ def add_provisioning_profile_config(config, jobs):
             elif config.params["project"] == "mozilla-central":
                 # Nightly
                 filename = PROVISIONING_PROFILE_FILENAMES["nightly"]
-            elif config.params["project"] == "enterprise-firefox":
+            elif config.params["project"] in (
+                "enterprise-firefox",
+                "enterprise-firefox-try",
+            ):
                 # Enterprise
                 filename = PROVISIONING_PROFILE_FILENAMES["enterprise"]
             else:

--- a/taskcluster/gecko_taskgraph/transforms/partner_repack.py
+++ b/taskcluster/gecko_taskgraph/transforms/partner_repack.py
@@ -57,14 +57,14 @@ def populate_repack_manifests_url(config, tasks):
     for task in tasks:
         partner_url_config = get_partner_url_config(config.params, config.graph_config)
 
+        repack_manifests_url = None
         for k in partner_url_config:
             if config.kind.startswith(k):
-                task["worker"].setdefault("env", {})["REPACK_MANIFESTS_URL"] = (
-                    partner_url_config[k]
-                )
+                repack_manifests_url = partner_url_config[k]
                 break
         else:
-            raise Exception("Can't find partner REPACK_MANIFESTS_URL")
+            if config.params["level"] == 3:
+                raise Exception("Can't find partner REPACK_MANIFESTS_URL")
 
         for property in ("limit-locales",):
             property = f"extra.{property}"
@@ -75,19 +75,24 @@ def populate_repack_manifests_url(config, tasks):
                 **{"release-level": release_level(config.params)},
             )
 
-        if task["worker"]["env"]["REPACK_MANIFESTS_URL"].startswith("git@"):
-            if "enterprise" in task["name"]:
-                task.setdefault("scopes", []).append(
-                    "secrets:get:project/enterprise/level-{level}/partner-github-ssh".format(
-                        **config.params
+        if repack_manifests_url:
+            task["worker"].setdefault("env", {})["REPACK_MANIFESTS_URL"] = (
+                repack_manifests_url
+            )
+
+            if repack_manifests_url.startswith("git@"):
+                if "enterprise" in task["name"]:
+                    task.setdefault("scopes", []).append(
+                        "secrets:get:project/enterprise/level-{level}/partner-github-ssh".format(
+                            **config.params
+                        )
                     )
-                )
-            else:
-                task.setdefault("scopes", []).append(
-                    "secrets:get:project/releng/gecko/build/level-{level}/partner-github-ssh".format(
-                        **config.params
+                else:
+                    task.setdefault("scopes", []).append(
+                        "secrets:get:project/releng/gecko/build/level-{level}/partner-github-ssh".format(
+                            **config.params
+                        )
                     )
-                )
 
         yield task
 
@@ -146,7 +151,7 @@ def add_command_arguments(config, tasks):
         # The upstream taskIds are stored a special environment variable, because we want to use
         # task-reference's to resolve dependencies, but the string handling of MOZHARNESS_OPTIONS
         # blocks that. It's space-separated string of ids in the end.
-        task["worker"]["env"]["UPSTREAM_TASKIDS"] = {
+        task["worker"].setdefault("env", {})["UPSTREAM_TASKIDS"] = {
             # We only want signing related tasks here, not build (used by mac builds for signing artifact resolution)
             "task-reference": " ".join([
                 f"<{dep}>"

--- a/taskcluster/gecko_taskgraph/transforms/repackage.py
+++ b/taskcluster/gecko_taskgraph/transforms/repackage.py
@@ -843,8 +843,10 @@ def make_job_description(config, jobs):
             if previous_repack and previous_repack not in repacks:
                 repacks += [previous_repack]
             else:
-                this_repack = config.params["release_partner_config"].get(config.kind)
-                if this_repack:
+                release_partner_config = (
+                    config.params.get("release_partner_config") or {}
+                )
+                if this_repack := release_partner_config.get(config.kind):
                     for enterprise_name, entries in this_repack.items():
                         for repack_name, entry in entries.items():
                             for platform_name in entry["platforms"]:

--- a/taskcluster/gecko_taskgraph/transforms/repackage.py
+++ b/taskcluster/gecko_taskgraph/transforms/repackage.py
@@ -845,14 +845,10 @@ def make_job_description(config, jobs):
             else:
                 this_repack = config.params["release_partner_config"].get(config.kind)
                 if this_repack:
-                    for enterprise_name in this_repack.keys():
-                        for repack_name in this_repack[enterprise_name]:
-                            for platform_name in this_repack[enterprise_name][
-                                repack_name
-                            ]["platforms"]:
-                                for repack_locale in this_repack[enterprise_name][
-                                    repack_name
-                                ]["locales"]:
+                    for enterprise_name, entries in this_repack.items():
+                        for repack_name, entry in entries.items():
+                            for platform_name in entry["platforms"]:
+                                for repack_locale in entry["locales"]:
                                     if platform_name == build_platform:
                                         repack_final_name = f"{enterprise_name}/{repack_name}/{repack_locale}"
                                         if repack_final_name not in repacks:

--- a/taskcluster/gecko_taskgraph/util/partners.py
+++ b/taskcluster/gecko_taskgraph/util/partners.py
@@ -650,13 +650,13 @@ def make_enterprise_repack(platforms):
 
 
 def get_release_partners(parameters):
-    if parameters["project"] != "enterprise-firefox":
+    if parameters["project"] not in ("enterprise-firefox", "enterprise-firefox-try"):
         return []
     return get_enterprise_partner_subset(parameters)
 
 
 def get_release_partner_config(parameters):
-    if parameters["project"] != "enterprise-firefox":
+    if parameters["project"] not in ("enterprise-firefox", "enterprise-firefox-try"):
         return {}
     return get_enterprise_partner_configs(parameters)
 

--- a/testing/enterprise/base_test.py
+++ b/testing/enterprise/base_test.py
@@ -106,7 +106,7 @@ class EnterpriseTestsBase(MarionetteTestCase):
     def open_tab_child(self, url):
         return self._open_tab(url, self._child_driver)
 
-    def get_marionette_port(self, max_try=100):
+    def get_marionette_port(self, max_try):
         marionette_port_file = os.path.join(
             self._child_profile_path, "MarionetteActivePort"
         )
@@ -124,8 +124,10 @@ class EnterpriseTestsBase(MarionetteTestCase):
 
         return (marionette_port, marionette_port_file)
 
-    def connect_child_browser(self, capabilities=None):
-        (marionette_port, marionette_port_file) = self.get_marionette_port()
+    def connect_child_browser(self, capabilities=None, max_try=100):
+        (marionette_port, marionette_port_file) = self.get_marionette_port(
+            max_try=max_try
+        )
         assert marionette_port > 0, "Valid marionette port"
         self._logger.info(f"Marionette PORT: {marionette_port}")
 

--- a/testing/enterprise/base_test.py
+++ b/testing/enterprise/base_test.py
@@ -156,8 +156,6 @@ class EnterpriseTestsBase(MarionetteTestCase):
         self._logger.info(
             f"New Marionette MOVED OUT {marionette_port_file} TO {port_file_copy}"
         )
-        self._child_driver.set_pref("enterprise.is_testing", True)
-        self._child_driver.set_pref("enterprise.log_level", "Debug")
 
     def get_driver(self, env):
         return self._driver if env == Environment.FELT else self._child_driver

--- a/testing/enterprise/base_test.py
+++ b/testing/enterprise/base_test.py
@@ -157,6 +157,7 @@ class EnterpriseTestsBase(MarionetteTestCase):
             f"New Marionette MOVED OUT {marionette_port_file} TO {port_file_copy}"
         )
         self._child_driver.set_pref("enterprise.is_testing", True)
+        self._child_driver.set_pref("enterprise.log_level", "Debug")
 
     def get_driver(self, env):
         return self._driver if env == Environment.FELT else self._child_driver

--- a/testing/enterprise/felt_browser_crashes.py
+++ b/testing/enterprise/felt_browser_crashes.py
@@ -24,7 +24,8 @@ class BrowserCrashes(FeltTests):
         try:
             # This is going to trigger exception for sure
             self._logger.info("Crashing main process")
-            self.open_tab_child("about:crashparent")
+            self._child_driver.set_context("content")
+            self._child_driver.navigate("about:crashparent")
         except Exception as ex:
             self._logger.info(f"Caught exception {ex}")
         finally:
@@ -45,10 +46,11 @@ class BrowserCrashes(FeltTests):
         self.connect_child_browser()
         self._browser_pid = self._child_driver.session_capabilities["moz:processID"]
         self._logger.info(f"Connected to {self._browser_pid}")
-        self.open_tab_child("about:support")
+        with self._child_driver.using_context("content"):
+            self._child_driver.navigate("about:buildconfig")
 
-        version_box = self.get_elem_child("#version-box")
-        self._child_wait.until(lambda d: len(version_box.text) > 0)
+        build_flags_box = self.get_elem_child("p:last-child")
+        self._child_wait.until(lambda d: len(build_flags_box.text) > 0)
 
     def run_felt_crash_parent_twice(self):
         self._manually_closed_child = True

--- a/testing/enterprise/felt_tests.py
+++ b/testing/enterprise/felt_tests.py
@@ -7,13 +7,14 @@ import ctypes
 import datetime
 import json
 import os
-import random
 import shutil
+import socket
 import sys
 import tempfile
 import time
 import urllib.parse
 import uuid
+from contextlib import closing
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from multiprocessing import Array, Process, Value
 
@@ -599,6 +600,12 @@ class FeltLogoutChecker:
         return False
 
 
+def find_free_port():
+    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
 class FeltTestsBase(EnterpriseTestsBase):
     EXTRA_ENV = {}
 
@@ -606,8 +613,8 @@ class FeltTestsBase(EnterpriseTestsBase):
         # test_prefs = kwargs.get("test_prefs", [])
 
         self._manually_closed_child = False
-        self.console_port = random.randrange(10000, 14999)
-        self.sso_port = random.randrange(15000, 20000)
+        self.console_port = find_free_port()
+        self.sso_port = find_free_port()
         self.policy_block_about_config = Value("b", 1)
         self.policy_extensions = Value("B", 0)
         self.policies_fail_request = Value("B", 0)

--- a/testing/enterprise/felt_tests.py
+++ b/testing/enterprise/felt_tests.py
@@ -897,6 +897,43 @@ class FeltTestsBase(EnterpriseTestsBase):
 
 
 class FeltTests(FeltTestsBase):
+    def reload_chrome_window(self):
+        # We set a marker before reloading so we can reliably detect when the
+        # new page is ready. A simple readyState == "complete" check is not
+        # sufficient because the old page may still report "complete" for a
+        # brief window after window.location.reload() is called, causing a
+        # false positive. The marker is absent on the new page, so we can
+        # unambiguously tell old page (marker matches), mid-reload (exception),
+        # and new page loading (marker gone, readyState != "complete") apart.
+        marker = str(uuid.uuid4())
+        with self._driver.using_context(self._driver.CONTEXT_CHROME):
+            try:
+                self._driver.execute_script(
+                    """
+                    window.__felt_reload_marker = arguments[0];
+                    window.location.reload();
+                    """,
+                    [marker],
+                )
+            except Exception:
+                pass
+
+            def new_page_loaded(_):
+                try:
+                    current = self._driver.execute_script(
+                        "return window.__felt_reload_marker;"
+                    )
+                    if current == marker:
+                        return False
+                    return (
+                        self._driver.execute_script("return document.readyState")
+                        == "complete"
+                    )
+                except Exception:
+                    return False
+
+            self._wait.until(new_page_loaded)
+
     def run_felt_chrome_on_email_submit(self):
         self.submit_email()
 

--- a/testing/enterprise/felt_tests.py
+++ b/testing/enterprise/felt_tests.py
@@ -143,16 +143,18 @@ class ConsoleHttpHandler(LocalHttpRequestHandler):
         auth = self.headers.get("Authorization")
         if not auth:
             self.reply("", 401, "Authorization required")
-            return
+            return False
 
         bearer = auth.split(" ")
         if len(bearer) != 2 or bearer[0].lower() != "bearer":
             self.reply("", 401, "Authorization required")
-            return
+            return False
 
         if bearer[1] != self.server.policy_access_token.value:
             self.reply("", 401, "Authorization required")
-            return
+            return False
+
+        return True
 
     def do_GET(self):
         print("GET", self.path)
@@ -200,7 +202,8 @@ class ConsoleHttpHandler(LocalHttpRequestHandler):
             })
 
         elif path == "/api/browser/policies":
-            self.check_auth()
+            if not self.check_auth():
+                return
             if self.server.policies_fail_request.value:
                 self.reply("", 500, "Internal Server Error", "application/json")
                 return
@@ -230,7 +233,8 @@ class ConsoleHttpHandler(LocalHttpRequestHandler):
             contentType = "application/json"
 
         elif path == "/api/browser/whoami":
-            self.check_auth()
+            if not self.check_auth():
+                return
 
             m = json.dumps({
                 "id": str(uuid.uuid4()),
@@ -428,7 +432,8 @@ class ConsoleHttpHandler(LocalHttpRequestHandler):
             m = json.dumps({"posture": self.server.device_posture_token})
 
         elif path == "/sso/logout":
-            self.check_auth()
+            if not self.check_auth():
+                return
             with self.server.signout_count.get_lock():
                 self.server.signout_count.value += 1
             self.server.policy_access_token.value = ""

--- a/testing/enterprise/felt_tests.py
+++ b/testing/enterprise/felt_tests.py
@@ -23,6 +23,8 @@ from base_test import EnterpriseTestsBase
 from felt_consts import firefox_config
 from marionette_driver import expected
 from marionette_driver.by import By
+from marionette_driver.geckoinstance import DesktopInstance, GeckoInstance
+from mozprofile.prefs import Preferences
 
 
 class SharedString:
@@ -696,6 +698,7 @@ class FeltTestsBase(EnterpriseTestsBase):
             name="enterprise-tests-browser"
         )
         self._logger.info(f"Using browser profile at {self._child_profile_path}")
+        self._apply_marionette_and_local_prefs_to_child_profile()
 
         # Pref does not like passing '\' ?
         if sys.platform == "win32":
@@ -736,6 +739,22 @@ class FeltTestsBase(EnterpriseTestsBase):
         if hasattr(self, "_child_profile_path"):
             self._logger.info(f"Removing browser profile at {self._child_profile_path}")
             shutil.rmtree(self._child_profile_path, ignore_errors=True)
+
+    def _apply_marionette_and_local_prefs_to_child_profile(self):
+        prefs = {
+            k: v
+            for k, v in {
+                **GeckoInstance.required_prefs,
+                **DesktopInstance.desktop_prefs,
+            }.items()
+            # Drop prefs with %-style format placeholders (e.g. "%(server)s")
+            # as they require interpolation that isn't performed here.
+            if not isinstance(v, str) or "%" not in v
+        }
+        prefs.update({"enterprise.is_testing": True, "enterprise.log_level": "Debug"})
+        if hasattr(self, "EXTRA_CHILD_PREFS"):
+            prefs.update(self.EXTRA_CHILD_PREFS)
+        Preferences.write(os.path.join(self._child_profile_path, "user.js"), prefs)
 
     def set_string_pref(self, pref_name, pref_value):
         self._logger.info(f"Setting {pref_name} to {pref_value}")

--- a/testing/enterprise/felt_tests.py
+++ b/testing/enterprise/felt_tests.py
@@ -626,6 +626,7 @@ class FeltTestsBase(EnterpriseTestsBase):
         self._extra_prefs = {
             "enterprise.console.address": f"http://localhost:{self.console_port}",
             "enterprise.is_testing": True,
+            "enterprise.log_level": "Debug",
         }  # + test_prefs
 
         if hasattr(self, "EXTRA_PREFS"):

--- a/testing/enterprise/felt_updater_errors.py
+++ b/testing/enterprise/felt_updater_errors.py
@@ -32,13 +32,14 @@ class FeltUpdaterErrorsBase(FeltTests):
             const callback = arguments[arguments.length - 1];
             const UM = Cc["@mozilla.org/updates/update-manager;1"].getService(Ci.nsIUpdateManager);
             UM.internal.reload(false).then(() => {
-              const { Updates } = ChromeUtils.importESModule("resource:///modules/enterprise/Updates.sys.mjs");
+              const { Updates } = ChromeUtils.importESModule("resource:///modules/enterprise/Updates.sys.mjs");
               Updates.uninit();
-              window.location.reload();
-            }).finally(() => callback());
+              callback();
+            });
             """
         )
         self._driver.set_context("content")
+        super().reload_chrome_window()
 
     def get_updates_served(self):
         return requests.get(

--- a/testing/enterprise/manifest.toml
+++ b/testing/enterprise/manifest.toml
@@ -70,6 +70,8 @@ run-if = [
 
 ["test_felt_email_input_focus.py"]
 
+["test_felt_harness_prefs.py"]
+
 ["test_felt_version.py"]
 
 ["test_firefox_start.py"]

--- a/testing/enterprise/test_felt_browser_console_error.py
+++ b/testing/enterprise/test_felt_browser_console_error.py
@@ -8,7 +8,7 @@ import sys
 
 sys.path.append(os.path.dirname(__file__))
 
-from felt_tests import FeltTestsBase
+from felt_tests import FeltTestsBase, find_free_port
 
 
 class FeltConsoleError(FeltTestsBase):
@@ -76,7 +76,7 @@ class FeltConsoleError(FeltTestsBase):
 
     def test_felt_error_details_include_console_address(self):
         # connectionFailure with host substitution so the console address appears in details.
-        refused_port = self.console_port + 20000
+        refused_port = find_free_port()
         console_addr = f"http://localhost:{refused_port}"
         return self.check_error_bar_message(
             console_addr,

--- a/testing/enterprise/test_felt_browser_crash_restart.py
+++ b/testing/enterprise/test_felt_browser_crash_restart.py
@@ -25,13 +25,4 @@ class BrowserCrashRestart(BrowserCrashes):
         self.run_felt_proper_restart_again()
 
     def run_felt_proper_restart_again(self):
-        self._manually_closed_child = False
-        self.wait_process_exit(self._browser_pid)
-        self._logger.info("Connecting to new browser")
-        self.connect_child_browser()
-        self._browser_pid = self._child_driver.session_capabilities["moz:processID"]
-        self._logger.info(f"Connected to {self._browser_pid}")
-        self.open_tab_child("about:support")
-
-        version_box = self.get_elem_child("#version-box")
-        self._child_wait.until(lambda d: len(version_box.text) > 0)
+        self.run_felt_proper_restart()

--- a/testing/enterprise/test_felt_browser_fxa.py
+++ b/testing/enterprise/test_felt_browser_fxa.py
@@ -12,10 +12,6 @@ from felt_tests import FeltTests
 
 
 class BrowserFxAccount(FeltTests):
-    EXTRA_PREFS = {
-        "enterprise.loglevel": "Debug",
-    }
-
     def test_browser_fxa(self):
         super().run_felt_base()
         self.run_felt_no_fxa_toolbar_button()

--- a/testing/enterprise/test_felt_browser_restart_is_quit.py
+++ b/testing/enterprise/test_felt_browser_restart_is_quit.py
@@ -47,6 +47,10 @@ class BrowserRestartIsQuit(FeltTests):
             self._logger.info("Received expected UnknownException")
         except NoSuchWindowException:
             self._logger.info("Received expected NoSuchWindowException")
+        except OSError:
+            self._logger.info(
+                "Firefox quit before execute_script returned, Marionette socket was closed"
+            )
         finally:
             self._logger.info(
                 f"Issued restartecting quit underway, checking PID {self._browser_pid}"

--- a/testing/enterprise/test_felt_browser_restart_works.py
+++ b/testing/enterprise/test_felt_browser_restart_works.py
@@ -37,6 +37,10 @@ class BrowserRestartWorks(FeltTests):
             self._logger.info("Received expected UnknownException")
         except NoSuchWindowException:
             self._logger.info("Received expected NoSuchWindowException")
+        except OSError:
+            self._logger.info(
+                "Firefox quit before execute_script returned, no data received over Marionette socket"
+            )
         finally:
             self._logger.info(
                 f"Issued restartecting quit underway, checking PID {self._browser_pid}"

--- a/testing/enterprise/test_felt_browser_shutdown_crash_exit.py
+++ b/testing/enterprise/test_felt_browser_shutdown_crash_exit.py
@@ -55,7 +55,7 @@ class BrowserShutdownCrash(FeltStartsBrowser):
         self.wait_process_exit(browser_pid)
         try:
             self._logger.info("Trying to connect to new browser")
-            self.connect_child_browser()
+            self.connect_child_browser(max_try=40)
             new_browser_pid = self._child_driver.session_capabilities["moz:processID"]
             assert browser_pid != new_browser_pid, (
                 f"PID should not be the same: {browser_pid} != {new_browser_pid}"

--- a/testing/enterprise/test_felt_browser_signout.py
+++ b/testing/enterprise/test_felt_browser_signout.py
@@ -12,6 +12,7 @@ sys.path.append(os.path.dirname(__file__))
 from base_test import Environment
 from felt_tests import FeltTests
 from marionette_driver.errors import (
+    NoAlertPresentException,
     UnexpectedAlertOpen,
 )
 
@@ -33,14 +34,7 @@ class BaseBrowserSignout(FeltTests):
         self._driver.set_context("content")
         return private_cookies
 
-    def run_perform_signout(self):
-        self.connect_child_browser(
-            capabilities={
-                # Do not auto-handle prompts.
-                "unhandledPromptBehavior": "ignore"
-            }
-        )
-
+    def _do_signout(self):
         self.assert_user_signed_in(env=Environment.FIREFOX)
         # Cache email for later use in prefilled email input field assertion
         user = self.get_logged_in_user_info(env=Environment.FIREFOX)
@@ -66,14 +60,18 @@ class BaseBrowserSignout(FeltTests):
             pass
 
         self._logger.info("Waiting for the signout dialog to open")
-        alert = self._child_driver.switch_to_alert()
-        # Wait(self._child_driver, 5).until(alert)
 
-        self._logger.info(
-            "Signing out the user by clicking the Signout button in the dialog"
-        )
-        # This target the primary action, which is clicking the Signout button
-        alert.accept()
+        def wait_for_and_accept_alert(driver):
+            try:
+                driver.switch_to_alert().accept()
+                self._logger.info(
+                    "Signing out the user by clicking the Signout button in the dialog"
+                )
+                return True
+            except NoAlertPresentException:
+                return False
+
+        self._waiter(self._child_driver).until(wait_for_and_accept_alert)
 
         self._child_driver.set_context("content")
 
@@ -96,6 +94,15 @@ class BaseBrowserSignout(FeltTests):
         # Verify no cookies from the previous sign in session
         cookies = self.get_private_cookies()
         assert len(cookies) == 0, f"No private cookies, found {len(cookies)}"
+
+    def run_perform_signout(self):
+        self.connect_child_browser(
+            capabilities={
+                # Do not auto-handle prompts.
+                "unhandledPromptBehavior": "ignore"
+            }
+        )
+        self._do_signout()
 
     def run_prefilled_email_submit(self):
         self._driver.set_context("chrome")

--- a/testing/enterprise/test_felt_browser_signout_on_exit.py
+++ b/testing/enterprise/test_felt_browser_signout_on_exit.py
@@ -50,5 +50,10 @@ class BrowserSignoutOnExit(FeltTests):
             Services.startup.quit(Ci.nsIAppStartup.eForceQuit);
             """,
         )
-        driver.set_context("content")
+        try:
+            driver.set_context("content")
+        except OSError:
+            self._logger.info(
+                "Firefox quit before set_context returned, no data received over Marionette socket"
+            )
         self._manually_closed_child = True

--- a/testing/enterprise/test_felt_browser_token_refresh.py
+++ b/testing/enterprise/test_felt_browser_token_refresh.py
@@ -41,7 +41,16 @@ class BrowserTokenRefresh(FeltTests):
         with self.felt_logout_checker.assert_browser_logouts_with(
             "console-forced-logout"
         ):
-            self.get_logged_in_user_info(env=Environment.FIREFOX)
+            self._child_driver.set_context("chrome")
+            # Run synchronously without awaiting the promise — the only purpose is
+            # to trigger a 401/403 response which causes the browser to shut down.
+            self._child_driver.execute_script("""
+                const { ConsoleClient } = ChromeUtils.importESModule(
+                    "resource:///modules/enterprise/ConsoleClient.sys.mjs"
+                );
+                ConsoleClient.getLoggedInUserInfo();
+            """)
+
         self._manually_closed_child = True
         self.assert_child_browser_closed()
 

--- a/testing/enterprise/test_felt_browser_updates_apply.py
+++ b/testing/enterprise/test_felt_browser_updates_apply.py
@@ -47,15 +47,6 @@ class FeltUpdatesApplyFromFelt(FeltTests):
         self._driver.set_context("content")
         return rv
 
-    def reload_chrome_window(self):
-        self._driver.set_context("chrome")
-        self._driver.execute_script(
-            """
-            window.location.reload();
-            """
-        )
-        self._driver.set_context("content")
-
     def test_felt_updates_apply_from_felt(self):
         self._update_root = os.path.dirname(self.get_update_config_file_path())
 

--- a/testing/enterprise/test_felt_browser_updates_errors.py
+++ b/testing/enterprise/test_felt_browser_updates_errors.py
@@ -33,7 +33,7 @@ class FeltUpdatesErrorHandling(FeltTests):
             if (document.readyState === "complete") {
                 done();
             } else {
-                window.addEventListener("load", done, { once: true });
+                window.addEventListener("load", () => done(), { once: true });
             }
             """
         )

--- a/testing/enterprise/test_felt_browser_updates_errors.py
+++ b/testing/enterprise/test_felt_browser_updates_errors.py
@@ -17,28 +17,6 @@ class FeltUpdatesErrorHandling(FeltTests):
         "enterprise.felt_tests.read_update_url_from_prefs": True,
     }
 
-    def reload_chrome_window(self):
-        self._driver.set_context("chrome")
-        self._driver.execute_script(
-            """
-            window.location.reload();
-            """
-        )
-        # Ensure document is ready when we finish this. Making reload in the same
-        # script does not work well, document gets unloaded and Marionette is
-        # unhappy.
-        self._driver.execute_async_script(
-            """
-            let done = arguments[0];
-            if (document.readyState === "complete") {
-                done();
-            } else {
-                window.addEventListener("load", () => done(), { once: true });
-            }
-            """
-        )
-        self._driver.set_context("content")
-
     def trigger_appUpdater_error(self, error):
         self._driver.set_context("chrome")
         self._driver.execute_script(

--- a/testing/enterprise/test_felt_harness_prefs.py
+++ b/testing/enterprise/test_felt_harness_prefs.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import os
+import sys
+
+sys.path.append(os.path.dirname(__file__))
+
+from marionette_driver.geckoinstance import DesktopInstance, GeckoInstance
+from test_felt_browser_signout import BaseBrowserSignout
+
+
+class HarnessPrefs(BaseBrowserSignout):
+    EXTRA_PREFS = {
+        "enterprise.felt_tests.harness_sets_pref": True,
+    }
+    EXTRA_CHILD_PREFS = {
+        "enterprise.felt_tests.harness_sets_child_pref": True,
+    }
+
+    def _check_prefs(self, driver, expected_prefs, label):
+        failures = []
+        for pref_name, expected_value in expected_prefs.items():
+            actual = driver.get_pref(pref_name)
+            if actual != expected_value:
+                failures.append(
+                    f"  {pref_name}: expected {expected_value!r}, got {actual!r}"
+                )
+        assert not failures, f"[{label}] Pref mismatches:\n" + "\n".join(failures)
+
+    def _check_env(self, expected, excluded):
+        failures = []
+        with self._driver.using_context("chrome"):
+            for key, value in expected.items():
+                actual = self._driver.execute_script(
+                    """
+                    const env = Cc["@mozilla.org/process/environment;1"].getService(Ci.nsIEnvironment);
+                    return env.get(arguments[0]);
+                    """,
+                    script_args=[key],
+                )
+                if actual != value:
+                    failures.append(f"  {key}: expected {value!r}, got {actual!r}")
+            for key in excluded:
+                exists = self._driver.execute_script(
+                    """
+                    const env = Cc["@mozilla.org/process/environment;1"].getService(Ci.nsIEnvironment);
+                    return env.exists(arguments[0]);
+                    """,
+                    script_args=[key],
+                )
+                if exists:
+                    failures.append(f"  {key}: expected absent in Firefox process")
+        assert not failures, "Env mismatches:\n" + "\n".join(failures)
+
+    def run_check_felt_prefs(self):
+        self._check_prefs(self._driver, self._extra_prefs, "FELT UI")
+        self._check_env(
+            getattr(self, "EXTRA_ENV", {}),
+            getattr(self, "EXCLUDED_ENV", set()),
+        )
+
+    def run_check_child_prefs(self):
+        # EnterpriseEndpoints.init() sets and locks these prefs on the default branch,
+        # pointing them at the enterprise console. Mirror RELATIVE_CONSOLE_ENDPOINT_PREFS
+        # and BASE_CONSOLE_URI_PREFS from EnterpriseEndpoints.sys.mjs.
+        base = f"http://localhost:{self.console_port}/"
+        enterprise_prefs = {
+            "identity.fxaccounts.remote.oauth.uri": f"{base}api/fxa/oauth/v1",
+            "identity.fxaccounts.remote.profile.uri": f"{base}api/fxa/profile/v1",
+            "identity.fxaccounts.auth.uri": f"{base}api/fxa/api/v1",
+            "security.certerrors.mitm.priming.endpoint": f"{base}api/misc/mitm/",
+            "captivedetect.canonicalURL": f"{base}api/misc/portal/canonical.html",
+            "network.connectivity-service.IPv4.url": f"{base}api/misc/connectivity?ipv4",
+            "network.connectivity-service.IPv6.url": f"{base}api/misc/connectivity?ipv6",
+            "browser.ipProtection.guardian.endpoint": base,
+            "identity.fxaccounts.remote.root": base,
+        }
+
+        gecko_prefs = {
+            k: v
+            for k, v in GeckoInstance.required_prefs.items()
+            # Drop prefs with %-style format placeholders (e.g. "%(server)s")
+            # as they require interpolation that isn't performed here.
+            if (not isinstance(v, str) or "%" not in v) and k not in enterprise_prefs
+        }
+        child_prefs = {
+            **gecko_prefs,
+            **DesktopInstance.desktop_prefs,
+            **enterprise_prefs,
+            # services.settings.server is set to "" by FELT via FeltProcessParent,
+            # which forwards remote_settings_url from the console Firefox configuration.
+            "services.settings.server": "",
+            "enterprise.is_testing": True,
+            **self.EXTRA_CHILD_PREFS,
+        }
+        self._check_prefs(self._child_driver, child_prefs, "child browser")
+
+
+class HarnessPrefsTest(HarnessPrefs):
+    # Verifies that prefs and environment variables set by the harness are
+    # correctly propagated to both the FELT UI browser and the child browser.
+    # Three sequential tests each inject a distinct environment variable so
+    # that the "no_leakage" tests can also assert that env vars from earlier
+    # test runs are absent, catching any cross-test contamination.
+    _ENV_BY_TEST = {
+        "test_1_harness_prefs": {"ENTERPRISE_HARNESS_TEST_1": "first"},
+        "test_2_harness_prefs_no_leakage": {"ENTERPRISE_HARNESS_TEST_2": "second"},
+        "test_3_harness_prefs_no_leakage": {"ENTERPRISE_HARNESS_TEST_3": "third"},
+    }
+
+    def setUp(self):
+        # Inject the env var for this test and exclude all env vars from other
+        # tests, so run_check_felt_prefs can assert presence and absence.
+        self.EXTRA_ENV = self._ENV_BY_TEST.get(self._testMethodName, {})
+        self.EXCLUDED_ENV = {
+            key
+            for test_name, env in self._ENV_BY_TEST.items()
+            if test_name != self._testMethodName
+            for key in env
+        }
+        super().setUp()
+
+    def _run(self):
+        self.run_felt_chrome_on_email_submit()
+        self.run_check_felt_prefs()
+        self.run_wait_until_sso_loaded()
+        self.run_felt_perform_sso_auth()
+        self.connect_child_browser(capabilities={"unhandledPromptBehavior": "ignore"})
+        self.run_check_child_prefs()
+        self._do_signout()
+
+    def test_1_harness_prefs(self):
+        self._run()
+
+    def test_2_harness_prefs_no_leakage(self):
+        self._run()
+
+    def test_3_harness_prefs_no_leakage(self):
+        self._run()

--- a/testing/profiles/mochitest/user.js
+++ b/testing/profiles/mochitest/user.js
@@ -37,6 +37,10 @@ user_pref("places.history.floodingPrevention.enabled", false);
 // don't do that.
 user_pref("geo.prompt.open_system_prefs", false);
 
-// Set a dummy push server URL for mochitest runs. In enterprise builds the
+// Set a push server URL for mochitest runs. In enterprise builds the
 // default is an empty string, but push tests need a non-empty value.
 user_pref("dom.push.serverURL", "wss://push.services.mozilla.com/");
+
+// Set a breakpad URL for mochitest runs. In enterprise builds the
+// default is an empty string, but push tests need a non-empty value.
+user_pref("breakpad.reportURL", "https://crash-stats.mozilla.org/report/index/");

--- a/testing/profiles/mochitest/user.js
+++ b/testing/profiles/mochitest/user.js
@@ -36,3 +36,7 @@ user_pref("places.history.floodingPrevention.enabled", false);
 // permission, and we can open it and wait for the user to give permission, then
 // don't do that.
 user_pref("geo.prompt.open_system_prefs", false);
+
+// Set a dummy push server URL for mochitest runs. In enterprise builds the
+// default is an empty string, but push tests need a non-empty value.
+user_pref("dom.push.serverURL", "wss://push.services.mozilla.com/");

--- a/toolkit/components/ml/actors/MLEngineParent.sys.mjs
+++ b/toolkit/components/ml/actors/MLEngineParent.sys.mjs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import { XPCOMUtils } from "resource://gre/modules/XPCOMUtils.sys.mjs";
 import { MLTelemetry } from "chrome://global/content/ml/MLTelemetry.sys.mjs";
+import { AppConstants } from "resource://gre/modules/AppConstants.sys.mjs";
 
 /**
  * @import { MLEngineChild } from "./MLEngineChild.sys.mjs"
@@ -50,9 +51,10 @@ const RS_RUNTIME_COLLECTION = "ml-onnx-runtime";
 const RS_INFERENCE_OPTIONS_COLLECTION = "ml-inference-options";
 const RS_ALLOW_DENY_COLLECTION = "ml-model-allow-deny-list";
 const TERMINATE_TIMEOUT = 5000;
-const RS_FALLBACK_BASE_URL =
-  "https://firefox-settings-attachments.cdn.mozilla.net";
 
+const RS_FALLBACK_BASE_URL = AppConstants.MOZ_ENTERPRISE
+  ? ""
+  : "https://firefox-settings-attachments.cdn.mozilla.net/";
 const RUNTIME_ROOT_IN_OPFS = "mlRuntimeFiles";
 
 /**

--- a/toolkit/mozapps/extensions/test/xpcshell/test_amo_stats_telemetry.js
+++ b/toolkit/mozapps/extensions/test/xpcshell/test_amo_stats_telemetry.js
@@ -40,7 +40,10 @@ add_setup(async () => {
   // xpcshell test environment and so here we force enable the default theme
   // (which is installed by disabled) to let this test to run across all builds
   // included the DevEdition beta builds.
-  if (AppConstants.MOZ_DEV_EDITION) {
+  // Similarly in Firefox Enterprise the default theme is expected to be
+  // firefox-enterprise-light@mozilla.org, but it isn't loaded in the minimal
+  // xpcshell test environment.
+  if (AppConstants.MOZ_DEV_EDITION || AppConstants.MOZ_ENTERPRISE) {
     const defaultTheme = await AddonManager.getAddonByID(
       "default-theme@mozilla.org"
     );

--- a/toolkit/mozapps/extensions/test/xpcshell/test_webextension_theme.js
+++ b/toolkit/mozapps/extensions/test/xpcshell/test_webextension_theme.js
@@ -48,8 +48,8 @@ add_task(async function setup_to_default_browserish_state() {
 
   await promiseStartupManager();
 
-  if (AppConstants.MOZ_DEV_EDITION) {
-    // Developer Edition selects the wrong theme by default.
+  if (AppConstants.MOZ_DEV_EDITION || AppConstants.MOZ_ENTERPRISE) {
+    // Developer Edition and Firefox Enterprise select the wrong theme by default.
     let defaultTheme = await AddonManager.getAddonByID(DEFAULT_THEME);
     await defaultTheme.enable();
   }

--- a/toolkit/mozapps/update/updater/updater.cpp
+++ b/toolkit/mozapps/update/updater/updater.cpp
@@ -3023,7 +3023,7 @@ static int PopulategMARStrings() {
                NS_T("%s/update-settings.ini"), gInstallDirPath);
   rv = ReadMARChannelIDsFromPath(updateSettingsPath, &gMARStrings);
 #  endif
-  return rv;
+  return rv == OK ? OK : UPDATE_SETTINGS_FILE_CHANNEL;
 }
 #endif  // MOZ_VERIFY_MAR_SIGNATURE
 

--- a/tools/@types/subs/AppConstants.sys.d.mts
+++ b/tools/@types/subs/AppConstants.sys.d.mts
@@ -11,6 +11,8 @@ export const AppConstants: Readonly<{
   // defines: https://wiki.mozilla.org/Platform/Channel-specific_build_defines
   NIGHTLY_BUILD: boolean;
 
+  MOZ_ENTERPRISE: boolean;
+
   ENABLE_EXPLICIT_RESOURCE_MANAGEMENT: boolean;
 
   RELEASE_OR_BETA: boolean;

--- a/tools/tryselect/push.py
+++ b/tools/tryselect/push.py
@@ -53,7 +53,7 @@ MAX_HISTORY = 10
 MACH_TRY_PUSH_TO_VCS = os.getenv("MACH_TRY_PUSH_TO_VCS") == "1"
 
 HG_TRY_URL = "ssh://hg.mozilla.org/try"
-MACH_TRY_REMOTE = HG_TRY_URL
+MACH_TRY_REMOTE = "git@github.com:mozilla/enterprise-firefox-try.git"
 
 TREEHERDER_LANDO_TRY_RUN_URL = (
     "https://treeherder.mozilla.org/jobs?repo=try&landoCommitID={job_id}"


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

NO BUG - Uplift recent fixes to `enterprise-release` for 150 release

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

### Included
d26806c7f1e9 Bug-2032516:  Fix crash when extracting filename from forward-slash paths on Windows (#741) r=lissyx
8e6c06bf3c57 Bug-2031236: fix double HTTP response when check_auth fails in mock console (#738) r=lissyx
c042a8f36d07 Bug-2031236: ensure child browser has harness prefs set before launch (#722) r=lissyx
e6be18755dc3 Bug-2032093 - Re-enable eslint rule no-console in browser/extensions/felt (#736)
9a3fd5b6eaad Bug-2032016 - Control enterprise log level via preference enterprise.logLevel (#733)
487158c278c9 Bug-2031933 - Fix lint regression on GitHub PR template
b4e77777fab2 Bug-2031742 - Set expected default theme in test when running in Enterprise
6e2c2173cbd8 Bug-2030392: handle exception if browser closes faster than marionette request (#718)
b20c03b01441 Bug-2030397: Do not use port 10080 for mock console as it is blocked by firefox (#719)
c7f384297c20 Bug-2028592: Use only enterprise on browser.toml (firefox not defined)(#658) r=jmendez
b2c066fd1c17 Bug-2031252: fix reload_chrome_window race condition with page marker (#721)
b02939a4a855 Bug-2013821, Bug-2013823 - Set expected default theme in test when running in Enterprise
eea7b4942cac NO BUG - Add PR template (#713)
143df683ce15 Bug-2031238:  Use about:buildconfig for restart checks and reduce connect_child_browser wait (#720)
15140a6d22ba Bug-2026130:  Add isEnterpriseManagedPrimaryPassword to LoginHelper mock in browser_primaryPassword test (#715)
8ad7bae3daf8 fix: set release_type parameter on enteprise-firefox-try
75d5dc702f2b fix: set default parameters according to enterprise
18fa12423c8d Bug-2030628: Do not put private properties in win + remove async from cmds (#701)
b75e0414a1ed Bug-2012442 - Basic signout prompt UX plus signout on exit
181674f1ed61 Revert "Bug-2028602 - Enterprise: ensure macOS reads MAR channel IDs correctly"
b863510303eb Bug-2030649: Fix BASE_CONSOLE_URI_PREFS test assertion to compare normalized URL (#703)
74dd8aad6262 Bug-2030737 - Simulate user signed out of enterprise account
ed07f36795a5 Bug-2030603: restore breakpad.reportURL for mochitests (#699)
f1803e33aa50 Bug-2030373: add alias for felt for static css checks browser_parsable_css.js (#694)
213e60e29881 Bug-2030065 - Clear RS_FALLBACK_BASE_URL (#686)
3825a769c221 Bug-2030258: Prevent css serialize issue by not passing event to done (#691)
10d314d5d4a5 Bug-2028565: Use overflows to make the test pass on html:link (#657)
e8c0742b4526 Bug-2006564: Put app as active on startup(macos) and focus email on windows focus (#687) r=lissyx
71be19d37320 Bug-2021009 - [ci] Include 'enterprise-firefox-try' in additional transform logic
cd416fdf44bf Bug-2021009 - [ci] Declare build secrets in enterprise-firefox-try as well
c0b3d2c9d454 Set dom.push.serverURL on test setup (#604)
a9ddc477333d Bug-2028563: Give expected schema on policy testutils when empty policies (#654)
a80337b9ab19 Bug-2029685 - Avoid removing random blocked about pages if desired unblocked page is not currently blocked
dc03c1a25837 Bug-2027104 - Fix more live policy application issues
0c6b19bddd0c Bug-2029233 - Add missing items of expected format for distribution.ini
f8a64f91b93a Cleanup unused FXA path entries in ConsoleClient (#663)
24447cb4a3ee Bug-2027104 - Enterprise: Fix Policies application
1bea131a5d29 Bug-2021009 - Add target_tasks and release_product params for enterprise-firefox-try
ecf4dc9d6193 Bug-2021009 - Setup proper Treeherder routes for enterprise-firefox-try tasks
a03fe6c8a3ea Bug-2021009 - Run tasks on all 'enterprise-firefox-try' branches
115d9154353a Bug-2021009 - Set MACH_TRY_REMOTE to mozilla/enteprise-firefox-try
79e70319b753 Bug-2021009 - [ci] Ensure graph generation can succeed without `release_product` or `release_partner_config`
b28e926b221f Bug-2021009 - [ci] Cleanup some repackage transform logic
1750a3291cb7 Bug-2012458 - Policies for AI Chat Sidebar (#623)

## Skipped for now

[Wait for #740] 4de545993012 Bug-2029205 - Enterprise: remove default enterprise.console.address value and rely only on distribution.ini

## Not included

[151] 99f45d110fc4 Fix changes from bug 1950203 on enterprise-main merge
[151] cd4f0b18e595 Fix merge conflict mistake
[will lint as needed] 77593990170c Fix lint
[will lint as needed] 080b53226256 Lint browser/components/ipprotection/content/ipprotection-content.mjs
[151] 6297434c61ac Add cateogry, description and examples for policy XSLTEnabled (#692)
[will lint as needed] ccc56c3822e3 Lint repackage_partner.py
[will lint as needed] 0d3058604ad4 Lint policies-schema.json
[already fixed in release via conflict resolution] fa76d3752eea Bug-2021009 - [ci] Remove 'gecko' hardcode in win11 25h2 pools
[151] 22f4b9954810 Bug-2021009 - [try] Ensure we push to enterprise-firefox-try by default
[151] a963c7ec8679 Fix indirect merge conflict
[151] f2586d2af794 Fix syntax in merge conflict resolution
[151] ba669adcb26e Bug-2028749 - Enterprise: unblock bootstrap
[151] 16d1c2ac812e Fix build: Add AppConstants import to IPPFxaAuthProvider.sys.mjs
[151] 4f771b1ffd53 Add pull_request_number to taskcluster docs
[151] aa97c0b8e602 Bug-2027836 - [ci] Add 'pull_request_number' to graph config schema, r?#taskgraph-reviewers
[151] 6a1363967985 Bug-2021009 - Enterprise: allow overriding 'mach try' push remote via env
[will lint as needed] 2dfd3cd70204 Fix lint
[151] e35e4d67b15b Fix treeherder_group definition
[conflict not present in release] 1494cc82a9b4 Fix merge conflict leftover
[151] 76bfbd08beab Bug-2026142 - Enterprise: avoid duplicated 'checks' routes

