### PR TITLE
Bug 2033859: unlock pref "identity.fxaccounts.remote.root" to prevent crash on test

### DIFF
--- a/browser/components/uitour/test/browser_UITour_sync.js
+++ b/browser/components/uitour/test/browser_UITour_sync.js
@@ -10,9 +10,18 @@ const MOCK_DEVICE_ID = "7e450f3337d3479b8582ea1c9bb5ba6c";
 
 const gFxaParams = `context=${Services.prefs.getStringPref("identity.fxaccounts.contextParam")}`;
 
+// In enterprise builds, EnterpriseEndpoints.sys.mjs locks this pref at startup.
+// Unlock it so the test can override it, and re-lock in cleanup.
+if (AppConstants.MOZ_ENTERPRISE) {
+  Services.prefs.unlockPref("identity.fxaccounts.remote.root");
+}
+
 registerCleanupFunction(function () {
   Services.prefs.clearUserPref("identity.fxaccounts.remote.root");
   Services.prefs.clearUserPref("services.sync.username");
+  if (AppConstants.MOZ_ENTERPRISE) {
+    Services.prefs.lockPref("identity.fxaccounts.remote.root");
+  }
 });
 
 add_task(setup_UITourTest);


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [x] Ensure the linked Bugzilla item is up to date
- [x] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2033859



The pref "identity.fxaccounts.remote.root" is locked in [enterpriseEndpoints](https://searchfox.org/enterprise-main/rev/b38a1b389382b925dd5983afd824ba6f1fca6529/browser/components/enterprise/EnterpriseEndpoints.sys.mjs#52), this makes the test fail cause they cannot setup their own pref


---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on:

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

---

### Testing <!-- OPTIONAL -->

* [ ] Added tests
* [x] Manual testing performed

[See crash](https://treeherder.mozilla.org/logviewer?job_id=561580081&repo=enterprise-firefox-pr&task=fItGAAKOQxmP8Tajb9GoUw.0&lineNumber=29401) (without the change)
[See test pass](https://treeherder.mozilla.org/logviewer?job_id=561502157&repo=enterprise-firefox-pr&task=b4-ehUQxSWi_oTZQ3Zv5-g.0&lineNumber=19313) (with the change)
<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
