### PR TITLE
Bug 2034402: unlock identity.fxaccounts.remote.root for enterprise builds in browser_sma_show_firefox_accounts test

### DIFF
--- a/toolkit/components/messaging-system/schemas/SpecialMessageActionSchemas/test/browser/browser_sma_show_firefox_accounts.js
+++ b/toolkit/components/messaging-system/schemas/SpecialMessageActionSchemas/test/browser/browser_sma_show_firefox_accounts.js
@@ -3,6 +3,19 @@
 
 "use strict";
 
+// Enterprise builds lock identity.fxaccounts.remote.root. Unlock it so tests can set it to a local server.
+add_setup(function () {
+  if (
+    AppConstants.MOZ_ENTERPRISE &&
+    Services.prefs.prefIsLocked("identity.fxaccounts.remote.root")
+  ) {
+    Services.prefs.unlockPref("identity.fxaccounts.remote.root");
+    registerCleanupFunction(() => {
+      Services.prefs.lockPref("identity.fxaccounts.remote.root");
+    });
+  }
+});
+
 // Note: "identity.fxaccounts.remote.root" is set to https://example.com in browser.toml
 add_task(async function test_SHOW_FIREFOX_ACCOUNTS() {
   await BrowserTestUtils.withNewTab("about:blank", async browser => {


### PR DESCRIPTION


<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2034402

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on:

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

---

### Testing <!-- OPTIONAL -->

* [ ] Added tests
* [x] Manual testing performed

[See run where it crashes](https://treeherder.mozilla.org/logviewer?job_id=561906101&repo=enterprise-firefox-pr&task=bfkIis82TTKL1xKYOtIWSA.0&lineNumber=93498)
[See run with changes](https://treeherder.mozilla.org/logviewer?job_id=562003792&repo=enterprise-firefox-pr&task=X79cQMeJRM2dTq3aQJ0j3A.0&lineNumber=24838)
<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
