### PR TITLE
Bug 2034457: Fix xpc telemetry tests for enterprise builds by unlocking toolkit.telemetry.server and using MOZ_TELEMETRY_REPORTING

### DIFF
--- a/toolkit/components/telemetry/tests/unit/head.js
+++ b/toolkit/components/telemetry/tests/unit/head.js
@@ -544,6 +544,20 @@ function getDateInSeconds(date) {
   return Math.floor(date / MS_IN_SEC);
 }
 
+// Enterprise builds lock toolkit.telemetry.server. Unlock it so tests can
+// point to a local server.
+add_setup(function () {
+  if (
+    AppConstants.MOZ_ENTERPRISE &&
+    Services.prefs.prefIsLocked("toolkit.telemetry.server")
+  ) {
+    Services.prefs.unlockPref("toolkit.telemetry.server");
+    registerCleanupFunction(() => {
+      Services.prefs.lockPref("toolkit.telemetry.server");
+    });
+  }
+});
+
 if (runningInParent) {
   // Set logging preferences for all the tests.
   Services.prefs.setCharPref("toolkit.telemetry.log.level", "Trace");

--- a/toolkit/components/telemetry/tests/unit/test_TelemetrySend.js
+++ b/toolkit/components/telemetry/tests/unit/test_TelemetrySend.js
@@ -885,8 +885,17 @@ add_task(async function test_sendCheckOverride() {
   await TelemetryController.testReset();
 
   // Submit a test ping and make sure it doesn't get sent. We only do
-  // that if we're on unofficial builds: pings will always get sent otherwise.
-  if (!Services.telemetry.isOfficialTelemetry) {
+  // that if setTestModeEnabled(false) can actually block sends. In enterprise
+  // builds, sendingEnabled() uses MOZ_TELEMETRY_REPORTING instead of
+  // isOfficialTelemetry, so the test mode flag has no effect when
+  // MOZ_TELEMETRY_REPORTING is true.
+  // Mimicking the checkPassed logic in TelemetrySend.sys.mjs:
+  // https://searchfox.org/enterprise-main/rev/1341260d60d8c0f3f20e8baf7c6e51de31dba2a0/toolkit/components/telemetry/app/TelemetrySend.sys.mjs#1607
+  const canBlockSending = AppConstants.MOZ_ENTERPRISE
+    ? !AppConstants.MOZ_TELEMETRY_REPORTING
+    : !Services.telemetry.isOfficialTelemetry;
+
+  if (canBlockSending) {
     TelemetrySend.setTestModeEnabled(false);
     PingServer.registerPingHandler(() =>
       Assert.ok(false, "Should not have received any pings now")

--- a/toolkit/components/telemetry/tests/unit/test_TelemetrySession.js
+++ b/toolkit/components/telemetry/tests/unit/test_TelemetrySession.js
@@ -213,8 +213,10 @@ function checkPayloadInfo(data, reason) {
 
   // Check for a valid revision.
   if (data.revision != "") {
-    const revisionUrlRegEx =
-      /^http[s]?:\/\/hg.mozilla.org(\/[a-z\S]+)+(\/rev\/[0-9a-z]+)$/g;
+    // Enterprise builds may use a GitHub repo, producing /commit/ URLs (see build/variables.py).
+    const revisionUrlRegEx = AppConstants.MOZ_ENTERPRISE
+      ? /^http[s]?:\/\/(hg.mozilla.org(\/[a-z\S]+)+(\/rev\/[0-9a-z]+)|github.com(\/[a-z\S]+)+(\/commit\/[0-9a-z]+))$/g
+      : /^http[s]?:\/\/hg.mozilla.org(\/[a-z\S]+)+(\/rev\/[0-9a-z]+)$/g;
     Assert.ok(revisionUrlRegEx.test(data.revision));
   }
 


### PR DESCRIPTION

<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2034457

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->



The tests ```MOZ_BYPASS_FELT=1  ./mach xpcshell-test toolkit/components/telemetry/tests/unit/```

Have currently few issues ( addressed in this PR). I unlocked the prefs they need + I mimicked the logic we use in https://searchfox.org/enterprise-main/diff/8f4c3107f2df67e7f6a28aa18579f527b4e04d9e/toolkit/components/telemetry/app/TelemetrySend.sys.mjs#1608


Fixes
```
TEST-UNEXPECTED-TIMEOUT | toolkit/components/telemetry/tests/unit/test_TelemetrySend.js | Test timed out
TEST-UNEXPECTED-FAIL | toolkit/components/telemetry/tests/unit/test_TelemetrySession.js | xpcshell return code: 0
TEST-UNEXPECTED-TIMEOUT | toolkit/components/telemetry/tests/unit/test_HealthPing.js | Test timed out
TEST-UNEXPECTED-TIMEOUT | toolkit/components/telemetry/tests/unit/test_TelemetryReportingPolicy.js | Test timed out
TEST-UNEXPECTED-TIMEOUT | toolkit/components/telemetry/tests/unit/test_TelemetryClientID_reset.js | Test timed out
TEST-UNEXPECTED-TIMEOUT | toolkit/components/telemetry/tests/unit/test_TelemetrySession_abortedSessionQueued.js | Test timed out
TEST-UNEXPECTED-TIMEOUT | toolkit/components/telemetry/tests/unit/test_TelemetryController.js | Test timed out
TEST-UNEXPECTED-TIMEOUT | toolkit/components/telemetry/tests/unit/test_TelemetrySendOldPings.js | Test timed out
```


---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on:

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

---

### Testing <!-- OPTIONAL -->

* [ ] Added tests
* [x] Manual testing performed

All tests are currently broken and creating [big logs](https://treeherder.mozilla.org/jobs?repo=enterprise-firefox-pr&fromchange=eb5ff768346e489377daeffab95688a458eace12&selectedTaskRun=dptkwA7DQ2Kp0Wq0nVMjbQ.0) i.e link to [400mb](https://firefox-ci-tc.services.mozilla.com/api/queue/v1/task/dptkwA7DQ2Kp0Wq0nVMjbQ/runs/0/artifacts/public/logs/live_backing.log)
Here with the fixes [link](https://treeherder.mozilla.org/logviewer?job_id=562055434&repo=enterprise-firefox-pr&task=OJIaEx7CSyK4_jW_LxD3qw.0&lineNumber=8456) filter for "toolkit/components/telemetry/tests/unit/"

<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
