### PR TITLE
Bug 2033414 - Enterprise: add update channel in profile name

### DIFF
--- a/browser/extensions/felt/content/FeltCommon.sys.mjs
+++ b/browser/extensions/felt/content/FeltCommon.sys.mjs
@@ -2,8 +2,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { AppConstants } from "resource://gre/modules/AppConstants.sys.mjs";
+
 export const FeltCommon = {
   PRIVATE_BROWSING_ID: 1,
-  ENTERPRISE_PROFILE: "enterprise-profile",
+  ENTERPRISE_PROFILE: `enterprise-profile-${AppConstants.MOZ_UPDATE_CHANNEL}`,
   POLICY_POLLING_FREQUENCY: 60_000,
 };

--- a/browser/extensions/felt/content/FeltProcessParent.sys.mjs
+++ b/browser/extensions/felt/content/FeltProcessParent.sys.mjs
@@ -596,18 +596,6 @@ export class FeltProcessParent extends JSProcessActorParent {
         }
       }
 
-      /* Remove once we finished foxfooding */
-      if (!foundProfile) {
-        let legacyProfileName = lazy.FeltCommon.ENTERPRISE_PROFILE;
-        for (let profile of profileService.profiles) {
-          if (profile.name === legacyProfileName) {
-            foundProfile = profile;
-            lazy.log.warn("using legacy profile");
-            break;
-          }
-        }
-      }
-
       if (!foundProfile) {
         lazy.log.debug(`FeltExtension: creating new ${profileName} profile`);
         foundProfile = profileService.createProfile(null, profileName);

--- a/toolkit/xre/nsAppRunner.cpp
+++ b/toolkit/xre/nsAppRunner.cpp
@@ -3150,11 +3150,11 @@ static nsresult SelectProfile(nsToolkitProfileService* aProfileSvc,
     const char* xreProfileLocalPath = PR_GetEnv("XRE_PROFILE_LOCAL_PATH");
     auto savedLocalProfile = xreProfileLocalPath && *xreProfileLocalPath;
 
-    // When running as FELT UI use a hardcoded profile named "felt" and living
-    // in the OS' temporary directory. There are a few special cases where it is
-    // required to use a profile that is being given from different means:
-    //  - CLI argument "-profile ..."
-    //  - environment variables "XRE_PROFILE_PATH" / "XRE_PROFILE_LOCAL_PATH"
+    // When running as FELT UI use a hardcoded profile named "felt-XXX" with
+    // XXX being the update channel and living in the OS' temporary directory.
+    // There are a few special cases where it is required to use a profile that
+    // is being given from different means: - CLI argument "-profile ..." -
+    // environment variables "XRE_PROFILE_PATH" / "XRE_PROFILE_LOCAL_PATH"
     //
     // If either of those are present, the following code is skipped and profile
     // selection continues. This accounts for manually setting the profile,
@@ -3164,7 +3164,7 @@ static nsresult SelectProfile(nsToolkitProfileService* aProfileSvc,
       nsCOMPtr<nsIFile> file;
       MOZ_TRY(GetSpecialSystemDirectory(OS_TemporaryDirectory,
                                         getter_AddRefs(file)));
-      MOZ_TRY(file->AppendNative("felt"_ns));
+      MOZ_TRY(file->AppendNative("felt-"_ns MOZ_STRINGIFY(MOZ_UPDATE_CHANNEL)));
 
       bool exists = false;
       MOZ_TRY(file->Exists(&exists));


### PR DESCRIPTION
Add the update channel to the name of the profile being used both for Felt and for browser, to avoid running into "profile downgrade" errors.

### Description <!-- REQUIRED -->

Bugzilla: Bug-2033414

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Testing <!-- OPTIONAL -->

* [ ] Added tests
* [ ] Manual testing performed

**Steps to verify changes:**
1. Download/build
2. Run felt
3. Connect and launch browser

**Expected result:**
1. (before step 3) Felt profile path (in your temporary directory) should be created including the update channel, e.g. `felt-nightly-enterprise`)
2. (after step 3) Browser to `about:support` and verify that the profile path includes the same update channel key
