### PR TITLE
Bug 2032092 - Enterprise: persist pending URLs to disk

### DIFF
--- a/browser/components/FeltURLHandler.sys.mjs
+++ b/browser/components/FeltURLHandler.sys.mjs
@@ -14,6 +14,10 @@ ChromeUtils.defineLazyGetter(
     )
 );
 
+ChromeUtils.defineESModuleGetters(lazy, {
+  JSONFile: "resource://gre/modules/JSONFile.sys.mjs",
+});
+
 export const FELT_OPEN_WINDOW_DISPOSITION = {
   DEFAULT: 0,
   NEW_WINDOW: 1,
@@ -23,7 +27,78 @@ export const FELT_OPEN_WINDOW_DISPOSITION = {
 // Queue for Felt external link handling
 // URL requests are stored here when they arrive via command line (before Felt extension loads)
 // FeltProcessParent imports this module and manages forwarding from this queue
-export let gFeltPendingURLs = [];
+export const gFeltPendingURLs = {
+  _pendingURLs: [],
+  _pendingFilePath: PathUtils.join(
+    Services.dirsvc.get("ProfD", Ci.nsIFile).path,
+    "pendingURLs.json"
+  ),
+  _ready: false,
+  _initPromise: null,
+
+  async init() {
+    if (this._ready) {
+      return;
+    }
+
+    if (this._initPromise) {
+      await this._initPromise;
+      return;
+    }
+
+    this._initPromise = (async () => {
+      if (this._ready) {
+        return;
+      }
+
+      const storage = new lazy.JSONFile({
+        path: this._pendingFilePath,
+      });
+
+      await storage.load();
+
+      if (storage.data?.pendingURLs) {
+        this._pendingURLs = storage.data.pendingURLs;
+      }
+
+      this._storage = storage;
+      this._ready = true;
+    })();
+    try {
+      await this._initPromise;
+    } finally {
+      this._initPromise = null;
+    }
+  },
+
+  [Symbol.iterator]() {
+    return this._pendingURLs[Symbol.iterator]();
+  },
+
+  async push(payload) {
+    await this.init();
+    const rv = this._pendingURLs.push(payload);
+    this._storage.data.pendingURLs = this._pendingURLs;
+    this._storage.saveSoon();
+    return rv;
+  },
+
+  get length() {
+    return this._pendingURLs.length;
+  },
+
+  clear() {
+    this._pendingURLs = [];
+    this._storage.data.pendingURLs = [];
+    this._storage.saveSoon();
+  },
+};
+
+if (Services.felt?.isFeltUI()) {
+  gFeltPendingURLs.init().catch(error => {
+    console.error(`Failed to initialize Felt pending URL storage: ${error}`);
+  });
+}
 
 let lastNotificationShown = 0;
 let gFeltFirefoxReadyNotified = false;
@@ -82,7 +157,9 @@ export function queueFeltURL(payload) {
       `Retrying to queue url ${payload.url} after initial failure:`,
       e
     );
-    gFeltPendingURLs.push(payload);
+    gFeltPendingURLs.push(payload).catch(err => {
+      console.error("Failed to persist pending Felt URL", err);
+    });
     Services.cpmm.sendAsyncMessage("FeltParent:ForceFeltFocus", {});
   }
 

--- a/browser/extensions/felt/content/FeltProcessParent.sys.mjs
+++ b/browser/extensions/felt/content/FeltProcessParent.sys.mjs
@@ -43,7 +43,9 @@ export function queueURL(payload) {
     Services.felt.makeBackgroundProcess(true);
   } else {
     // Queue at module level until ready
-    gFeltPendingURLs.push(payload);
+    gFeltPendingURLs.push(payload).catch(err => {
+      lazy.log.error("Failed to persist pending Felt URL", err);
+    });
     Services.cpmm.sendAsyncMessage("FeltParent:ForceFeltFocus", {});
   }
 }
