### PR TITLE
Bug 2034389: unlock enterprise-locked prefs for IP protection guardian client test

### DIFF
--- a/browser/components/ipprotection/tests/browser/browser_guardian_client.js
+++ b/browser/components/ipprotection/tests/browser/browser_guardian_client.js
@@ -4,6 +4,24 @@
 
 "use strict";
 
+// Enterprise builds lock these prefs. Unlock them so tests can set them
+// to local servers, and re-lock on cleanup.
+if (AppConstants.MOZ_ENTERPRISE) {
+  const lockedPrefs = [
+    "browser.ipProtection.guardian.endpoint",
+    "identity.fxaccounts.remote.root",
+  ].filter(p => Services.prefs.prefIsLocked(p));
+
+  for (const pref of lockedPrefs) {
+    Services.prefs.unlockPref(pref);
+  }
+  registerCleanupFunction(() => {
+    for (const pref of lockedPrefs) {
+      Services.prefs.lockPref(pref);
+    }
+  });
+}
+
 const { GuardianClient } = ChromeUtils.importESModule(
   "moz-src:///toolkit/components/ipprotection/GuardianClient.sys.mjs"
 );


### PR DESCRIPTION


<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2034389

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

The following two settings are locked. 
```
"browser.ipProtection.guardian.endpoint",
"identity.fxaccounts.remote.root"
```

See [link](https://searchfox.org/enterprise-main/rev/11acd910851157e4c161e4eb32623217ab1d0f0a/browser/components/ipprotection/tests/browser/browser_guardian_client.js#93)

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on:

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

---

### Testing <!-- OPTIONAL -->

* [ ] Added tests
* [x] Manual testing performed

[See current run ](https://treeherder.mozilla.org/logviewer?job_id=561913790&repo=enterprise-firefox-pr&task=MPHQvqmVTY6wjwa8X3pBGg.0&lineNumber=15587)
[See with new changes](https://treeherder.mozilla.org/logviewer?job_id=561992929&repo=enterprise-firefox-pr&task=SK8ZUrWQSZWxfVJrbSgsvw.0&lineNumber=7323)
<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
