### PR TITLE
Bug 2033812 - Support enterprise-beta branch in Taskgraph

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -413,13 +413,13 @@ tasks:
                   in:
                       $if: >
                         eventType in ["action", "cron"]
-                        || (eventType == "push" && shortRef == "enterprise-main")
+                        || (eventType == "push" && shortRef in ["enterprise-main", "enterprise-beta", "enterprise-release"])
                         || (eventType == "push" && project == "enterprise-firefox-try")
                         || (isPullRequest && eventAction in ["opened", "reopened", "synchronize"])
                       then:
                           $let:
                               level:
-                                  $if: '(tasks_for == "action" || eventType in ["cron", "push"]) && repoUrl == "https://github.com/mozilla/enterprise-firefox" && shortRef == "enterprise-main"'
+                                  $if: '(tasks_for == "action" || eventType in ["cron", "push"]) && repoUrl == "https://github.com/mozilla/enterprise-firefox" && project == "enterprise-firefox"'
                                   then: 3
                                   else: 1
                           in:

--- a/taskcluster/config.yml
+++ b/taskcluster/config.yml
@@ -12,6 +12,7 @@ treeherder:
                 default: enterprise-firefox-try
             default:
                 enterprise-main: enterprise-main
+                enterprise-beta: enterprise-beta
                 enterprise-release: enterprise-release
     group-names:
         'js-bench-sm': 'JavaScript shell benchmarks with Spidermonkey'

--- a/taskcluster/gecko_taskgraph/parameters.py
+++ b/taskcluster/gecko_taskgraph/parameters.py
@@ -136,6 +136,8 @@ def get_release_type(parameters):
 
     if parameters["head_ref"] == "refs/heads/enterprise-release":
         return "release-enterprise"
+    elif parameters["head_ref"] == "refs/heads/enterprise-beta":
+        return "beta-enterprise"
     else:
         return "nightly-enterprise"
 

--- a/taskcluster/gecko_taskgraph/util/scriptworker.py
+++ b/taskcluster/gecko_taskgraph/util/scriptworker.py
@@ -75,6 +75,7 @@ SIGNING_SCOPE_ALIAS_TO_PROJECT = [
             "comm-esr115",
             "comm-esr128",
             "comm-esr140",
+            ("enterprise-firefox", "refs/heads/enterprise-beta"),
             ("enterprise-firefox", "refs/heads/enterprise-release"),
         },
     ],


### PR DESCRIPTION
### Description

Adds support for the enterprise-beta branch. Also refactors .taskcluster.yml so it doesn't need to carry differences across branches.

Bugzilla: Bug-2033812