### PR TITLE
Bug 1998394: Defer policy fetch failure shutdown to "profile-after-change"

### DIFF
--- a/testing/enterprise/test_felt_browser_init_failures.py
+++ b/testing/enterprise/test_felt_browser_init_failures.py
@@ -14,11 +14,12 @@ from felt_tests import FeltTests
 
 class BrowserInitFailures(FeltTests):
     def test_browser_init_policy_fetch_fail(self):
-        self.policies_fail_request.value = 1
-        super().run_felt_base()
         self._manually_closed_child = True
-
-        self.await_felt_auth_window()
-        self.policies_fail_request.value = 0
-        self.force_window()
-        self.assert_user_signed_out(env=Environment.FELT)
+        for _ in range(5):
+            self.policies_fail_request.value = 1
+            super().run_felt_base()
+            self.await_felt_auth_window()
+            self.policies_fail_request.value = 0
+            self.force_window()
+            self.assert_user_signed_out(env=Environment.FELT)
+            self.await_felt_auth_window()

--- a/toolkit/components/enterprisepolicies/EnterprisePoliciesParent.sys.mjs
+++ b/toolkit/components/enterprisepolicies/EnterprisePoliciesParent.sys.mjs
@@ -174,7 +174,7 @@ EnterprisePoliciesManager.prototype = {
     if (Services.felt?.isFeltBrowser() && remoteProvider.failed) {
       // bug 2027006 will move the fetching of policies to felt
       // and not shutdown will be needed then
-      await lazy.EnterpriseHandler.initiateShutdown();
+      this._shutdownOnFailureNeeded = true;
     }
     remoteProvider.onPoliciesChanges(handler);
 
@@ -452,6 +452,9 @@ EnterprisePoliciesManager.prototype = {
       }
       case "profile-after-change":
         this._runPoliciesCallbacks("onProfileAfterChange");
+        if (this._shutdownOnFailureNeeded) {
+          lazy.EnterpriseHandler.initiateShutdown().catch(console.error);
+        }
         break;
 
       case "final-ui-startup":


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-1998394

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on:

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

---

### Testing <!-- OPTIONAL -->

* [x] Added tests
* [x] Manual testing performed

Tried manually adding exception here
```
    try {
      throw new Error("ok")
      res = await lazy.ConsoleClient.getRemotePolicies();
    } catch (e) {
      console.error(`Failed to fetch remote policies on startup: ${e}`);
      this._failed = true;
      return;
    }

```

<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
