### PR TITLE
Bug 2034394: unlock captivedetect.canonicalURL for captive portal tests on enterprise builds

### DIFF
--- a/browser/base/content/test/captivePortal/head.js
+++ b/browser/base/content/test/captivePortal/head.js
@@ -1,3 +1,14 @@
+// Enterprise builds lock captivedetect.canonicalURL. Unlock it so tests can set it to a local server.
+if (
+  AppConstants.MOZ_ENTERPRISE &&
+  Services.prefs.prefIsLocked("captivedetect.canonicalURL")
+) {
+  Services.prefs.unlockPref("captivedetect.canonicalURL");
+  registerCleanupFunction(() => {
+    Services.prefs.lockPref("captivedetect.canonicalURL");
+  });
+}
+
 XPCOMUtils.defineLazyServiceGetter(
   this,
   "cps",


### PR DESCRIPTION


<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2034394

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

The following tests have all the same issue, crashing because enterprise builds are locking the pref "captivedetect.canonicalURL"
```
[task 2026-04-23T09:03:12.236+00:00] 09:03:12     INFO - TEST-CRASH | browser/base/content/test/captivePortal/browser_CaptivePortalWatcher.js | took 12157ms
[task 2026-04-23T09:03:33.844+00:00] 09:03:33     INFO - TEST-CRASH | browser/base/content/test/captivePortal/browser_CaptivePortalWatcher_1.js | took 19844ms
[task 2026-04-23T09:03:51.623+00:00] 09:03:51     INFO - TEST-CRASH | browser/base/content/test/captivePortal/browser_captivePortalTabReference.js | took 15924ms
[task 2026-04-23T09:04:05.028+00:00] 09:04:05     INFO - TEST-CRASH | browser/base/content/test/captivePortal/browser_captivePortal_certErrorUI.js | took 11674ms
[task 2026-04-23T09:04:22.776+00:00] 09:04:22     INFO - TEST-CRASH | browser/base/content/test/captivePortal/browser_captivePortal_https_only.js | took 15995ms
[task 2026-04-23T09:04:34.740+00:00] 09:04:34     INFO - TEST-CRASH | browser/base/content/test/captivePortal/browser_captivePortal_lna.js | took 10211ms
[task 2026-04-23T09:04:47.775+00:00] 09:04:47     INFO - TEST-CRASH | browser/base/content/test/captivePortal/browser_captivePortal_trr_mode3.js | took 11209ms
[task 2026-04-23T09:05:50.373+00:00] 09:05:50     INFO - TEST-CRASH | browser/base/content/test/captivePortal/browser_captivePortal_https_only.js | took 13776ms
```


### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on:

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

---

### Testing <!-- OPTIONAL -->

* [ ] Added tests
* [x] Manual testing performed

[See issues from the tests](https://treeherder.mozilla.org/logviewer?job_id=561913849&repo=enterprise-firefox-pr&task=X3WdN2TNSzuXbxlBae_xqQ.0&lineNumber=11326). filter by ```captivePortal/browser_captivePortal```
[See this log with the changes](https://treeherder.mozilla.org/logviewer?job_id=562004565&repo=enterprise-firefox-pr&task=Ke-s4JKWTPeYEAell7LIHg.0&lineNumber=1983) filter by ```captivePortal/browser_captivePortal```
<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
