### PR TITLE
Bug 2034247 - Undo any enterprise preprocessing of JS files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1233,7 +1233,6 @@ toolkit/mozapps/update/tests/data/xpcshellConstantsPP.js
 toolkit/modules/AppConstants.sys.mjs
 
 # Files with MOZ_ENTERPRISE preprocessor directives
-browser/components/enterprisepolicies/helpers/WebsiteFilter.sys.mjs
 services/fxaccounts/FxAccounts.sys.mjs
 services/fxaccounts/FxAccountsClient.sys.mjs
 toolkit/components/downloads/DownloadCore.sys.mjs

--- a/.prettierignore
+++ b/.prettierignore
@@ -1233,7 +1233,6 @@ toolkit/mozapps/update/tests/data/xpcshellConstantsPP.js
 toolkit/modules/AppConstants.sys.mjs
 
 # Files with MOZ_ENTERPRISE preprocessor directives
-services/fxaccounts/FxAccountsClient.sys.mjs
 toolkit/components/downloads/DownloadCore.sys.mjs
 toolkit/components/printing/content/print.js
 toolkit/mozapps/extensions/AddonManager.sys.mjs

--- a/.prettierignore
+++ b/.prettierignore
@@ -1233,7 +1233,6 @@ toolkit/mozapps/update/tests/data/xpcshellConstantsPP.js
 toolkit/modules/AppConstants.sys.mjs
 
 # Files with MOZ_ENTERPRISE preprocessor directives
-toolkit/mozapps/extensions/AddonManager.sys.mjs
 toolkit/mozapps/extensions/internal/XPIDatabase.sys.mjs
 
 # Tests of ESLint command.

--- a/.prettierignore
+++ b/.prettierignore
@@ -1232,9 +1232,6 @@ toolkit/components/translations/cld2/
 toolkit/mozapps/update/tests/data/xpcshellConstantsPP.js
 toolkit/modules/AppConstants.sys.mjs
 
-# Files with MOZ_ENTERPRISE preprocessor directives
-toolkit/mozapps/extensions/internal/XPIDatabase.sys.mjs
-
 # Tests of ESLint command.
 tools/lint/test/files
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1233,7 +1233,6 @@ toolkit/mozapps/update/tests/data/xpcshellConstantsPP.js
 toolkit/modules/AppConstants.sys.mjs
 
 # Files with MOZ_ENTERPRISE preprocessor directives
-services/fxaccounts/FxAccounts.sys.mjs
 services/fxaccounts/FxAccountsClient.sys.mjs
 toolkit/components/downloads/DownloadCore.sys.mjs
 toolkit/components/printing/content/print.js

--- a/.prettierignore
+++ b/.prettierignore
@@ -1233,7 +1233,6 @@ toolkit/mozapps/update/tests/data/xpcshellConstantsPP.js
 toolkit/modules/AppConstants.sys.mjs
 
 # Files with MOZ_ENTERPRISE preprocessor directives
-toolkit/components/printing/content/print.js
 toolkit/mozapps/extensions/AddonManager.sys.mjs
 toolkit/mozapps/extensions/internal/XPIDatabase.sys.mjs
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1233,7 +1233,6 @@ toolkit/mozapps/update/tests/data/xpcshellConstantsPP.js
 toolkit/modules/AppConstants.sys.mjs
 
 # Files with MOZ_ENTERPRISE preprocessor directives
-toolkit/components/downloads/DownloadCore.sys.mjs
 toolkit/components/printing/content/print.js
 toolkit/mozapps/extensions/AddonManager.sys.mjs
 toolkit/mozapps/extensions/internal/XPIDatabase.sys.mjs

