### PR TITLE
Bug 2034385: unlock MITM priming endpoint pref for cert error test inenterprise builds

### DIFF
--- a/browser/base/content/test/about/browser_aboutCertError_mitm.js
+++ b/browser/base/content/test/about/browser_aboutCertError_mitm.js
@@ -13,6 +13,18 @@ const PREF_FELT_PRIV_V1 = "security.certerrors.felt-privacy-v1";
 
 const UNKNOWN_ISSUER = "https://untrusted.example.com";
 
+// Enterprise builds lock the MITM priming endpoint. Unlock it so tests can
+// set it to a local server.
+if (
+  AppConstants.MOZ_ENTERPRISE &&
+  Services.prefs.prefIsLocked(PREF_MITM_PRIMING_ENDPOINT)
+) {
+  Services.prefs.unlockPref(PREF_MITM_PRIMING_ENDPOINT);
+  registerCleanupFunction(() => {
+    Services.prefs.lockPref(PREF_MITM_PRIMING_ENDPOINT);
+  });
+}
+
 async function checkMitmPriming(useFelt) {
   await SpecialPowers.pushPrefEnv({
     set: [


### PR DESCRIPTION


<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2034385

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---
The test is crashing cause it cannot set the proper url due to being locked by enterprise.

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on:

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

---

### Testing <!-- OPTIONAL -->

* [ ] Added tests
* [x] Manual testing performed

[See normal run](https://treeherder.mozilla.org/logviewer?job_id=561913832&repo=enterprise-firefox-pr&task=daEMMg2KRYGaQkXIB9G85w.0&lineNumber=10420)

[See with the PR changes](https://treeherder.mozilla.org/logviewer?job_id=562003539&repo=enterprise-firefox-pr&task=B1ZrQMccSK2t7NjxMvI3IQ.0&lineNumber=1571)

<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
