### PR TITLE
Bug 2033812 - Common taskcluster setup for enterprise-beta

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -413,13 +413,13 @@ tasks:
                   in:
                       $if: >
                         eventType in ["action", "cron"]
-                        || (eventType == "push" && shortRef == "enterprise-main")
+                        || (eventType == "push" && shortRef in ["enterprise-release", "enterprise-beta"])
                         || (eventType == "push" && project == "enterprise-firefox-try")
                         || (isPullRequest && eventAction in ["opened", "reopened", "synchronize"])
                       then:
                           $let:
                               level:
-                                  $if: '(tasks_for == "action" || eventType in ["cron", "push"]) && repoUrl == "https://github.com/mozilla/enterprise-firefox" && shortRef == "enterprise-main"'
+                                  $if: '(tasks_for == "action" || eventType in ["cron", "push"]) && repoUrl == "https://github.com/mozilla/enterprise-firefox" && shortRef in ["enterprise-release", "enterprise-beta"]'
                                   then: 3
                                   else: 1
                           in:

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -413,13 +413,13 @@ tasks:
                   in:
                       $if: >
                         eventType in ["action", "cron"]
-                        || (eventType == "push" && shortRef in ["enterprise-release", "enterprise-beta"])
+                        || (eventType == "push" && shortRef in ["enterprise-main", "enterprise-beta", "enterprise-release"])
                         || (eventType == "push" && project == "enterprise-firefox-try")
                         || (isPullRequest && eventAction in ["opened", "reopened", "synchronize"])
                       then:
                           $let:
                               level:
-                                  $if: '(tasks_for == "action" || eventType in ["cron", "push"]) && repoUrl == "https://github.com/mozilla/enterprise-firefox" && shortRef in ["enterprise-release", "enterprise-beta"]'
+                                  $if: '(tasks_for == "action" || eventType in ["cron", "push"]) && repoUrl == "https://github.com/mozilla/enterprise-firefox" && project == "enterprise-firefox"'
                                   then: 3
                                   else: 1
                           in:

--- a/python/mozbuild/mozbuild/artifacts.py
+++ b/python/mozbuild/mozbuild/artifacts.py
@@ -118,7 +118,9 @@ class EnterpriseJobConfiguration:
     nightly_candidate_trees = [
         "enterprise-firefox.branch.enterprise-main",
     ]
-    beta_candidate_trees = []
+    beta_candidate_trees = [
+        "enterprise-firefox.branch.enterprise-beta",
+    ]
     # The list below list should be updated when we have new ESRs.
     esr_candidate_trees = []
     try_tree = "try"

--- a/python/mozbuild/mozbuild/repackaging/desktop_file.py
+++ b/python/mozbuild/mozbuild/repackaging/desktop_file.py
@@ -174,6 +174,8 @@ def _get_en_US_brand_fluent_filename(
         return branding_fluent_filename_template.format(brand="official")
     elif release_type == "nightly-enterprise":
         return branding_fluent_filename_template.format(brand="enterprise")
+    elif release_type == "beta-enterprise":
+        return branding_fluent_filename_template.format(brand="enterprise")
     elif release_type == "release-enterprise":
         return branding_fluent_filename_template.format(brand="enterprise")
     else:

--- a/taskcluster/config.yml
+++ b/taskcluster/config.yml
@@ -12,6 +12,7 @@ treeherder:
                 default: enterprise-firefox-try
             default:
                 enterprise-main: enterprise-main
+                enterprise-beta: enterprise-beta
                 enterprise-release: enterprise-release
     group-names:
         'js-bench-sm': 'JavaScript shell benchmarks with Spidermonkey'

--- a/taskcluster/gecko_taskgraph/parameters.py
+++ b/taskcluster/gecko_taskgraph/parameters.py
@@ -136,6 +136,8 @@ def get_release_type(parameters):
 
     if parameters["head_ref"] == "refs/heads/enterprise-release":
         return "release-enterprise"
+    elif parameters["head_ref"] == "refs/heads/enterprise-beta":
+        return "beta-enterprise"
     else:
         return "nightly-enterprise"
 

--- a/taskcluster/gecko_taskgraph/util/scriptworker.py
+++ b/taskcluster/gecko_taskgraph/util/scriptworker.py
@@ -75,6 +75,7 @@ SIGNING_SCOPE_ALIAS_TO_PROJECT = [
             "comm-esr115",
             "comm-esr128",
             "comm-esr140",
+            ("enterprise-firefox", "refs/heads/enterprise-beta"),
             ("enterprise-firefox", "refs/heads/enterprise-release"),
         },
     ],

