### PR TITLE
Bug 2033795: put locked properties on expected schema for enterprise

### DIFF
--- a/toolkit/modules/tests/browser/browser_Troubleshoot.js
+++ b/toolkit/modules/tests/browser/browser_Troubleshoot.js
@@ -489,6 +489,20 @@ const SNAPSHOT_SCHEMA = {
           required: false,
           type: "boolean",
         },
+        ...(AppConstants.MOZ_ENTERPRISE && {
+          "network.connectivity-service.IPv4.url": {
+            required: false,
+            type: "string",
+          },
+          "network.connectivity-service.IPv6.url": {
+            required: false,
+            type: "string",
+          },
+          "security.certerrors.mitm.priming.endpoint": {
+            required: false,
+            type: "string",
+          },
+        }),
       },
     },
     places: {


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2033795

The test uses Troubleshoot.snapshot() to check all information that goes on about:support, for the preferences it is failing as it is checking which ones we have locked, to fix this I just added to the schema our prefs

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on:

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

---

### Testing <!-- OPTIONAL -->

* [ ] Added tests
* [x] Manual testing performed

[here](https://treeherder.mozilla.org/logviewer?job_id=561472635&repo=enterprise-firefox-pr&task=RKNoLdv_RsexQM-TwcDNFw.0&lineNumber=76416) the test passes 
<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
