### PR TITLE
Bug 2034430 - Disable Firefox Relay feature in enterprise builds

### DIFF
--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -2974,7 +2974,12 @@ pref("browser.migrate.preferences-entrypoint.enabled", true);
 // "offered"        - we have offered feature to user and they have not yet made a decision.
 // "enabled"        - user opted in to the feature.
 // "disabled"       - user opted out of the feature.
+#ifdef MOZ_ENTERPRISE
+// Firefox Relay is not supported in enterprise builds
+pref("signon.firefoxRelay.feature", "unavailable");
+#else
 pref("signon.firefoxRelay.feature", "available");
+#endif
 pref("signon.management.page.breach-alerts.enabled", true);
 pref("signon.management.page.vulnerable-passwords.enabled", true);
 pref("signon.management.page.sort", "name");

--- a/toolkit/components/passwordmgr/test/browser/browser.toml
+++ b/toolkit/components/passwordmgr/test/browser/browser.toml
@@ -282,17 +282,25 @@ skip-if = [
   "os == 'win' && os_version == '11.26200' && verify-standalone",
 ]
 
+["browser_relay_disabled_enterprise.js"]
+support-files = ["browser_relay_utils.js"]
+run-if = ["enterprise"]
+
 ["browser_relay_signup_flow.js"]
 support-files = ["browser_relay_utils.js"]
+skip-if = ["enterprise"]
 
 ["browser_relay_signup_flow_showToAllBrowsers.js"]
 support-files = ["browser_relay_utils.js"]
+skip-if = ["enterprise"]
 
 ["browser_relay_telemetry.js"]
 support-files = ["browser_relay_utils.js"]
+skip-if = ["enterprise"]
 
 ["browser_relay_use.js"]
 support-files = ["browser_relay_utils.js"]
+skip-if = ["enterprise"]
 
 ["browser_telemetry_SignUpFormRuleset.js"]
 

--- a/toolkit/components/passwordmgr/test/browser/browser_relay_disabled_enterprise.js
+++ b/toolkit/components/passwordmgr/test/browser/browser_relay_disabled_enterprise.js
@@ -1,0 +1,50 @@
+const TEST_URL_PATH = `https://example.org${DIRECTORY_PATH}form_basic_signup.html`;
+
+Services.scriptloader.loadSubScript(
+  "chrome://mochitests/content/browser/toolkit/components/passwordmgr/test/browser/browser_relay_utils.js",
+  this
+);
+
+add_task(async function test_enterprise_relay_feature_default_disabled() {
+  Assert.equal(
+    Services.prefs
+      .getDefaultBranch("")
+      .getStringPref("signon.firefoxRelay.feature"),
+    "unavailable",
+    "signon.firefoxRelay.feature default should be 'unavailable' in enterprise builds"
+  );
+});
+
+add_task(async function test_enterprise_relay_utils_reports_disabled() {
+  const { FirefoxRelayUtils } = ChromeUtils.importESModule(
+    "resource://gre/modules/FirefoxRelayUtils.sys.mjs"
+  );
+
+  Assert.ok(
+    !FirefoxRelayUtils.relayIsAvailableOrEnabled(),
+    "FirefoxRelayUtils.relayIsAvailableOrEnabled() should return false when feature is disabled"
+  );
+});
+
+add_task(
+  async function test_enterprise_relay_autocomplete_not_shown_when_disabled() {
+    const rsSandbox = await stubRemoteSettingsAllowList();
+    await BrowserTestUtils.withNewTab(
+      {
+        gBrowser,
+        url: TEST_URL_PATH,
+      },
+      async function (browser) {
+        const popup = document.getElementById("PopupAutoComplete");
+        await openACPopup(popup, browser, "#form-basic-username");
+
+        const relayItem = getRelayItemFromACPopup(popup);
+        Assert.ok(
+          !relayItem,
+          "Relay item SHOULD NOT be present in the autocomplete popup when the feature is disabled"
+        );
+      }
+    );
+    rsSandbox.restore();
+  }
+);


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2034430

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

This PR does the following:
- Sets the signon.firefoxRelay.feature pref default to "disabled" (instead of "available") in enterprise builds via #ifdef MOZ_ENTERPRISE in firefox.js
  - Skips the existing Relay browser tests (browser_relay_signup_flow.js, browser_relay_signup_flow_showToAllBrowsers.js, browser_relay_telemetry.js,
  browser_relay_use.js) on enterprise builds since they assume the feature is available
  - Adds a new enterprise-only test (browser_relay_disabled_enterprise.js) that verifies:
    - The default pref value is "disabled"
    - FirefoxRelayUtils.relayIsAvailableOrEnabled() returns false
    - The Relay autocomplete item does not appear in the password popup

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on:

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

---

### Testing <!-- OPTIONAL -->

* [x] Added tests
* [x] Manual testing performed

[See issue](https://treeherder.mozilla.org/logviewer?job_id=561992871&repo=enterprise-firefox-pr&task=Hw735vkiTPyRoyuwAWb97g.0&lineNumber=196211)
[Here with the changes, passing](https://treeherder.mozilla.org/logviewer?job_id=562024511&repo=enterprise-firefox-pr&task=OyOP9BifRG6eMaQTnO2Uzw.0&lineNumber=187484)
<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