--- a/taskcluster/kinds/build/kind.yml
+++ b/taskcluster/kinds/build/kind.yml
@@ -50,6 +50,7 @@ task-defaults:
                 # https://searchfox.org/mozilla-central/rev/ce9ff94ffed34dc17ec0bfa406156d489eaa8ee1/browser/config/mozconfigs/linux32/release#1    # noqa
                 esr.*: release
                 release-enterprise: release-enterprise
+                beta-enterprise: beta-enterprise
                 nightly-enterprise: nightly-enterprise
                 default: nightly
         # Note: These settings are only honored by nightly (i.e. shipping) builds
@@ -64,6 +65,7 @@ task-defaults:
                 nightly-pine: nightly-pine
                 nightly-cypress: nightly-cypress
                 release-enterprise: release-enterprise
+                beta-enterprise: beta-enterprise
                 nightly-enterprise: nightly-enterprise
                 beta:
                     by-shipping-product:
@@ -82,6 +84,7 @@ task-defaults:
                 nightly-oak: firefox-nightly-oak
                 nightly-pine: firefox-nightly-pine
                 release-enterprise: firefox-enterprise-release
+                beta-enterprise: firefox-enterprise-beta
                 nightly-enterprise: firefox-enterprise-nightly
                 beta:
                     by-shipping-product:
@@ -96,6 +99,7 @@ task-defaults:
                 nightly-oak: firefox-nightly-oak
                 nightly-pine: firefox-nightly-pine
                 release-enterprise: firefox-enterprise-release
+                beta-enterprise: firefox-enterprise-beta
                 nightly-enterprise: firefox-enterprise-nightly
                 beta:
                     by-shipping-product:

--- a/taskcluster/kinds/mar-signing-l10n/kind.yml
+++ b/taskcluster/kinds/mar-signing-l10n/kind.yml
@@ -36,7 +36,7 @@ tasks:
         from-deps:
             group-by: single-with-filters
         run-on-projects: [enterprise-firefox]
-        run-on-git-branches: [enterprise-main, enterprise-release]
+        run-on-git-branches: [enterprise-main, enterprise-beta, enterprise-release]
         treeherder-group: ms
         description-suffix: 'mar signing'
         required_signoffs:

--- a/taskcluster/kinds/mar-signing/kind.yml
+++ b/taskcluster/kinds/mar-signing/kind.yml
@@ -36,7 +36,7 @@ tasks:
         from-deps:
             group-by: single-with-filters
         run-on-projects: [enterprise-firefox]
-        run-on-git-branches: [enterprise-main, enterprise-release]
+        run-on-git-branches: [enterprise-main, enterprise-beta, enterprise-release]
         treeherder-group: ms
         description-suffix: 'mar signing'
         required_signoffs:

--- a/toolkit/mozapps/update/updater/moz.build
+++ b/toolkit/mozapps/update/updater/moz.build
@@ -51,7 +51,7 @@ xpcshell_cert.script = "gen_cert_header.py:create_header"
 dep1_cert.script = "gen_cert_header.py:create_header"
 dep2_cert.script = "gen_cert_header.py:create_header"
 
-if CONFIG["MOZ_UPDATE_CHANNEL"] in ("beta", "release", "esr", "release-enterprise"):
+if CONFIG["MOZ_UPDATE_CHANNEL"] in ("beta", "release", "esr", "beta-enterprise", "release-enterprise"):
     primary_cert.inputs += ["release_primary.der"]
     secondary_cert.inputs += ["release_secondary.der"]
 elif CONFIG["MOZ_UPDATE_CHANNEL"] in (


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2033812

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

This PR does two things:
1. Cherry-picks https://github.com/mozilla/enterprise-firefox/commit/395eea5f63ad225a11d297e17aa7570ec018c875 from `enterprise-beta`, which enabled builds on that branch
2. Makes a further change to allow `.taskcluster.yml` to be the same across all three branches

These changes can then be uplifted to `enterprise-beta` and `enterprise-release` to bring the consistency to all three branches.
