### PR TITLE
Bug 2032400: Reduce number of restarted processes

### DIFF
--- a/testing/enterprise/base_test.py
+++ b/testing/enterprise/base_test.py
@@ -18,6 +18,27 @@ from marionette_driver.wait import Wait
 from marionette_harness import MarionetteTestCase
 
 
+def patch_process_runner_args(instance):
+    # It looks like on windows we are hitting bug 1906191, even after
+    # all processes exit, the pipe write end may not close, causing mozprocess's
+    # reader thread to block indefinitely on readline(). ignore_children makes
+    # mozprocess skip joining the reader thread, allowing shutdown to proceed.
+    original = instance._get_runner_args
+
+    def _patched():
+        args = original()
+        # ignore_children is only supported by mozprocess (not the macOS psutil-based handler)
+        if not sys.platform.startswith("darwin"):
+            args["process_args"]["ignore_children"] = True
+        return args
+
+    def unpatch():
+        instance._get_runner_args = original
+
+    instance._get_runner_args = _patched
+    return unpatch
+
+
 class Environment(Enum):
     FELT = "felt"
     FIREFOX = "Firefox"
@@ -27,29 +48,38 @@ class EnterpriseTestsBase(MarionetteTestCase):
     def setUp(self):
         os.environ.update({"MOZ_DISABLE_NONLOCAL_CONNECTIONS": "0"})
 
-        if hasattr(self, "EXTRA_ENV"):
+        if getattr(self, "EXTRA_ENV", None):
             self._saved_env = deepcopy(os.environ)
             os.environ.update(self.EXTRA_ENV)
 
         self._logger = self.logger
 
-        super().setUp()
+        marionette = self._marionette_weakref()
+
+        if hasattr(self, "_extra_cli_args"):
+            self._saved_cli_args = deepcopy(marionette.instance.app_args)
+            marionette.instance.app_args += self._extra_cli_args
+
+        self._unpatch_process_runner_args = patch_process_runner_args(
+            marionette.instance
+        )
+
+        # On the first test the harness has Firefox already running, so we stop
+        # it here. On subsequent tests tearDown already quit it, so this
+        # will only discard and recreate the profile.
+        marionette.instance.close(clean=True)
+
+        if hasattr(self, "_apply_prefs_for_instance"):
+            self._apply_prefs_for_instance()
 
         # All this needs to happen before process is started to avoid race
         # conditions, but requires self.marionette that is setup by
         # super().setUp() right above.
-        self.overwrite_distribution_ini()
+        self.overwrite_distribution_ini(marionette)
 
-        if hasattr(self, "_extra_cli_args"):
-            self._saved_cli_args = deepcopy(self.marionette.instance.app_args)
-            self.marionette.instance.app_args += self._extra_cli_args
+        super().setUp()
 
-        self._logger.info("Marionette force quit with cleanup.")
-        self.marionette.quit(in_app=False, clean=True)
-        self._logger.info("Marionette start new session, new instance expected.")
-        self.marionette.start_session(timeout=60)
-
-        if hasattr(self, "_extra_prefs"):
+        if getattr(self, "_extra_prefs", None):
             self._logger.info("Marionette enforcing gecko prefs")
             self.marionette.enforce_gecko_prefs(self._extra_prefs)
 
@@ -73,6 +103,8 @@ class EnterpriseTestsBase(MarionetteTestCase):
             self.marionette.instance.app_args = deepcopy(self._saved_cli_args)
             del self._saved_cli_args
 
+        self._unpatch_process_runner_args()
+
         # If there were prefs forced during setUp(), marionette's geckoinstance
         # does cache them and on the next execution of enforce_gecko_pref(), if
         # those prefs are not there anymore in self._extra_prefs, marionette code
@@ -87,12 +119,12 @@ class EnterpriseTestsBase(MarionetteTestCase):
 
         self.restore_distribution_ini()
 
-    def overwrite_distribution_ini(self):
+    def overwrite_distribution_ini(self, marionette):
         # Some test may need a non modified distribution.ini, so respect it and
         # and do not overwrite it when requested.
         # Also some tests may not define a console port, so skip this for them.
         if hasattr(self, "console_port") and not hasattr(self, "KEEP_DISTRIBUTION_INI"):
-            self.distribution_ini_path = self.get_distribution_ini(self.marionette)
+            self.distribution_ini_path = self.get_distribution_ini(marionette)
             self.distribution_ini_orig_path = os.path.join(
                 os.path.dirname(self.distribution_ini_path), "distribution.ini.orig"
             )

