### PR TITLE
Bug 2034412: fix browser_UITour.js distribution test for enterprise builds

### DIFF
--- a/browser/components/uitour/test/browser_UITour.js
+++ b/browser/components/uitour/test/browser_UITour.js
@@ -510,14 +510,16 @@ var tests = [
         "Check distribution isn't undefined."
       );
       // distribution id defaults to "default" for most builds,
-      // "mozilla-MSIX" for MSIX builds, and "mozilla-official" for
-      // official Mozilla builds.
+      // "mozilla-MSIX" for MSIX builds, "mozilla-official" for
+      // official Mozilla builds, and "enterprise-local" for enterprise builds.
       let expectedDistribution = "default";
       if (
         AppConstants.platform === "win" &&
         Services.sysinfo.getProperty("hasWinPackageId")
       ) {
         expectedDistribution = "mozilla-MSIX";
+      } else if (AppConstants.MOZ_ENTERPRISE) {
+        expectedDistribution = "enterprise-local";
       } else if (AppConstants.BUILT_BY_MOZILLA) {
         expectedDistribution = "mozilla-official";
       }


### PR DESCRIPTION


<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2034412

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---
The test read distribution id and it goes to "default", I changed that to match "enterprise-local"

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on:

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

---

### Testing <!-- OPTIONAL -->

* [ ] Added tests
* [x] Manual testing performed

[See run failing](https://treeherder.mozilla.org/logviewer?job_id=561984186&repo=enterprise-firefox-pr&task=Wx-P1feRQK2GM8OYYRMs8Q.0&lineNumber=77946)
[See test passing with changes](https://treeherder.mozilla.org/logviewer?job_id=562010206&repo=enterprise-firefox-pr&task=JutIbTYEQ4yJh_5GBXUoTw.0&lineNumber=56994)

<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
