### PR TITLE
Bug 2005746 - Add authenticode_comment to MSI repackage signing artifacts

### DIFF
--- a/taskcluster/docs/attributes.rst
+++ b/taskcluster/docs/attributes.rst
@@ -615,3 +615,10 @@ required_checks
 ===============
 
 Indicates that a task should report on GitHub Checks
+
+msi_display_name
+================
+
+The human-readable product name for the MSI installer (e.g. ``Firefox Nightly``,
+``Firefox Beta``, ``Firefox``). Used by downstream signing tasks to construct
+the Authenticode comment embedded in the installer signature.

--- a/taskcluster/gecko_taskgraph/transforms/repackage.py
+++ b/taskcluster/gecko_taskgraph/transforms/repackage.py
@@ -46,6 +46,13 @@ packaging_description_schema = LegacySchema({
     Required("package-formats"): optionally_keyed_by(
         "build-platform", "release-type", "build-type", [str]
     ),
+    Optional("msi"): {
+        Optional("display-name"): optionally_keyed_by(
+            "release-type",
+            "shipping-product",
+            str,
+        ),
+    },
     Optional("msix"): {
         Optional("channel"): optionally_keyed_by(
             "package-format",
@@ -412,6 +419,7 @@ def handle_keyed_by(config, jobs):
     """
     fields = [
         "mozharness.config",
+        "msi.display-name",
         "package-formats",
         "worker.max-run-time",
         "flatpak.name",
@@ -428,6 +436,7 @@ def handle_keyed_by(config, jobs):
                 **{
                     "release-type": config.params["release_type"],
                     "level": config.params["level"],
+                    "shipping-product": job.get("shipping-product"),
                 },
             )
         yield job
@@ -564,6 +573,8 @@ def make_job_description(config, jobs):
                 treeherder["symbol"] = f"MSI-Ent({repack_id})"
             else:
                 treeherder["symbol"] = "MSI({})".format(locale or "N")
+            if display_name := job.get("msi", {}).get("display-name"):
+                attributes["msi_display_name"] = display_name
 
         elif config.kind == "repackage-msix":
             assert not locale

--- a/taskcluster/gecko_taskgraph/transforms/repackage_signing.py
+++ b/taskcluster/gecko_taskgraph/transforms/repackage_signing.py
@@ -138,12 +138,20 @@ def make_repackage_signing_description(config, jobs):
         for artifact in sorted(dep_job.attributes.get("release_artifacts")):
             basename = os.path.basename(artifact)
             if basename in SIGNING_FORMATS:
-                upstream_artifacts.append({
+                artifact_entry = {
                     "taskId": {"task-reference": f"<{dep_kind}>"},
                     "taskType": "repackage",
                     "paths": [artifact],
-                    "formats": SIGNING_FORMATS[os.path.basename(artifact)],
-                })
+                    "formats": SIGNING_FORMATS[basename],
+                }
+                if basename == "target.installer.msi":
+                    msi_display_name = dep_job.attributes.get(
+                        "msi_display_name", "Firefox"
+                    )
+                    artifact_entry["authenticode_comment"] = (
+                        f"{msi_display_name} Installer"
+                    )
+                upstream_artifacts.append(artifact_entry)
 
         task = {
             "label": label,

--- a/taskcluster/kinds/repackage-msi/kind.yml
+++ b/taskcluster/kinds/repackage-msi/kind.yml
@@ -49,6 +49,7 @@ tasks:
             display-name:
                 by-shipping-product:
                     devedition: "Firefox Developer Edition"
+                    firefox-enterprise: "Firefox Enterprise"
                     default:
                         by-release-type:
                             beta.*: "Firefox Beta"

--- a/taskcluster/kinds/repackage-msi/kind.yml
+++ b/taskcluster/kinds/repackage-msi/kind.yml
@@ -45,6 +45,16 @@ tasks:
                         - repackage/base.py
                         - repackage/win64-aarch64_sfx_stub.py
                         - repackage/win64_signed.py
+        msi:
+            display-name:
+                by-shipping-product:
+                    devedition: "Firefox Developer Edition"
+                    default:
+                        by-release-type:
+                            beta.*: "Firefox Beta"
+                            release: "Firefox"
+                            esr.*: "Firefox"
+                            default: "Firefox Nightly"
         package-formats: [msi]
         fetches:
             fetch:


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

This PR mirrors the upstream change which adds a `msi.display-name` field on the `repackage-msi` task for handling the human-readable display name. This new field gets used by `repackage-signing` for constructing the `authenticode_comment` as "{display_name} Installer".

Bug-2005746

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* https://phabricator.services.mozilla.com/D293535