--- a/testing/enterprise/felt_tests.py
+++ b/testing/enterprise/felt_tests.py
@@ -630,14 +630,6 @@ class FeltTestsBase(EnterpriseTestsBase):
         self.device_posture_reply_forbidden = Value("B", 0)
         """
 
-        self._extra_prefs = {
-            "enterprise.is_testing": True,
-            "enterprise.log_level": "Debug",
-        }  # + test_prefs
-
-        if hasattr(self, "EXTRA_PREFS"):
-            self._extra_prefs.update(self.EXTRA_PREFS)
-
         self.policy_access_token = SharedString("")
         self.policy_refresh_token = SharedString("")
         self.signout_count = Value("i", 0)
@@ -684,6 +676,18 @@ class FeltTestsBase(EnterpriseTestsBase):
         self._logger.info(f"Starting console server: {self.console_port}")
         self._logger.info(f"Starting SSO server: {self.sso_port}")
 
+    def _apply_prefs_for_instance(self):
+        self._extra_prefs = {
+            "enterprise.is_testing": True,
+            "enterprise.log_level": "Debug",
+        }  # + test_prefs
+
+        if hasattr(self, "EXTRA_PREFS"):
+            self._extra_prefs.update(self.EXTRA_PREFS)
+
+        marionette = self._marionette_weakref()
+        marionette.instance.profile.set_preferences(self._extra_prefs)
+
     def setup(self):
         console_addr = f"http://localhost:{self.console_port}"
 
@@ -722,9 +726,11 @@ class FeltTestsBase(EnterpriseTestsBase):
         if not self._manually_closed_child:
             self._logger.info("Closing browser")
             self._child_driver.set_context("chrome")
+            pid = self._child_driver.session_capabilities["moz:processID"]
             self._child_driver.execute_script(
                 "Services.startup.quit(Ci.nsIAppStartup.eForceQuit);"
             )
+            self.wait_process_exit(pid)
             self._logger.info("Closed browser")
         else:
             self._logger.info("Browser was already manually closed.")

--- a/testing/enterprise/test_felt_browser_signout_verify.py
+++ b/testing/enterprise/test_felt_browser_signout_verify.py
@@ -19,4 +19,4 @@ class BrowserSignoutVerify(BaseBrowserSignout):
             self.run_prefilled_email_submit()
             self.run_load_sso()
             self.run_perform_sso_auth()
-        self._manually_closed_child = True
+        self.run_perform_signout()

--- a/testing/enterprise/test_felt_harness_prefs.py
+++ b/testing/enterprise/test_felt_harness_prefs.py
@@ -13,12 +13,30 @@ from test_felt_browser_signout import BaseBrowserSignout
 
 
 class HarnessPrefs(BaseBrowserSignout):
-    EXTRA_PREFS = {
-        "enterprise.felt_tests.harness_sets_pref": True,
-    }
-    EXTRA_CHILD_PREFS = {
-        "enterprise.felt_tests.harness_sets_child_pref": True,
-    }
+    # Marionette runs each test_* method through its own setUp()/tearDown()
+    # cycle, which starts a new session each time. We count session starts to
+    # verify sequential execution (e.g., test_4 expects exactly 4 starts).
+    # Subclasses that need cumulative restart tracking must define
+    # start_session_count = 0 to get their own independent counter.
+    start_session_count = 0
+
+    def setUp(self):
+        marionette = self._marionette_weakref()
+        self._original_start_session = marionette.start_session
+
+        def counting_start_session(*args, **kwargs):
+            type(self).start_session_count += 1
+            return self._original_start_session(*args, **kwargs)
+
+        marionette.start_session = counting_start_session
+
+        super().setUp()
+
+        self._manually_closed_child = True
+
+    def tearDown(self):
+        super().tearDown()
+        self.marionette.start_session = self._original_start_session
 
     def _check_prefs(self, driver, expected_prefs, label):
         failures = []
@@ -52,17 +70,20 @@ class HarnessPrefs(BaseBrowserSignout):
                     script_args=[key],
                 )
                 if exists:
-                    failures.append(f"  {key}: expected absent in Firefox process")
+                    failures.append(f"  {key}: expected absent in FELT process")
         assert not failures, "Env mismatches:\n" + "\n".join(failures)
 
-    def run_check_felt_prefs(self):
-        self._check_prefs(self._driver, self._extra_prefs, "FELT UI")
-        self._check_env(
-            getattr(self, "EXTRA_ENV", {}),
-            getattr(self, "EXCLUDED_ENV", set()),
+    def _check_prefs_absent(self, driver, excluded_prefs, label):
+        failures = []
+        for pref_name in excluded_prefs:
+            actual = driver.get_pref(pref_name)
+            if actual is not None:
+                failures.append(f"  {pref_name}: expected absent, got {actual!r}")
+        assert not failures, f"[{label}] Prefs should be absent:\n" + "\n".join(
+            failures
         )
 
-    def run_check_child_prefs(self):
+    def _build_common_prefs(self):
         # EnterpriseEndpoints.init() sets and locks these prefs on the default branch,
         # pointing them at the enterprise console. Mirror RELATIVE_CONSOLE_ENDPOINT_PREFS
         # and BASE_CONSOLE_URI_PREFS from EnterpriseEndpoints.sys.mjs.
@@ -77,66 +98,211 @@ class HarnessPrefs(BaseBrowserSignout):
             "network.connectivity-service.IPv6.url": f"{base}api/misc/connectivity?ipv6",
             "browser.ipProtection.guardian.endpoint": base,
             "identity.fxaccounts.remote.root": base,
+            "enterprise.is_testing": True,
+            "enterprise.log_level": "Debug",
         }
-
         gecko_prefs = {
             k: v
-            for k, v in GeckoInstance.required_prefs.items()
+            for k, v in {
+                **GeckoInstance.required_prefs,
+                **DesktopInstance.desktop_prefs,
+            }.items()
             # Drop prefs with %-style format placeholders (e.g. "%(server)s")
             # as they require interpolation that isn't performed here.
             if (not isinstance(v, str) or "%" not in v) and k not in enterprise_prefs
         }
+        return enterprise_prefs, gecko_prefs
+
+    def run_check_felt_set_prefs_absent_prefs_and_env(self):
+        enterprise_prefs, gecko_prefs = self._build_common_prefs()
+        felt_prefs = {
+            **gecko_prefs,
+            **enterprise_prefs,
+            **self._extra_prefs,
+        }
+        self._check_prefs(self._driver, felt_prefs, "FELT UI")
+        self._check_prefs_absent(
+            self._driver, getattr(self, "EXCLUDED_PREFS", set()), "FELT UI"
+        )
+        self._check_env(
+            getattr(self, "EXTRA_ENV", {}),
+            getattr(self, "EXCLUDED_ENV", set()),
+        )
+
+    def run_check_child_prefs(self):
+        enterprise_prefs, gecko_prefs = self._build_common_prefs()
         child_prefs = {
             **gecko_prefs,
-            **DesktopInstance.desktop_prefs,
             **enterprise_prefs,
             # services.settings.server is set to "" by FELT via FeltProcessParent,
             # which forwards remote_settings_url from the console Firefox configuration.
             "services.settings.server": "",
-            "enterprise.is_testing": True,
             **self.EXTRA_CHILD_PREFS,
         }
         self._check_prefs(self._child_driver, child_prefs, "child browser")
 
 
-class HarnessPrefsTest(HarnessPrefs):
-    # Verifies that prefs and environment variables set by the harness are
-    # correctly propagated to both the FELT UI browser and the child browser.
-    # Three sequential tests each inject a distinct environment variable so
-    # that the "no_leakage" tests can also assert that env vars from earlier
-    # test runs are absent, catching any cross-test contamination.
-    _ENV_BY_TEST = {
-        "test_1_harness_prefs": {"ENTERPRISE_HARNESS_TEST_1": "first"},
-        "test_2_harness_prefs_no_leakage": {"ENTERPRISE_HARNESS_TEST_2": "second"},
-        "test_3_harness_prefs_no_leakage": {"ENTERPRISE_HARNESS_TEST_3": "third"},
-    }
+class HarnessPrefsFirstTestNoCliArgsTest(HarnessPrefs):
+    # Verifies that when the first test has no EXTRA_ENV and no _extra_cli_args,
+    # only one start_session happens (ideally it should be 0, but unavoidable).
+    EXTRA_ENV = {}
+    EXTRA_PREFS = {}
+    start_session_count = 0
+
+    def test_no_extra_env_no_restart(self):
+        assert HarnessPrefsFirstTestNoCliArgsTest.start_session_count == 1, (
+            f"Expected 1 session starts, got {HarnessPrefsFirstTestNoCliArgsTest.start_session_count}"
+        )
+
+
+class HarnessPrefsNoEnvSubsequentTest(HarnessPrefs):
+    # Verifies that subsequent tests without EXTRA_ENV cost 1 start_session calls each.
+    EXTRA_ENV = {}
+    EXTRA_PREFS = {}
+    start_session_count = 0
+
+    def test_1_no_env(self):
+        assert HarnessPrefsNoEnvSubsequentTest.start_session_count == 1, (
+            f"Expected 1 session starts, got {HarnessPrefsNoEnvSubsequentTest.start_session_count}"
+        )
+
+    def test_2_no_env(self):
+        assert HarnessPrefsNoEnvSubsequentTest.start_session_count == 2, (
+            f"Expected 2 session starts, got {HarnessPrefsNoEnvSubsequentTest.start_session_count}"
+        )
+
+
+class HarnessPrefsFirstTestWithCliArgsTest(HarnessPrefs):
+    # Verifies that a truthy _extra_cli_args triggers only 1 session start per test
+    EXTRA_ENV = {}
+    EXTRA_PREFS = {}
+    start_session_count = 0
 
     def setUp(self):
-        # Inject the env var for this test and exclude all env vars from other
-        # tests, so run_check_felt_prefs can assert presence and absence.
-        self.EXTRA_ENV = self._ENV_BY_TEST.get(self._testMethodName, {})
-        self.EXCLUDED_ENV = {
+        self._extra_cli_args = ["--test"]
+        super().setUp()
+
+    def test_cli_args_triggers_restart(self):
+        assert HarnessPrefsFirstTestWithCliArgsTest.start_session_count == 1, (
+            f"Expected 1 session start, got {HarnessPrefsFirstTestWithCliArgsTest.start_session_count}"
+        )
+
+
+class HarnessPrefsTest(HarnessPrefs):
+    EXTRA_ENV = {
+        "MOZ_ENTERPRISE_HARNESS_ENV_TEST": "1",
+    }
+    EXTRA_PREFS = {
+        "enterprise.felt_tests.harness_sets_pref": True,
+    }
+    EXTRA_CHILD_PREFS = {
+        "enterprise.felt_tests.harness_sets_child_pref": True,
+    }
+
+    # Verifies that prefs and environment variables set by the harness are
+    # correctly propagated to both the FELT UI browser and the child browser.
+    # Four sequential tests each inject a distinct environment variable so
+    # that the "no_leakage" tests can also assert that env vars from earlier
+    # test runs are absent, catching any cross-test contamination.
+    # harness_sets_pref_value uses the same pref name across all tests but a
+    # different value each time, verifying that same-name prefs don't leak.
+    _ENV_BY_TEST = {
+        "test_1_harness_prefs": {
+            "ENTERPRISE_HARNESS_TEST_1": "first",
+            "ENTERPRISE_HARNESS_TEST_VALUE": "first",
+        },
+        "test_2_harness_prefs_no_leakage": {
+            "ENTERPRISE_HARNESS_TEST_2": "second",
+            "ENTERPRISE_HARNESS_TEST_VALUE": "second",
+        },
+        "test_3_harness_prefs_no_leakage": {
+            "ENTERPRISE_HARNESS_TEST_3": "third",
+            "ENTERPRISE_HARNESS_TEST_VALUE": "third",
+        },
+        "test_4_harness_prefs_no_leakage": {
+            "ENTERPRISE_HARNESS_TEST_4": "fourth",
+            "ENTERPRISE_HARNESS_TEST_VALUE": "fourth",
+        },
+    }
+    _PREFS_BY_TEST = {
+        "test_1_harness_prefs": {
+            "enterprise.felt_tests.harness_sets_pref_1": True,
+            "enterprise.felt_tests.harness_sets_pref_value": 1,
+        },
+        "test_2_harness_prefs_no_leakage": {
+            "enterprise.felt_tests.harness_sets_pref_2": True,
+            "enterprise.felt_tests.harness_sets_pref_value": 2,
+        },
+        "test_3_harness_prefs_no_leakage": {
+            "enterprise.felt_tests.harness_sets_pref_3": True,
+            "enterprise.felt_tests.harness_sets_pref_value": 3,
+        },
+        "test_4_harness_prefs_no_leakage": {
+            "enterprise.felt_tests.harness_sets_pref_4": True,
+            "enterprise.felt_tests.harness_sets_pref_value": 4,
+        },
+    }
+
+    start_session_count = 0
+
+    @staticmethod
+    def _merge_and_exclude(base, by_test, test_name):
+        merged = {**base, **by_test.get(test_name, {})}
+        excluded = {
             key
-            for test_name, env in self._ENV_BY_TEST.items()
-            if test_name != self._testMethodName
-            for key in env
+            for name, items in by_test.items()
+            if name != test_name
+            for key in items
+            if key not in merged
         }
+        return merged, excluded
+
+    def setUp(self):
+        self.EXTRA_ENV, self.EXCLUDED_ENV = self._merge_and_exclude(
+            HarnessPrefsTest.EXTRA_ENV, self._ENV_BY_TEST, self._testMethodName
+        )
+        self.EXTRA_PREFS, self.EXCLUDED_PREFS = self._merge_and_exclude(
+            HarnessPrefsTest.EXTRA_PREFS, self._PREFS_BY_TEST, self._testMethodName
+        )
+
+        assert not (self.EXTRA_ENV.keys() & self.EXCLUDED_ENV)
+        assert not (self.EXTRA_PREFS.keys() & self.EXCLUDED_PREFS)
+
         super().setUp()
 
     def _run(self):
         self.run_felt_chrome_on_email_submit()
-        self.run_check_felt_prefs()
+        self.run_check_felt_set_prefs_absent_prefs_and_env()
         self.run_wait_until_sso_loaded()
         self.run_felt_perform_sso_auth()
         self.connect_child_browser(capabilities={"unhandledPromptBehavior": "ignore"})
         self.run_check_child_prefs()
         self._do_signout()
 
+    # Each test triggers a setUp()/tearDown() cycle, incrementing
+    # start_session_count by one. The cumulative count confirms that
+    # tests run in order and each gets exactly one new session.
+
     def test_1_harness_prefs(self):
         self._run()
+        assert HarnessPrefsTest.start_session_count == 1, (
+            f"Expected 1 session start, got {HarnessPrefsTest.start_session_count}"
+        )
 
     def test_2_harness_prefs_no_leakage(self):
         self._run()
+        assert HarnessPrefsTest.start_session_count == 2, (
+            f"Expected 2 session starts, got {HarnessPrefsTest.start_session_count}"
+        )
 
     def test_3_harness_prefs_no_leakage(self):
         self._run()
+        assert HarnessPrefsTest.start_session_count == 3, (
+            f"Expected 3 session starts, got {HarnessPrefsTest.start_session_count}"
+        )
+
+    def test_4_harness_prefs_no_leakage(self):
+        self._run()
+        assert HarnessPrefsTest.start_session_count == 4, (
+            f"Expected 4 session starts, got {HarnessPrefsTest.start_session_count}"
+        )


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [x] Ensure the linked Bugzilla item is up to date
- [x] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2032400



The goal of the PR is to improve the start/stop sequence firefox is having on marionette, current sequence is as follows


**General marionette starts =>**

- firefox starts on harness ([link](https://searchfox.org/enterprise-main/rev/8411df1e6f57ed9261bae54ebcfc96cf8a3986fb/testing/marionette/client/marionette_driver/marionette.py#636))
  - test 1 starts
      - we close firefox                                                                                                                                                                                
      - we start firefox
      - we enforce prefs (can also restart firefox)                                                                                                                                                     
  - test 1 finished                                                                                                                                                                                   
      - we close firefox                                                                                                                                                                                
  - test 2 starts 
      - firefox is started by harness
      - we close firefox
      - we start firefox
      - we enforce prefs (can also restart firefox)                                                                                                                                                     
  - test 2 finished
      - we close firefox

After this PR:


**General marionette starts =>**
  - firefox starts on harness ([link](https://searchfox.org/enterprise-main/rev/8411df1e6f57ed9261bae54ebcfc96cf8a3986fb/testing/marionette/client/marionette_driver/marionette.py#636))
  - test 1 starts                                                                                                                                                                                       
      - we close firefox                                                                                                                                                     
      - we enforce prefs (can also restart firefox, but should never really happen)                                                                                                                                              
  - test 1 finished                                                                                                                                                                                     
      - we close firefox                                                                                                                                                                                
  - test 2 starts                                                                                                                                                                                       
      - we set prefs before harness starts firefox                                                                                                                                                      
      - firefox is started by harness                                                                                                                                                                   
      - we enforce prefs as security (should not restart)
  - test 2 finished                                                                                                                                                                                     
      - we close firefox

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on:

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

---

### Testing <!-- OPTIONAL -->

* [x] Added tests
* [x] Manual testing performed

<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
