### PR TITLE
Bug 2012268: unlock toolkit.telemetry.server for crash test

### DIFF
--- a/toolkit/crashreporter/test/unit/test_crashreporter_crash.js
+++ b/toolkit/crashreporter/test/unit/test_crashreporter_crash.js
@@ -122,6 +122,15 @@ add_task(async function run_test() {
         "datareporting.healthreport.uploadEnabled",
         true
       );
+      const { AppConstants: AC } = ChromeUtils.importESModule(
+        "resource://gre/modules/AppConstants.sys.mjs"
+      );
+      if (
+        AC.MOZ_ENTERPRISE &&
+        Services.prefs.prefIsLocked("toolkit.telemetry.server")
+      ) {
+        Services.prefs.unlockPref("toolkit.telemetry.server");
+      }
       Services.prefs.setCharPref(
         "toolkit.telemetry.server",
         "http://a.telemetry.server"


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2012268

Test is currently failing with ```toolkit/crashreporter/test/unit/test_crashreporter_crash.js | run_test - [run_test : 168] The TelemetryServerURL field is present when the FHR is on - false == true```

We are unlocking pref "toolkit.telemetry.server" the test can work correctly

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on:

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

---

### Testing <!-- OPTIONAL -->

* [ ] Added tests
* [x] Manual testing performed

See [Link](https://firefox-ci-tc.services.mozilla.com/tasks/YW90LYXFS327OptbzahjdQ/runs/0/logs/public/logs/live.log#L6995) for test passing 

<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
