### PR TITLE
Bug 2005746 - Add msi.display-name for Firefox Enterprise to repackage-msi task parameters

### DIFF
--- a/taskcluster/kinds/repackage-msi/kind.yml
+++ b/taskcluster/kinds/repackage-msi/kind.yml
@@ -49,6 +49,7 @@ tasks:
             display-name:
                 by-shipping-product:
                     devedition: "Firefox Developer Edition"
+                    firefox-enterprise: "Firefox Enterprise"
                     default:
                         by-release-type:
                             beta.*: "Firefox Beta"


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

This PR adds the enterprise key to the repackage-msi taskcluster task parameters for use in the repackage-signing step.

Bugzilla: Bug-2005746

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on: #752

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

<img width="450" alt="firefox-msi-uac-description" src="https://github.com/user-attachments/assets/b4d34811-2375-4709-bea9-d7e66e678028" />


_Before_

<img width="450" alt="msi-installer-fixed-description-2" src="https://github.com/user-attachments/assets/af0da746-b65f-4b3e-bd49-a47bd13c8bc2" />

_After (note: test run uses a fake CA)_

