### PR TITLE
Bug 2034425: fix browser_toolbarKeyNav.js for enterprise builds where FxA button is hidden and enterprise badge takes its place in keyboard navigation

### DIFF
--- a/browser/base/content/test/keyboard/browser_toolbarKeyNav.js
+++ b/browser/base/content/test/keyboard/browser_toolbarKeyNav.js
@@ -18,7 +18,11 @@ let gCUITestUtils = new CustomizableUITestUtils(window);
 
 const PERMISSIONS_PAGE =
   "https://example.com/browser/browser/base/content/test/permissions/permissions.html";
-const afterUrlBarButton = "fxa-toolbar-menu-button";
+// On enterprise, the FxA button is hidden and the enterprise badge takes its
+// place in the toolbar keyboard navigation order.
+const afterUrlBarButton = AppConstants.MOZ_ENTERPRISE
+  ? "enterprise-badge-toolbar-button"
+  : "fxa-toolbar-menu-button";
 const sidebarRevampEnabled = Services.prefs.getBoolPref(
   "sidebar.revamp",
   false
@@ -50,23 +54,23 @@ function AddOldMenuSideButtons() {
     document.documentElement.getAttribute("fxastatus")
   );
   document.documentElement.setAttribute("fxastatus", "signed_in");
-  // The FxA button is supposed to be last, add these buttons before it.
+  const endOffset = AppConstants.MOZ_ENTERPRISE ? 4 : 3;
   CustomizableUI.addWidgetToArea(
     "library-button",
     "nav-bar",
-    CustomizableUI.getWidgetIdsInArea("nav-bar").length - 3
+    CustomizableUI.getWidgetIdsInArea("nav-bar").length - endOffset
   );
   if (!sidebarRevampEnabled) {
     CustomizableUI.addWidgetToArea(
       "sidebar-button",
       "nav-bar",
-      CustomizableUI.getWidgetIdsInArea("nav-bar").length - 3
+      CustomizableUI.getWidgetIdsInArea("nav-bar").length - endOffset
     );
   }
   CustomizableUI.addWidgetToArea(
     "unified-extensions-button",
     "nav-bar",
-    CustomizableUI.getWidgetIdsInArea("nav-bar").length - 3
+    CustomizableUI.getWidgetIdsInArea("nav-bar").length - endOffset
   );
 }
 
@@ -345,7 +349,7 @@ add_task(async function testArrowsToolbarbuttons() {
       await expectFocusAfterKey("ArrowRight", "sidebar-button");
     }
     await expectFocusAfterKey("ArrowRight", "unified-extensions-button");
-    await expectFocusAfterKey("ArrowRight", "fxa-toolbar-menu-button");
+    await expectFocusAfterKey("ArrowRight", afterUrlBarButton);
     // This next check also confirms that the overflow menu button is skipped,
     // since it is currently invisible.
     await expectFocusAfterKey("ArrowRight", "PanelUI-menu-button");
@@ -355,7 +359,7 @@ add_task(async function testArrowsToolbarbuttons() {
       "PanelUI-menu-button",
       "ArrowRight at end of button group does nothing"
     );
-    await expectFocusAfterKey("ArrowLeft", "fxa-toolbar-menu-button");
+    await expectFocusAfterKey("ArrowLeft", afterUrlBarButton);
     await expectFocusAfterKey("ArrowLeft", "unified-extensions-button");
     if (!sidebarRevampEnabled) {
       await expectFocusAfterKey("ArrowLeft", "sidebar-button");
@@ -441,17 +445,15 @@ add_task(async function testArrowsOverflowButton() {
       await expectFocusAfterKey("ArrowRight", "sidebar-button");
     }
     await expectFocusAfterKey("ArrowRight", "unified-extensions-button");
-    await expectFocusAfterKey("ArrowRight", "fxa-toolbar-menu-button");
+    await expectFocusAfterKey("ArrowRight", afterUrlBarButton);
     await expectFocusAfterKey("ArrowRight", "nav-bar-overflow-button");
     // Make sure the button is not reachable once it is invisible again.
     await expectFocusAfterKey("ArrowRight", "PanelUI-menu-button");
     resetToolbarWithoutDevEditionButtons();
     // Flush layout so its invisibility can be detected.
     document.getElementById("nav-bar-overflow-button").clientWidth;
-    // We reset the toolbar above so the unified extensions button is now the
-    // "last" button.
     await expectFocusAfterKey("ArrowLeft", "unified-extensions-button");
-    await expectFocusAfterKey("ArrowLeft", "fxa-toolbar-menu-button");
+    await expectFocusAfterKey("ArrowLeft", afterUrlBarButton);
   });
   RemoveOldMenuSideButtons();
 });