@@ -238,7 +240,9 @@ export class FeltProcessParent extends JSProcessActorParent {
           case "felt-extension-ready": {
             if (gFeltProcessParentInstance) {
               gFeltProcessParentInstance.extensionReady = true;
-              gFeltProcessParentInstance.forwardPendingURLs();
+              gFeltProcessParentInstance.forwardPendingURLs().catch(err => {
+                lazy.log.error("Failed to forward pending URLs", err);
+              });
               notifyFirefoxReady();
             }
             break;
@@ -478,7 +482,7 @@ export class FeltProcessParent extends JSProcessActorParent {
         this.firefoxReady = true;
 
         // Try to forward pending URLs now (will only forward if extension is also ready)
-        this.forwardPendingURLs();
+        await this.forwardPendingURLs();
         notifyFirefoxReady();
       })
       .then(() => {
@@ -686,7 +690,9 @@ export class FeltProcessParent extends JSProcessActorParent {
   /**
    * Forward all pending URLs to Firefox
    */
-  forwardPendingURLs() {
+  async forwardPendingURLs() {
+    await gFeltPendingURLs.init();
+
     if (gFeltPendingURLs.length === 0) {
       return;
     }
@@ -717,7 +723,7 @@ export class FeltProcessParent extends JSProcessActorParent {
     }
 
     // Clear the queue
-    gFeltPendingURLs.length = 0;
+    gFeltPendingURLs.clear();
   }
 
   /**

--- a/security/sandbox/test/browser_content_sandbox_fs_tests.js
+++ b/security/sandbox/test/browser_content_sandbox_fs_tests.js
@@ -117,6 +117,32 @@ async function testFileAccessAllPlatforms() {
     });
   }
 
+  if (AppConstants.MOZ_ENTERPRISE) {
+    const uAppDataDir = GetUserAppDataDir();
+    const feltJson = uAppDataDir.clone();
+    feltJson.append("felt.json");
+    await IOUtils.writeUTF8(feltJson.path, "{}");
+    tests.push({
+      desc: "felt storage", // description
+      ok: false, // expected to succeed?
+      browser: webBrowser, // browser to run test in
+      file: feltJson, // nsIFile object
+      minLevel: minProfileReadSandboxLevel(), // min level to enable test
+      func: readFile,
+    });
+
+    const feltPendingURLs = GetProfileEntry("pendingURLs.json");
+    await IOUtils.writeUTF8(feltPendingURLs.path, "{}");
+    tests.push({
+      desc: "felt pending urls", // description
+      ok: false, // expected to succeed?
+      browser: webBrowser, // browser to run test in
+      file: feltPendingURLs, // nsIFile object
+      minLevel: minProfileReadSandboxLevel(), // min level to enable test
+      func: readFile,
+    });
+  }
+
   let homeDir = GetHomeDir();
   tests.push({
     desc: "home dir",

--- a/security/sandbox/test/browser_content_sandbox_utils.js
+++ b/security/sandbox/test/browser_content_sandbox_utils.js
@@ -349,6 +349,12 @@ function GetProfileDir() {
   return profileDir;
 }
 
+function GetUserAppDataDir() {
+  // get userAppData directory
+  let userAppDataDir = Services.dirsvc.get("UAppData", Ci.nsIFile);
+  return userAppDataDir;
+}
+
 function GetHomeDir() {
   // get home directory
   let homeDir = Services.dirsvc.get("Home", Ci.nsIFile);

--- a/testing/enterprise/test_felt_browser_external_link.py
+++ b/testing/enterprise/test_felt_browser_external_link.py
@@ -3,6 +3,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import json
 import os
 import subprocess
 import sys
@@ -15,7 +16,7 @@ from felt_tests import FeltTests
 
 class FeltStartsBrowserExternalLink(FeltTests):
     def test_browser_external_link(self):
-        super().run_felt_base()
+        self.run_felt_base()
         self._external_link = f"http://localhost:{self.console_port}/ping"
         self.run_felt_browser_started()
         self.run_felt_open_external_link()
@@ -23,7 +24,16 @@ class FeltStartsBrowserExternalLink(FeltTests):
     def run_felt_browser_started(self):
         self.connect_child_browser()
 
-    def run_felt_open_external_link(self):
+    def third_party_open_external_link(self):
+        args = [
+            f"{self._driver.instance.binary}",
+            "-profile",
+            self._driver.profile,
+            self._external_link,
+        ]
+        subprocess.check_call(args, shell=False)
+
+    def check_no_external_link_tab(self):
         tabs = self._child_driver.window_handles
         self._logger.info(f"Tabs before opening external link: {tabs}")
 
@@ -36,16 +46,11 @@ class FeltStartsBrowserExternalLink(FeltTests):
                 break
 
         assert not has_tab, f"Should not have {self._external_link} opened"
+        return tabs
 
-        args = [
-            f"{self._driver.instance.binary}",
-            "-profile",
-            self._driver.profile,
-            self._external_link,
-        ]
-        subprocess.check_call(args, shell=False)
-
-        self._child_wait.until(lambda mn: len(mn.window_handles) > len(tabs))
+    def check_has_external_link_tab(self, tabs=None):
+        if tabs is not None:
+            self._child_wait.until(lambda mn: len(mn.window_handles) > len(tabs))
 
         has_new_tab = False
         loops = 0
@@ -62,3 +67,99 @@ class FeltStartsBrowserExternalLink(FeltTests):
             time.sleep(0.5)
 
         assert has_new_tab, f"Should have {self._external_link} opened"
+
+    def run_felt_open_external_link(self):
+        tabs = self.check_no_external_link_tab()
+        self.third_party_open_external_link()
+        self.check_has_external_link_tab(tabs)
+
+    def run_open_about_pages(self):
+        self._external_link = "about:buildconfig"
+        self.check_has_external_link_tab()
+        self._external_link = "about:logo"
+        self.check_has_external_link_tab()
+
+    def test_browser_pending_external_link(self):
+        self._external_link = "about:welcome"
+        urls_file = os.path.join(self._driver.profile, "pendingURLs.json")
+
+        assert not os.path.exists(urls_file), (
+            f"Pending URLs file should not exist: {urls_file}"
+        )
+        self.third_party_open_external_link()
+
+        self._logger.info(f"Waiting for pending URLs file to be populated: {urls_file}")
+        self._wait.until(lambda mn: os.path.exists(urls_file))
+
+        with open(urls_file) as pending:
+            parsed = json.loads(pending.read())
+            assert len(parsed["pendingURLs"]) == 1, (
+                "There should be only one pending URL"
+            )
+            parsed_url = parsed["pendingURLs"][0]["url"]
+            assert parsed_url == self._external_link, (
+                f"Pending URL should be '{self._external_link}', found '{parsed_url}'"
+            )
+
+        self._driver.set_pref("enterprise.felt_tests.is_blocking_shutdown", True)
+        self.run_felt_base()
+        self.run_felt_browser_started()
+        self.check_has_external_link_tab()
+
+        self._logger.info(f"Waiting for pending URLs file to be cleared: {urls_file}")
+
+        def has_no_pending_url(file):
+            with open(file) as pending:
+                parsed = json.loads(pending.read())
+                return len(parsed["pendingURLs"]) == 0
+
+        self._wait.until(lambda mn: has_no_pending_url(urls_file))
+        self._logger.info(f"Pending URLs cleared from {urls_file}!")
+
+        browser_pid = self._child_driver.session_capabilities["moz:processID"]
+        self._child_driver.set_context("chrome")
+        self._child_driver.execute_script(
+            """
+            Services.startup.quit(Ci.nsIAppStartup.eForceQuit)
+            """
+        )
+        self._manually_closed_child = False
+        self.wait_process_exit(browser_pid)
+
+        self._logger.info("Closing Felt")
+        self._driver.quit(in_app=True, clean=False)
+
+        # Write new content to the file, close the browser, wait for FELT and re-do everything
+        with open(urls_file, "w") as pending:
+            pending.write(
+                json.dumps({
+                    "pendingURLs": [
+                        {
+                            "url": "about:buildconfig",
+                            "disposition": 0,
+                        },
+                        {
+                            "url": "about:logo",
+                            "disposition": 0,
+                        },
+                    ]
+                })
+            )
+        self._logger.info(f"New pending URLs file: {urls_file}")
+
+        self._driver.start_session(timeout=60)
+        new_urls_file = os.path.join(self._driver.profile, "pendingURLs.json")
+        assert os.path.exists(new_urls_file), (
+            f"Pending URLs file should exists: {new_urls_file}"
+        )
+
+        self._driver.set_context("chrome")
+        self._driver.execute_script(
+            """
+            console.debug(`Felt: Test: started new FELT`);
+            """
+        )
+
+        self.run_felt_base()
+        self.run_felt_browser_started()
+        self.run_open_about_pages()


### PR DESCRIPTION
If Felt is being restarted without authentication being completed (e.g. updates being applied), then the pending URLs that may have opened it are going to be lost on next restart. This change ensures those are persisted on disk and reloaded.

### Description <!-- REQUIRED -->

Bugzilla: Bug-2032092

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->


### Testing <!-- OPTIONAL -->

* [x] Added tests