--- a/browser/components/enterprisepolicies/helpers/WebsiteFilter.sys.mjs
+++ b/browser/components/enterprisepolicies/helpers/WebsiteFilter.sys.mjs
@@ -195,9 +195,6 @@ export let WebsiteFilter = {
     return true;
   },
   _recordBlocklistDomainBrowsed(originalUrl, resolvedUrl, referrer) {
-    if (!AppConstants.MOZ_ENTERPRISE) {
-      return;
-    }
     const isEnabled = Services.prefs.getBoolPref(
       "browser.policies.enterprise.telemetry.blocklistDomainBrowsed.enabled",
       true

--- a/browser/components/enterprisepolicies/helpers/WebsiteFilter.sys.mjs
+++ b/browser/components/enterprisepolicies/helpers/WebsiteFilter.sys.mjs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { AppConstants } from "resource://gre/modules/AppConstants.sys.mjs";
+
 /*
  * This module implements the policy to block websites from being visited,
  * or to only allow certain websites to be visited.
@@ -149,19 +151,23 @@ export let WebsiteFilter = {
         url = URL.parse(location, channel.URI.spec);
       }
       if (url && !this.isAllowed(url.href)) {
-#ifdef MOZ_ENTERPRISE
-        let referrerSpec = "";
-        try {
-          let referrerInfo = channel.referrerInfo;
-          if (referrerInfo) {
-            let originalReferrer = referrerInfo.originalReferrer;
-            if (originalReferrer) {
-              referrerSpec = originalReferrer.spec;
+        if (AppConstants.MOZ_ENTERPRISE) {
+          let referrerSpec = "";
+          try {
+            let referrerInfo = channel.referrerInfo;
+            if (referrerInfo) {
+              let originalReferrer = referrerInfo.originalReferrer;
+              if (originalReferrer) {
+                referrerSpec = originalReferrer.spec;
+              }
             }
-          }
-        } catch (e) {}
-        this._recordBlocklistDomainBrowsed(channel.originalURI.spec, url.href, referrerSpec);
-#endif
+          } catch (e) {}
+          this._recordBlocklistDomainBrowsed(
+            channel.originalURI.spec,
+            url.href,
+            referrerSpec
+          );
+        }
         channel.cancel(Cr.NS_ERROR_BLOCKED_BY_POLICY);
       }
     } catch (e) {}
@@ -188,9 +194,11 @@ export let WebsiteFilter = {
     }
     return true;
   },
-  /* eslint-disable */
-#ifdef MOZ_ENTERPRISE
+
   _recordBlocklistDomainBrowsed(originalUrl, resolvedUrl, referrer) {
+    if (!AppConstants.MOZ_ENTERPRISE) {
+      return;
+    }
     const isEnabled = Services.prefs.getBoolPref(
       "browser.policies.enterprise.telemetry.blocklistDomainBrowsed.enabled",
       true
@@ -263,6 +271,4 @@ export let WebsiteFilter = {
         return sourceUrl;
     }
   },
-#endif
-  /* eslint-enable */
 };

--- a/browser/components/enterprisepolicies/helpers/WebsiteFilter.sys.mjs
+++ b/browser/components/enterprisepolicies/helpers/WebsiteFilter.sys.mjs
@@ -194,7 +194,6 @@ export let WebsiteFilter = {
     }
     return true;
   },
-
   _recordBlocklistDomainBrowsed(originalUrl, resolvedUrl, referrer) {
     if (!AppConstants.MOZ_ENTERPRISE) {
       return;

--- a/browser/components/enterprisepolicies/helpers/moz.build
+++ b/browser/components/enterprisepolicies/helpers/moz.build
@@ -9,13 +9,10 @@ EXTRA_JS_MODULES.policies += [
     "AIChatbotPolicies.sys.mjs",
     "BookmarksPolicies.sys.mjs",
     "ProxyPolicies.sys.mjs",
+    "WebsiteFilter.sys.mjs",
 ]
 
 if CONFIG["MOZ_ENTERPRISE"]:
     EXTRA_JS_MODULES.policies += [
         "SyncPolicy.sys.mjs",
     ]
-
-EXTRA_PP_JS_MODULES.policies += [
-    "WebsiteFilter.sys.mjs",
-]

--- a/eslint-ignores.config.mjs
+++ b/eslint-ignores.config.mjs
@@ -285,9 +285,6 @@ export default [
   "toolkit/mozapps/update/tests/data/xpcshellConstantsPP.js",
   "toolkit/modules/AppConstants.sys.mjs",
 
-  // Files with MOZ_ENTERPRISE preprocessor directives
-  "toolkit/mozapps/extensions/internal/XPIDatabase.sys.mjs",
-
   // ESLint tests.
   "tools/lint/test/files",
   "tools/lint/eslint/eslint-plugin-mozilla/tests/globals-data/import-globals-from-invalid.js",

--- a/eslint-ignores.config.mjs
+++ b/eslint-ignores.config.mjs
@@ -286,7 +286,6 @@ export default [
   "toolkit/modules/AppConstants.sys.mjs",
 
   // Files with MOZ_ENTERPRISE preprocessor directives
-  "toolkit/mozapps/extensions/AddonManager.sys.mjs",
   "toolkit/mozapps/extensions/internal/XPIDatabase.sys.mjs",
 
   // ESLint tests.

--- a/eslint-ignores.config.mjs
+++ b/eslint-ignores.config.mjs
@@ -286,7 +286,6 @@ export default [
   "toolkit/modules/AppConstants.sys.mjs",
 
   // Files with MOZ_ENTERPRISE preprocessor directives
-  "toolkit/components/downloads/DownloadCore.sys.mjs",
   "toolkit/components/printing/content/print.js",
   "toolkit/mozapps/extensions/AddonManager.sys.mjs",
   "toolkit/mozapps/extensions/internal/XPIDatabase.sys.mjs",

--- a/eslint-ignores.config.mjs
+++ b/eslint-ignores.config.mjs
@@ -286,7 +286,6 @@ export default [
   "toolkit/modules/AppConstants.sys.mjs",
 
   // Files with MOZ_ENTERPRISE preprocessor directives
-  "services/fxaccounts/FxAccountsClient.sys.mjs",
   "toolkit/components/downloads/DownloadCore.sys.mjs",
   "toolkit/components/printing/content/print.js",
   "toolkit/mozapps/extensions/AddonManager.sys.mjs",

--- a/eslint-ignores.config.mjs
+++ b/eslint-ignores.config.mjs
@@ -286,7 +286,6 @@ export default [
   "toolkit/modules/AppConstants.sys.mjs",
 
   // Files with MOZ_ENTERPRISE preprocessor directives
-  "browser/components/enterprisepolicies/helpers/WebsiteFilter.sys.mjs",
   "services/fxaccounts/FxAccounts.sys.mjs",
   "services/fxaccounts/FxAccountsClient.sys.mjs",
   "toolkit/components/downloads/DownloadCore.sys.mjs",

--- a/eslint-ignores.config.mjs
+++ b/eslint-ignores.config.mjs
@@ -286,7 +286,6 @@ export default [
   "toolkit/modules/AppConstants.sys.mjs",
 
   // Files with MOZ_ENTERPRISE preprocessor directives
-  "toolkit/components/printing/content/print.js",
   "toolkit/mozapps/extensions/AddonManager.sys.mjs",
   "toolkit/mozapps/extensions/internal/XPIDatabase.sys.mjs",
 

--- a/eslint-ignores.config.mjs
+++ b/eslint-ignores.config.mjs
@@ -286,7 +286,6 @@ export default [
   "toolkit/modules/AppConstants.sys.mjs",
 
   // Files with MOZ_ENTERPRISE preprocessor directives
-  "services/fxaccounts/FxAccounts.sys.mjs",
   "services/fxaccounts/FxAccountsClient.sys.mjs",
   "toolkit/components/downloads/DownloadCore.sys.mjs",
   "toolkit/components/printing/content/print.js",

--- a/services/fxaccounts/FxAccounts.sys.mjs
+++ b/services/fxaccounts/FxAccounts.sys.mjs
@@ -4,11 +4,7 @@
 
 import { XPCOMUtils } from "resource://gre/modules/XPCOMUtils.sys.mjs";
 
-#ifdef MOZ_ENTERPRISE
-import { EnterpriseStorageManager } from "resource:///modules/enterprise/EnterpriseAccountsStorage.sys.mjs";
-#else
 import { FxAccountsStorageManager } from "resource://gre/modules/FxAccountsStorage.sys.mjs";
-#endif
 
 import {
   ATTACHED_CLIENTS_CACHE_DURATION,
@@ -38,11 +34,14 @@ import {
   logPII,
   logManager,
 } from "resource://gre/modules/FxAccountsCommon.sys.mjs";
+import { AppConstants } from "resource://gre/modules/AppConstants.sys.mjs";
 
 const lazy = {};
 
 ChromeUtils.defineESModuleGetters(lazy, {
   CryptoUtils: "moz-src:///services/crypto/modules/utils.sys.mjs",
+  EnterpriseStorageManager:
+    "resource:///modules/enterprise/EnterpriseAccountsStorage.sys.mjs",
   FxAccountsClient: "resource://gre/modules/FxAccountsClient.sys.mjs",
   FxAccountsCommands: "resource://gre/modules/FxAccountsCommands.sys.mjs",
   FxAccountsConfig: "resource://gre/modules/FxAccountsConfig.sys.mjs",
@@ -952,14 +951,9 @@ FxAccountsInternal.prototype = {
 
   // A hook-point for tests who may want a mocked AccountState or mocked storage.
   newAccountState(credentials) {
-    let storage =
-#ifdef MOZ_ENTERPRISE
-      new EnterpriseStorageManager()
-#else
-      new FxAccountsStorageManager()
-#endif
-    ;
-
+    let storage = AppConstants.MOZ_ENTERPRISE
+      ? new lazy.EnterpriseStorageManager()
+      : new FxAccountsStorageManager();
     storage.initialize(credentials);
     return new AccountState(storage);
   },

--- a/services/fxaccounts/FxAccountsClient.sys.mjs
+++ b/services/fxaccounts/FxAccountsClient.sys.mjs
@@ -8,12 +8,12 @@ import { HawkClient } from "resource://services-common/hawkclient.sys.mjs";
 import { deriveHawkCredentials } from "resource://services-common/hawkrequest.sys.mjs";
 import { CryptoUtils } from "moz-src:///services/crypto/modules/utils.sys.mjs";
 
-#ifdef MOZ_ENTERPRISE
 const lazy = {};
-ChromeUtils.defineESModuleGetters(lazy, {
-  ConsoleClient: "resource:///modules/enterprise/ConsoleClient.sys.mjs",
-});
-#endif
+if (AppConstants.MOZ_ENTERPRISE) {
+  ChromeUtils.defineESModuleGetters(lazy, {
+    ConsoleClient: "resource:///modules/enterprise/ConsoleClient.sys.mjs",
+  });
+}
 
 import {
   ERRNO_ACCOUNT_DOES_NOT_EXIST,
@@ -26,6 +26,7 @@ import {
 } from "resource://gre/modules/FxAccountsCommon.sys.mjs";
 
 import { Credentials } from "resource://gre/modules/Credentials.sys.mjs";
+import { AppConstants } from "resource://gre/modules/AppConstants.sys.mjs";
 
 const HOST_PREF = "identity.fxaccounts.auth.uri";
 
@@ -789,20 +790,16 @@ FxAccountsClient.prototype = {
       log.debug("Received new request during backoff, re-rejecting.");
       throw this.backoffError;
     }
-#ifdef MOZ_ENTERPRISE
-    let accessToken = await lazy.ConsoleClient.getAccessToken();
-#endif
-
     let response;
     try {
       response = await this.hawk.request(
         path,
         method,
         credentials,
-        jsonPayload
-#ifdef MOZ_ENTERPRISE
-        , { "Authorization": `Bearer ${accessToken}`}
-#endif
+        jsonPayload,
+        ...(AppConstants.MOZ_ENTERPRISE && {
+          Authorization: `Bearer ${await lazy.ConsoleClient.getAccessToken()}`,
+        })
       );
     } catch (error) {
       log.error(`error ${method}ing ${path}`, error);

--- a/services/fxaccounts/FxAccountsClient.sys.mjs
+++ b/services/fxaccounts/FxAccountsClient.sys.mjs
@@ -7,6 +7,7 @@ import { CommonUtils } from "resource://services-common/utils.sys.mjs";
 import { HawkClient } from "resource://services-common/hawkclient.sys.mjs";
 import { deriveHawkCredentials } from "resource://services-common/hawkrequest.sys.mjs";
 import { CryptoUtils } from "moz-src:///services/crypto/modules/utils.sys.mjs";
+import { AppConstants } from "resource://gre/modules/AppConstants.sys.mjs";
 
 const lazy = {};
 if (AppConstants.MOZ_ENTERPRISE) {
@@ -26,7 +27,6 @@ import {
 } from "resource://gre/modules/FxAccountsCommon.sys.mjs";
 
 import { Credentials } from "resource://gre/modules/Credentials.sys.mjs";
-import { AppConstants } from "resource://gre/modules/AppConstants.sys.mjs";
 
 const HOST_PREF = "identity.fxaccounts.auth.uri";
 

--- a/services/fxaccounts/moz.build
+++ b/services/fxaccounts/moz.build
@@ -13,6 +13,7 @@ XPCSHELL_TESTS_MANIFESTS += ["tests/xpcshell/xpcshell.toml"]
 
 EXTRA_JS_MODULES += [
     "Credentials.sys.mjs",
+    "FxAccounts.sys.mjs",
     "FxAccountsCommands.sys.mjs",
     "FxAccountsCommon.sys.mjs",
     "FxAccountsConfig.sys.mjs",
@@ -30,7 +31,6 @@ EXTRA_JS_MODULES += [
 ]
 
 EXTRA_PP_JS_MODULES += [
-    "FxAccounts.sys.mjs",
     "FxAccountsClient.sys.mjs",
 ]
 

--- a/services/fxaccounts/moz.build
+++ b/services/fxaccounts/moz.build
@@ -14,6 +14,7 @@ XPCSHELL_TESTS_MANIFESTS += ["tests/xpcshell/xpcshell.toml"]
 EXTRA_JS_MODULES += [
     "Credentials.sys.mjs",
     "FxAccounts.sys.mjs",
+    "FxAccountsClient.sys.mjs",
     "FxAccountsCommands.sys.mjs",
     "FxAccountsCommon.sys.mjs",
     "FxAccountsConfig.sys.mjs",
@@ -28,10 +29,6 @@ EXTRA_JS_MODULES += [
     "FxAccountsStorage.sys.mjs",
     "FxAccountsTelemetry.sys.mjs",
     "FxAccountsWebChannel.sys.mjs",
-]
-
-EXTRA_PP_JS_MODULES += [
-    "FxAccountsClient.sys.mjs",
 ]
 
 XPCOM_MANIFESTS += [

--- a/toolkit/components/downloads/DownloadCore.sys.mjs
+++ b/toolkit/components/downloads/DownloadCore.sys.mjs
@@ -427,19 +427,17 @@ Download.prototype = {
     this.currentBytes = 0;
     this.startTime = new Date();
 
-/* eslint-disable */
-#ifdef MOZ_ENTERPRISE
-    // Record telemetry when download attempt starts
-    if (
-      Services.prefs.getBoolPref(
-        "browser.download.enterprise.telemetry.enabled",
-        true
-      )
-    ) {
-      this._recordDownloadAttempt();
+    if (AppConstants.MOZ_ENTERPRISE) {
+      // Record telemetry when download attempt starts
+      if (
+        Services.prefs.getBoolPref(
+          "browser.download.enterprise.telemetry.enabled",
+          true
+        )
+      ) {
+        this._recordDownloadAttempt();
+      }
     }
-#endif
-/* eslint-enable */
 
     // Create a new deferred object and an associated promise before starting
     // the actual download.  We store it on the download as the current attempt.
@@ -699,9 +697,7 @@ Download.prototype = {
     }
   },
 
-/* eslint-disable */
-#ifdef MOZ_ENTERPRISE
-    /**
+  /**
    * Gets the configured URL logging level from enterprise policy preferences.
    *
    * @returns {string} One of: "full", "domain", "none"
@@ -857,8 +853,6 @@ Download.prototype = {
       console.warn("Failed to record download attempt telemetry:", ex);
     }
   },
-#endif
-/* eslint-enable */
 
   /**
    * When a request to unblock the download is received, contains a promise

--- a/toolkit/components/downloads/moz.build
+++ b/toolkit/components/downloads/moz.build
@@ -28,6 +28,7 @@ if CONFIG["OS_ARCH"] == "WINNT":
     ]
 
 EXTRA_JS_MODULES += [
+    "DownloadCore.sys.mjs",
     "DownloadIntegration.sys.mjs",
     "DownloadLegacy.sys.mjs",
     "DownloadList.sys.mjs",
@@ -35,10 +36,6 @@ EXTRA_JS_MODULES += [
     "Downloads.sys.mjs",
     "DownloadStore.sys.mjs",
     "DownloadUIHelper.sys.mjs",
-]
-
-EXTRA_PP_JS_MODULES += [
-    "DownloadCore.sys.mjs",
 ]
 
 XPCOM_MANIFESTS += [

--- a/toolkit/components/printing/content/print.js
+++ b/toolkit/components/printing/content/print.js
@@ -420,9 +420,9 @@ var PrintEventHandler = {
       this.printProgressIndicator.hidden = false;
       let bc = this.printPreviewEl.currentBrowsingContext;
       await this._doPrint(bc, settings);
-#ifdef MOZ_ENTERPRISE
-      this._recordPagePrinted(settings);
-#endif
+      if (AppConstants.MOZ_ENTERPRISE) {
+        this._recordPagePrinted(settings);
+      }
     } catch (e) {
       console.error(e);
     }
@@ -449,7 +449,6 @@ var PrintEventHandler = {
     return aBrowsingContext.print(aSettings);
   },
 
-#ifdef MOZ_ENTERPRISE
   _recordPagePrinted(aSettings) {
     const isEnabled = Services.prefs.getBoolPref(
       "print.enterprise.telemetry.printPage.enabled",
@@ -509,7 +508,6 @@ var PrintEventHandler = {
         return sourceUrl;
     }
   },
-#endif
 
   cancelPrint() {
     Glean.printing.previewCancelledTm.add(1);

--- a/toolkit/components/printing/jar.mn
+++ b/toolkit/components/printing/jar.mn
@@ -7,7 +7,7 @@ toolkit.jar:
    content/global/printPageSetup.js                 (content/printPageSetup.js)
    content/global/printPageSetup.xhtml              (content/printPageSetup.xhtml)
 #endif
-*  content/global/print.js                          (content/print.js)
+   content/global/print.js                          (content/print.js)
    content/global/print.html                        (content/print.html)
    content/global/print.css                         (content/print.css)
    content/global/printPagination.css               (content/printPagination.css)

--- a/toolkit/mozapps/extensions/AddonManager.sys.mjs
+++ b/toolkit/mozapps/extensions/AddonManager.sys.mjs
@@ -5932,8 +5932,11 @@ AMTelemetry = {
         step: extra.step,
       })
     );
-#ifdef MOZ_ENTERPRISE
-    if (eventMethod == "install" && extra.step == "completed") {
+    if (
+      AppConstants.MOZ_ENTERPRISE &&
+      eventMethod == "install" &&
+      extra.step == "completed"
+    ) {
       Glean.addonsManager.installComplete.record(
         this.formatExtraVars({
           addon_id: extra.addon_id,
@@ -5952,7 +5955,6 @@ AMTelemetry = {
       );
       GleanPings.enterprise.submit();
     }
-#endif
   },
 
   /**

--- a/toolkit/mozapps/extensions/internal/XPIDatabase.sys.mjs
+++ b/toolkit/mozapps/extensions/internal/XPIDatabase.sys.mjs
@@ -14,6 +14,8 @@ import { XPCOMUtils } from "resource://gre/modules/XPCOMUtils.sys.mjs";
 
 import { XPIExports } from "resource://gre/modules/addons/XPIExports.sys.mjs";
 
+import { AppConstants } from "resource://gre/modules/AppConstants.sys.mjs";
+
 const lazy = {};
 
 ChromeUtils.defineESModuleGetters(lazy, {
@@ -1221,11 +1223,9 @@ export class AddonWrapper {
       return true;
     }
 
-#ifdef MOZ_ENTERPRISE
-    if (this.isInstalledByEnterprisePolicy) {
+    if (AppConstants.MOZ_ENTERPRISE && this.isInstalledByEnterprisePolicy) {
       return true;
     }
-#endif
 
     return XPIExports.XPIInternal.canRunInSafeMode(addon);
   }
@@ -1684,7 +1684,13 @@ const updatedAddonFluentIds = new Map([
       let fluentId =
         updatedAddonFluentIds.get(defaultFluentId) || defaultFluentId;
       try {
-        const l10n = new Localization(["browser/appExtensionFields.ftl", "browser/enterprise/enterprise.ftl"], true);
+        const l10n = new Localization(
+          [
+            "browser/appExtensionFields.ftl",
+            "browser/enterprise/enterprise.ftl",
+          ],
+          true
+        );
         [formattedMessage] = l10n.formatMessagesSync([{ id: fluentId }]);
       } catch (e) {
         // Log a warning when no fluent string was found, but fallback to the value set

--- a/toolkit/mozapps/extensions/internal/moz.build
+++ b/toolkit/mozapps/extensions/internal/moz.build
@@ -9,8 +9,8 @@ EXTRA_JS_MODULES.addons += [
     "crypto-utils.sys.mjs",
     "ProductAddonChecker.sys.mjs",
     "siteperms-addon-utils.sys.mjs",
-    "XPIExports.sys.mjs",
     "XPIDatabase.sys.mjs",
+    "XPIExports.sys.mjs",
     "XPIInstall.sys.mjs",
     "XPIProvider.sys.mjs",
 ]

--- a/toolkit/mozapps/extensions/internal/moz.build
+++ b/toolkit/mozapps/extensions/internal/moz.build
@@ -10,12 +10,9 @@ EXTRA_JS_MODULES.addons += [
     "ProductAddonChecker.sys.mjs",
     "siteperms-addon-utils.sys.mjs",
     "XPIExports.sys.mjs",
+    "XPIDatabase.sys.mjs",
     "XPIInstall.sys.mjs",
     "XPIProvider.sys.mjs",
-]
-
-EXTRA_PP_JS_MODULES.addons += [
-    "XPIDatabase.sys.mjs",
 ]
 
 if CONFIG["MOZ_WIDGET_TOOLKIT"] != "android":

--- a/toolkit/mozapps/extensions/moz.build
+++ b/toolkit/mozapps/extensions/moz.build
@@ -60,16 +60,13 @@ EXTRA_PP_COMPONENTS += [
 
 EXTRA_JS_MODULES += [
     "AbuseReporter.sys.mjs",
+    "AddonManager.sys.mjs",
     "amContentHandler.sys.mjs",
     "amManager.sys.mjs",
     "amWebAPI.sys.mjs",
     "Blocklist.sys.mjs",
     "ColorwayThemeMigration.sys.mjs",
     "LightweightThemeManager.sys.mjs",
-]
-
-EXTRA_PP_JS_MODULES += [
-    "AddonManager.sys.mjs",
 ]
 
 JAR_MANIFESTS += ["jar.mn"]


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2034247

Undo pre-processing of JS files as they are normally not preprocessed in Firefox (only few exceptions). Instead exclude enterprise-specific code at runtime. This also unblocks those files to be linted and formatted again. 