--- a/browser/components/customizableui/CustomizableUI.sys.mjs
+++ b/browser/components/customizableui/CustomizableUI.sys.mjs
@@ -368,6 +368,7 @@ var CustomizableUIInternal = {
       AppConstants.MOZ_DEV_EDITION ? "developer-button" : null,
       lazy.ippEnabled ? "ipprotection-button" : null,
       "fxa-toolbar-menu-button",
+      AppConstants.MOZ_ENTERPRISE ? "enterprise-badge-toolbar-button" : null,
       lazy.resetPBMToolbarButtonEnabled ? "reset-pbm-toolbar-button" : null,
     ].filter(name => name);
 

--- a/browser/components/customizableui/test/marionette/test_assert_no_toolbar_changes.py
+++ b/browser/components/customizableui/test/marionette/test_assert_no_toolbar_changes.py
@@ -35,12 +35,6 @@ class TestNoToolbarChanges(MarionetteTestCase):
         navbarPlacements = self.get_area_default_placements("AREA_NAVBAR")
         navbarPlacements.append("unified-extensions-button")
 
-        if (
-            self.marionette.session_capabilities.get("moz:browserFlavor")
-            == "enterprise"
-        ):
-            navbarPlacements.append("enterprise-badge-toolbar-button")
-
         self.assertEqual(
             self.get_area_widgets("AREA_NAVBAR"),
             navbarPlacements,

--- a/browser/components/enterprise/content/enterprise-badge.inc.xhtml
+++ b/browser/components/enterprise/content/enterprise-badge.inc.xhtml
@@ -5,7 +5,7 @@
 <html:link rel="stylesheet" href="chrome://browser/content/enterprise/enterprise-badge.css" overflows="false"/>
 <html:link rel="localization" href="browser/enterprise/enterprise.ftl" overflows="false"/>
 
-<toolbarbutton id="enterprise-badge-toolbar-button" class="toolbarbutton-1" delegatesanchor="true" data-l10n-id="enterprise-toolbar-button" removable="false">
+<toolbarbutton id="enterprise-badge-toolbar-button" class="toolbarbutton-1" delegatesanchor="true" data-l10n-id="enterprise-toolbar-button" removable="false" cui-areatype="toolbar">
   <hbox>
     <div class="enterprise-badge">
       <div id="enterprise-company-logo__wrapper" class="is-hidden">


### PR DESCRIPTION

<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2034425

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

The test "browser_toolbarKeyNav.js"  tests that keyboard navigation (Tab, arrow keys, F6) moves focus correctly between toolbar buttons and controls in the browser's default toolbar configuration. 

I added the parts to make it work, I tried to be not very invasive.

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on:

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

---

### Testing <!-- OPTIONAL -->

* [ ] Added tests
* [x] Manual testing performed

[See failure ](https://treeherder.mozilla.org/logviewer?job_id=561992883&repo=enterprise-firefox-pr&task=bLBbivxBTK2vjVCpceVgAw.0&lineNumber=62806)
[See test with the changes(updated to latest run)](https://treeherder.mozilla.org/logviewer?job_id=562660440&repo=enterprise-firefox-pr&task=U9bIeDDgQuuNzttSjO0w_Q.0&lineNumber=79878)
[Marionette test that was modified, also passing](https://treeherder.mozilla.org/logviewer?job_id=562660363&repo=enterprise-firefox-pr&task=eYtZTi3nT-mUE2bAt1QOnA.0&lineNumber=4000)

<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
