### PR TITLE
Bug 2034765: Expose glean telemetry dictionary in a standardized format

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1348,6 +1348,10 @@ build/pgo/blueprint/**/*.css
 # Ignore web-platform tests as they are not necessarily under our control.
 testing/web-platform/tests/
 
+# These are vendored from https://github.com/open-telemetry/weaver/blob/173fed70c05bf9c7833f59f80aae09642ac05114/schemas/
+toolkit/components/glean/build_scripts/semconv/schemas/publication-manifest.v2.json
+toolkit/components/glean/build_scripts/semconv/schemas/semconv.resolved.v2.json
+
 ##############################################################################
 # The list below is copied from ThirdPartyPaths.txt. Prettier doesn't currently
 # support multiple ignore files or dynamic ignore configurations.

--- a/taskcluster/config.yml
+++ b/taskcluster/config.yml
@@ -209,6 +209,7 @@ treeherder:
         'updt-tst': 'Test updates to release from older firefox versions'
         'Rpk-Ent': 'Enterprise repacks'
         'Rpk-Ent-Rpk': 'Enterprise repacks repackage'
+        'Glean': 'Glean tooling'
         'Rpk': 'Classic repacks'
         'MSI-Ent': "MSI Enterprise repacks"
         'MSIs-Ent': "MSI signed Enterprise repacks"

--- a/taskcluster/docs/kinds.rst
+++ b/taskcluster/docs/kinds.rst
@@ -977,3 +977,10 @@ Mac notarization of customized versions of releases for enterprises.
 enterprise-repack-mac-signing
 ----------------------------------
 Mac signature of customized versions of releases for enterprises.
+
+glean
+-----
+Tasks that run ``./mach glean`` utilities. The ``semconv`` task produces the
+resolved OTel semantic convention registry schema from Firefox Glean metric
+definitions, consumed by the ``moa generate release``
+tool.

--- a/taskcluster/kinds/glean/kind.yml
+++ b/taskcluster/kinds/glean/kind.yml
@@ -1,0 +1,48 @@
+---
+loader: taskgraph.loader.transform:loader
+
+transforms:
+    - gecko_taskgraph.transforms.job:transforms
+    - gecko_taskgraph.transforms.task:transforms
+
+kind-dependencies:
+    - toolchain
+    - fetch
+
+tasks:
+    semconv:
+        description: >-
+            Generate the resolved OTel semantic convention registry schema from
+            Firefox Glean metric definitions. The resulting resolved.yaml is
+            consumed by the `moa generate release` tool, which embeds it as a
+            semconv referrer artifact on Harbor.
+        run-on-projects: ["enterprise-firefox"]
+        run-on-repo-type: ["git"]
+        worker-type: b-linux
+        worker:
+            docker-image: {in-tree: "lint"}
+            max-run-time: 1800
+            artifacts:
+                - type: file
+                  name: public/build/resolved.yaml
+                  path: /builds/worker/artifacts/resolved.yaml
+                - type: file
+                  name: public/build/manifest.yaml
+                  path: /builds/worker/artifacts/manifest.yaml
+        run:
+            using: mach
+            mach: "glean semconv --output-dir /builds/worker/artifacts"
+            use-caches: [checkout, pip, uv]
+        attributes:
+            shippable: true
+        shipping-phase: build
+        shipping-product: firefox-enterprise
+        index:
+            product: firefox
+            job-name: glean-semconv
+            type: shippable
+        treeherder:
+            symbol: Glean(semconv)
+            kind: build
+            platform: linux64/opt
+            tier: 1

--- a/toolkit/components/glean/build_scripts/mach_commands.py
+++ b/toolkit/components/glean/build_scripts/mach_commands.py
@@ -386,6 +386,28 @@ def glean_source(command_context, cargo_toml, content, patch=None):
     )
 
 
+@SubCommand(
+    "glean",
+    "semconv",
+    description="Convert parsed Glean metrics into a resolved OTel semconv registry schema.",
+)
+@CommandArgument(
+    "--output-dir",
+    type=str,
+    default=None,
+    help="Directory to write resolved.yaml and manifest.yaml into.",
+)
+def glean_semconv(command_context, output_dir=None):
+    import sys
+
+    COMPONENT_DIR = Path(__file__).parent.resolve()
+    sys.path.insert(0, str(COMPONENT_DIR))
+
+    from semconv import run
+
+    run(output_dir=Path(output_dir) if output_dir else None)
+
+
 def run_mach(command_context, cmd, **kwargs):
     return command_context._mach_context.commands.dispatch(
         cmd, command_context._mach_context, **kwargs

--- a/toolkit/components/glean/build_scripts/semconv/__init__.py
+++ b/toolkit/components/glean/build_scripts/semconv/__init__.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 import yaml
-from buildconfig import config, topsrcdir
+from buildconfig import topsrcdir
 from glean_parser import parser
 from jsonschema import Draft202012Validator
 
@@ -120,7 +120,17 @@ class OtelEvent:
 def run(output_dir: Path | None = None):
     input_files = load_metrics_index()
 
-    moz_app_version = config.substs.get("MOZ_APP_VERSION", "1")
+    # Read MOZ_APP_VERSION directly from browser/config/version.txt rather than
+    # via buildconfig.config.substs, so this command can be run in CI without
+    # requiring a prior `./mach configure` step (which would need the full
+    # build toolchain). `browser/config/version.txt` is Firefox's authoritative
+    # source for the application version and is always present in the tree.
+    try:
+        moz_app_version = (
+            TOP_SRC_DIR / "browser" / "config" / "version.txt"
+        ).read_text().strip()
+    except OSError:
+        moz_app_version = "1"
     app_version_major = moz_app_version.split(".", 1)[0]
 
     res = parser.parse_objects(

--- a/toolkit/components/glean/build_scripts/semconv/__init__.py
+++ b/toolkit/components/glean/build_scripts/semconv/__init__.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+from buildconfig import config, topsrcdir
+from glean_parser import parser
+from jsonschema import Draft202012Validator
+
+TOP_SRC_DIR = Path(topsrcdir)
+
+V2_RESOLVED_FILE_FORMAT = "resolved/2.0.0"
+V2_MANIFEST_FILE_FORMAT = "manifest/2.0.0"
+SCHEMA_URL = "https://mozilla.org/schemas/glean/semconv"
+
+SCHEMA_PATH = Path(__file__).parent / "schemas" / "semconv.resolved.v2.json"
+MANIFEST_SCHEMA_PATH = (
+    Path(__file__).parent / "schemas" / "publication-manifest.v2.json"
+)
+
+GLEAN_TYPE_TO_OTEL_TYPE = {
+    "string": "string",
+    "boolean": "boolean",
+    "quantity": "int",
+    "counter": "int",
+    "timespan": "int",
+    "timing_distribution": "int",
+    "memory_distribution": "int",
+    "custom_distribution": "int",
+    "rate": "double",
+    "uuid": "string",
+    "url": "string",
+    "datetime": "string",
+    "text": "string",
+    "object": "string",
+    "denominator": "int",
+    "labeled_boolean": "boolean",
+    "labeled_string": "string",
+    "labeled_counter": "int",
+    "string_list": "string[]",
+}
+
+
+@dataclass
+class CatalogAttribute:
+    key: str
+    type: str
+    brief: str
+    stability: str = "development"
+    note: str | None = None
+
+    def to_dict(self) -> dict:
+        d: dict = {
+            "key": self.key,
+            "type": self.type,
+            "brief": self.brief,
+            "stability": self.stability,
+        }
+        if self.note:
+            d["note"] = self.note
+        return d
+
+
+class AttributeCatalog:
+    def __init__(self):
+        self._attrs: list[CatalogAttribute] = []
+        self._index: dict[str, int] = {}
+
+    def get_or_add(self, attr: CatalogAttribute) -> int:
+        if attr.key in self._index:
+            return self._index[attr.key]
+        idx = len(self._attrs)
+        self._attrs.append(attr)
+        self._index[attr.key] = idx
+        return idx
+
+    def to_list(self) -> list[dict]:
+        return [a.to_dict() for a in self._attrs]
+
+    def all_indices(self) -> list[int]:
+        return list(range(len(self._attrs)))
+
+
+@dataclass
+class EventAttributeRef:
+    base: int
+    requirement_level: str = "recommended"
+
+    def to_dict(self) -> dict:
+        return {
+            "base": self.base,
+            "requirement_level": self.requirement_level,
+        }
+
+
+@dataclass
+class OtelEvent:
+    name: str
+    brief: str
+    stability: str = "development"
+    note: str = ""
+    attributes: list[EventAttributeRef] = field(default_factory=list)
+
+    def to_registry_dict(self) -> dict:
+        d: dict = {
+            "name": self.name,
+            "brief": self.brief,
+            "stability": self.stability,
+        }
+        if self.note:
+            d["note"] = self.note
+        if self.attributes:
+            d["attributes"] = [a.to_dict() for a in self.attributes]
+        return d
+
+
+def run(output_dir: Path | None = None):
+    input_files = load_metrics_index()
+
+    moz_app_version = config.substs.get("MOZ_APP_VERSION", "1")
+    app_version_major = moz_app_version.split(".", 1)[0]
+
+    res = parser.parse_objects(
+        input_files,
+        {"expire_by_version": int(app_version_major), "interesting": input_files},
+    )
+
+    for err in res:
+        print(err)
+    objs = res.value
+
+    catalog, events = convert_glean_events(objs)
+    resolved = build_resolved_registry(catalog, events)
+
+    errors = validate_against_schema(resolved, SCHEMA_PATH)
+    if errors:
+        print(
+            f"Resolved schema validation found {len(errors)} error(s):",
+            file=sys.stderr,
+        )
+        for e in errors:
+            print(f"  - {e}", file=sys.stderr)
+        sys.exit(1)
+
+    print(
+        f"Schema validation passed. {len(events)} events converted, {len(catalog.to_list())} attributes cataloged."
+    )
+
+    if output_dir is None:
+        output_dir = (
+            TOP_SRC_DIR
+            / "toolkit"
+            / "components"
+            / "glean"
+            / "build_scripts"
+            / "semconv"
+            / "output"
+        )
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    resolved_path = output_dir / "resolved.yaml"
+    manifest_path = output_dir / "manifest.yaml"
+
+    manifest = build_manifest(resolved_path.name)
+
+    with open(resolved_path, "w") as f:
+        yaml.dump(
+            resolved, f, default_flow_style=False, sort_keys=False, allow_unicode=True
+        )
+
+    with open(manifest_path, "w") as f:
+        yaml.dump(
+            manifest, f, default_flow_style=False, sort_keys=False, allow_unicode=True
+        )
+
+    manifest_errors = validate_against_schema(manifest, MANIFEST_SCHEMA_PATH)
+    if manifest_errors:
+        print(
+            f"Manifest schema validation found {len(manifest_errors)} error(s):",
+            file=sys.stderr,
+        )
+        for e in manifest_errors:
+            print(f"  - {e}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Wrote {resolved_path}")
+    print(f"Wrote {manifest_path}")
+
+
+def load_metrics_index():
+    index = TOP_SRC_DIR / "toolkit" / "components" / "glean" / "metrics_index.py"
+
+    with open(index) as f:
+        index_src = f.read()
+
+    namespace = {}
+    exec(index_src, namespace)
+
+    return [TOP_SRC_DIR / x for x in namespace["metrics_yamls"]]
+
+
+def convert_glean_events(objs) -> tuple[AttributeCatalog, list[OtelEvent]]:
+    catalog = AttributeCatalog()
+    events: list[OtelEvent] = []
+
+    for category_name, category_metrics in sorted(objs.items()):
+        for metric in sorted(category_metrics.values(), key=lambda m: m.identifier()):
+            if metric.type != "event":
+                continue
+
+            event_name = metric.identifier()
+            brief = metric.description.strip() if metric.description else event_name
+
+            attr_refs: list[EventAttributeRef] = []
+            if hasattr(metric, "extra_keys") and metric.extra_keys:
+                for key_name, key_info in sorted(metric.extra_keys.items()):
+                    glean_type = (
+                        key_info.get("type", "string")
+                        if isinstance(key_info, dict)
+                        else "string"
+                    )
+                    otel_type = glean_extra_key_type_to_otel(glean_type)
+                    key_desc = ""
+                    if isinstance(key_info, dict):
+                        key_desc = key_info.get("description", "").strip()
+
+                    attr_key = f"{event_name}.{key_name}"
+                    cat_attr = CatalogAttribute(
+                        key=attr_key,
+                        type=otel_type,
+                        brief=key_desc or attr_key,
+                        stability="development",
+                    )
+                    idx = catalog.get_or_add(cat_attr)
+                    attr_refs.append(
+                        EventAttributeRef(base=idx, requirement_level="recommended")
+                    )
+
+            otel_event = OtelEvent(
+                name=event_name,
+                brief=brief,
+                stability="development",
+                attributes=attr_refs,
+            )
+            events.append(otel_event)
+
+    return catalog, events
+
+
+def glean_extra_key_type_to_otel(glean_type: str) -> str:
+    return GLEAN_TYPE_TO_OTEL_TYPE.get(glean_type, "string")
+
+
+def build_resolved_registry(catalog: AttributeCatalog, events: list[OtelEvent]):
+    registry_events = [e.to_registry_dict() for e in events]
+
+    return {
+        "file_format": V2_RESOLVED_FILE_FORMAT,
+        "schema_url": {"url": SCHEMA_URL},
+        "attribute_catalog": catalog.to_list(),
+        "registry": {
+            "attributes": catalog.all_indices(),
+            "attribute_groups": [],
+            "spans": [],
+            "metrics": [],
+            "events": registry_events,
+            "entities": [],
+        },
+        "refinements": {
+            "spans": [],
+            "metrics": [],
+            "events": [],
+        },
+    }
+
+
+def validate_against_schema(instance, schema_path: Path) -> list[str]:
+    if not schema_path.exists():
+        return [f"Schema file not found: {schema_path}"]
+
+    with open(schema_path) as f:
+        schema = json.load(f)
+
+    validator = Draft202012Validator(schema)
+    errors = []
+    for error in sorted(
+        validator.iter_errors(instance), key=lambda e: list(e.absolute_path)
+    ):
+        errors.append(
+            f"{'.'.join(str(p) for p in error.absolute_path)}: {error.message}"
+        )
+    return errors
+
+
+def build_manifest(resolved_schema_uri: str) -> dict:
+    return {
+        "file_format": V2_MANIFEST_FILE_FORMAT,
+        "schema_url": {"url": SCHEMA_URL},
+        "resolved_schema_uri": resolved_schema_uri,
+        "stability": "development",
+    }

--- a/toolkit/components/glean/build_scripts/semconv/__init__.py
+++ b/toolkit/components/glean/build_scripts/semconv/__init__.py
@@ -1,3 +1,7 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 from __future__ import annotations
 
 import json

--- a/toolkit/components/glean/build_scripts/semconv/__init__.py
+++ b/toolkit/components/glean/build_scripts/semconv/__init__.py
@@ -44,7 +44,7 @@ GLEAN_TYPE_TO_OTEL_TYPE = {
 }
 
 
-@dataclass
+@dataclass(frozen=True)
 class CatalogAttribute:
     key: str
     type: str
@@ -67,14 +67,14 @@ class CatalogAttribute:
 class AttributeCatalog:
     def __init__(self):
         self._attrs: list[CatalogAttribute] = []
-        self._index: dict[str, int] = {}
+        self._index: dict[CatalogAttribute, int] = {}
 
     def get_or_add(self, attr: CatalogAttribute) -> int:
-        if attr.key in self._index:
-            return self._index[attr.key]
+        if attr in self._index:
+            return self._index[attr]
         idx = len(self._attrs)
         self._attrs.append(attr)
-        self._index[attr.key] = idx
+        self._index[attr] = idx
         return idx
 
     def to_list(self) -> list[dict]:
@@ -120,15 +120,14 @@ class OtelEvent:
 def run(output_dir: Path | None = None):
     input_files = load_metrics_index()
 
-    # Read MOZ_APP_VERSION directly from browser/config/version.txt rather than
-    # via buildconfig.config.substs, so this command can be run in CI without
-    # requiring a prior `./mach configure` step (which would need the full
-    # build toolchain). `browser/config/version.txt` is Firefox's authoritative
-    # source for the application version and is always present in the tree.
+    # We read the MOZ_APP_VERSION directly from browser/config/version.txt rather
+    # rather than via buildconfig.config.substs, so this command can be run in CI
+    # without requiring a prior `./mach configure` step (which would need the full
+    # build toolchain).
     try:
         moz_app_version = (
-            TOP_SRC_DIR / "browser" / "config" / "version.txt"
-        ).read_text().strip()
+            (TOP_SRC_DIR / "browser" / "config" / "version.txt").read_text().strip()
+        )
     except OSError:
         moz_app_version = "1"
     app_version_major = moz_app_version.split(".", 1)[0]
@@ -179,13 +178,15 @@ def run(output_dir: Path | None = None):
 
     with open(resolved_path, "w") as f:
         yaml.dump(
-            resolved, f, default_flow_style=False, sort_keys=False, allow_unicode=True
+            resolved,
+            f,
+            Dumper=_LiteralBlockDumper,
+            sort_keys=False,
+            allow_unicode=True,
         )
 
     with open(manifest_path, "w") as f:
-        yaml.dump(
-            manifest, f, default_flow_style=False, sort_keys=False, allow_unicode=True
-        )
+        yaml.dump(manifest, f, sort_keys=False, allow_unicode=True)
 
     manifest_errors = validate_against_schema(manifest, MANIFEST_SCHEMA_PATH)
     if manifest_errors:
@@ -222,29 +223,23 @@ def convert_glean_events(objs) -> tuple[AttributeCatalog, list[OtelEvent]]:
             if metric.type != "event":
                 continue
 
-            event_name = metric.identifier()
-            brief = metric.description.strip() if metric.description else event_name
+            event_name = f"{category_name}.{metric.name}"
 
             attr_refs: list[EventAttributeRef] = []
             if hasattr(metric, "extra_keys") and metric.extra_keys:
                 for key_name, key_info in sorted(metric.extra_keys.items()):
-                    glean_type = (
-                        key_info.get("type", "string")
-                        if isinstance(key_info, dict)
-                        else "string"
-                    )
-                    otel_type = glean_extra_key_type_to_otel(glean_type)
-                    key_desc = ""
-                    if isinstance(key_info, dict):
-                        key_desc = key_info.get("description", "").strip()
-
-                    attr_key = f"{event_name}.{key_name}"
+                    glean_type = key_info.get("type", "string")
+                    otel_type = GLEAN_TYPE_TO_OTEL_TYPE.get(glean_type, "string")
+                    key_desc = key_info.get("description", "").strip()
+                    if "Why the SERP is deemed abandoned" in key_desc:
+                        print(key_info.get("description", ""))
                     cat_attr = CatalogAttribute(
-                        key=attr_key,
+                        key=key_name,
                         type=otel_type,
-                        brief=key_desc or attr_key,
+                        brief=key_desc,
                         stability="development",
                     )
+
                     idx = catalog.get_or_add(cat_attr)
                     attr_refs.append(
                         EventAttributeRef(base=idx, requirement_level="recommended")
@@ -252,17 +247,13 @@ def convert_glean_events(objs) -> tuple[AttributeCatalog, list[OtelEvent]]:
 
             otel_event = OtelEvent(
                 name=event_name,
-                brief=brief,
+                brief=metric.description.strip(),
                 stability="development",
                 attributes=attr_refs,
             )
             events.append(otel_event)
 
     return catalog, events
-
-
-def glean_extra_key_type_to_otel(glean_type: str) -> str:
-    return GLEAN_TYPE_TO_OTEL_TYPE.get(glean_type, "string")
 
 
 def build_resolved_registry(catalog: AttributeCatalog, events: list[OtelEvent]):
@@ -304,6 +295,19 @@ def validate_against_schema(instance, schema_path: Path) -> list[str]:
             f"{'.'.join(str(p) for p in error.absolute_path)}: {error.message}"
         )
     return errors
+
+
+class _LiteralBlockDumper(yaml.Dumper):
+    pass
+
+
+def _str_representer(dumper, data):
+    if "\n" in data:
+        return dumper.represent_scalar("tag:yaml.org,2002:str", data, style="|")
+    return dumper.represent_scalar("tag:yaml.org,2002:str", data)
+
+
+_LiteralBlockDumper.add_representer(str, _str_representer)
 
 
 def build_manifest(resolved_schema_uri: str) -> dict:

--- a/toolkit/components/glean/build_scripts/semconv/schemas/publication-manifest.v2.json
+++ b/toolkit/components/glean/build_scripts/semconv/schemas/publication-manifest.v2.json
@@ -1,0 +1,124 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "PublicationRegistryManifest",
+  "description": "Represents the publication manifest for a packaged semantic convention registry.\n\nThis is produced by `weaver registry package` and describes the contents of\na self-contained registry artifact, including its resolved schema location.",
+  "type": "object",
+  "properties": {
+    "dependencies": {
+      "description": "List of the registry's dependencies.",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Dependency"
+      }
+    },
+    "description": {
+      "description": "An optional description of the registry.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "file_format": {
+      "description": "The file format version of this publication manifest.\nAlways `\"manifest/2.0.0\"`in this version.",
+      "type": "string",
+      "const": "manifest/2.0.0"
+    },
+    "resolved_schema_uri": {
+      "description": "URI pointing to the resolved telemetry schema included in this package.",
+      "type": "string"
+    },
+    "schema_url": {
+      "description": "The schema URL for this registry.\nUniquely identifies the registry and its version.",
+      "$ref": "#/$defs/SchemaUrl"
+    },
+    "stability": {
+      "description": "The stability of this registry.",
+      "$ref": "#/$defs/Stability",
+      "default": "development"
+    }
+  },
+  "required": [
+    "file_format",
+    "schema_url",
+    "resolved_schema_uri"
+  ],
+  "$defs": {
+    "Dependency": {
+      "description": "Represents a dependency of a semantic convention registry.",
+      "type": "object",
+      "properties": {
+        "registry_path": {
+          "description": "The path to the dependency (optional).\nThis can be either:\n- A manifest of a published registry\n- A directory containing the raw definition.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VirtualDirectoryPath"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "schema_url": {
+          "description": "The schema URL for the dependency (required).\nIt must follow OTel schema URL format, which is: `http[s]://server[:port]/path/<version>`.\nThis is not necessarily the URL registry can be accessed at, but it provides\na unique identifier for the dependency registry and its version.\n\nWhen registry is not published yet, this field should be populated with a placeholder URL,\nbut it must follow the URL format and include a version segment.\nThe actual registry files can be provided in `registry_path` field.",
+          "$ref": "#/$defs/SchemaUrl"
+        }
+      },
+      "required": [
+        "schema_url"
+      ]
+    },
+    "SchemaUrl": {
+      "description": "Represents the schema URL of a registry, which serves as a unique identifier for the registry\nalong with its version.",
+      "type": "object",
+      "properties": {
+        "url": {
+          "description": "The schema URL string.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "url"
+      ]
+    },
+    "Stability": {
+      "description": "The level of stability for a definition. Defined in [OTEP-232](https://github.com/open-telemetry/oteps/blob/main/text/0232-maturity-of-otel.md)",
+      "oneOf": [
+        {
+          "description": "A deprecated definition.",
+          "type": "string",
+          "const": "deprecated",
+          "deprecated": true
+        },
+        {
+          "description": "A stable definition.",
+          "type": "string",
+          "const": "stable"
+        },
+        {
+          "description": "A definition in development. Formally known as experimental.",
+          "type": "string",
+          "const": "development"
+        },
+        {
+          "description": "An alpha definition.",
+          "type": "string",
+          "const": "alpha"
+        },
+        {
+          "description": "A beta definition.",
+          "type": "string",
+          "const": "beta"
+        },
+        {
+          "description": "A release candidate definition.",
+          "type": "string",
+          "const": "release_candidate"
+        }
+      ]
+    },
+    "VirtualDirectoryPath": {
+      "description": "Represents a virtual path pointing to a directory-like resource.\n\nSupported formats include:\n- **Local directories** (`/path/to/directory`)\n- **Local archives** (`/path/to/archive.zip` or `/path/to/archive.tar.gz`)\n- **Remote archives** (`https://example.com/archive.zip` or `.tar.gz`)\n- **Git repositories** (`https://github.com/user/repo.git`)\n\nPaths may optionally specify:\n- A sub-folder within the archive or repository via `[sub_folder]`\n- [Not Yet Implemented] A specific Git refspec (branch, tag, or commit) via `@refspec`",
+      "type": "string"
+    }
+  }
+}

--- a/toolkit/components/glean/build_scripts/semconv/schemas/semconv.resolved.v2.json
+++ b/toolkit/components/glean/build_scripts/semconv/schemas/semconv.resolved.v2.json
@@ -1,0 +1,1414 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ResolvedTelemetrySchema",
+  "description": "A Resolved Telemetry Schema.\nA Resolved Telemetry Schema is self-contained and doesn't contain any\nexternal references to other schemas or semantic conventions.",
+  "type": "object",
+  "properties": {
+    "attribute_catalog": {
+      "description": "Catalog of attributes. Note: this will include duplicates for the same key.",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/Attribute"
+      }
+    },
+    "file_format": {
+      "description": "Version of the file structure.",
+      "type": "string"
+    },
+    "refinements": {
+      "description": "Refinements for the registry",
+      "$ref": "#/$defs/Refinements"
+    },
+    "registry": {
+      "description": "The registry that this schema belongs to.",
+      "$ref": "#/$defs/Registry"
+    },
+    "schema_url": {
+      "description": "Schema URL that this file is published at.",
+      "$ref": "#/$defs/SchemaUrl"
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "file_format",
+    "schema_url",
+    "attribute_catalog",
+    "registry",
+    "refinements"
+  ],
+  "$defs": {
+    "Attribute": {
+      "description": "The definition of an Attribute.",
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "description": "Annotations for the attribute or signal.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/YamlValue"
+          }
+        },
+        "brief": {
+          "description": "A brief description of the attribute or signal.",
+          "type": "string"
+        },
+        "deprecated": {
+          "description": "Specifies if the semantic convention is deprecated. The string\nprovided as description MUST specify why it's deprecated and/or what\nto use instead. See also stability.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Deprecated"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "examples": {
+          "description": "Sequence of example values for the attribute or single example\nvalue. They are required only for string and string array\nattributes. Example values must be of the same type of the\nattribute. If only a single example is provided, it can directly\nbe reported without encapsulating it into a sequence/dictionary.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Examples"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "key": {
+          "description": "String that uniquely identifies the attribute.",
+          "type": "string"
+        },
+        "note": {
+          "description": "A more elaborate description of the attribute or signal.\nIt defaults to an empty string.",
+          "type": "string"
+        },
+        "stability": {
+          "description": "Specifies the stability of the attribute or signal.",
+          "$ref": "#/$defs/Stability"
+        },
+        "type": {
+          "description": "Either a string literal denoting the type as a primitive or an\narray type, a template type or an enum definition.",
+          "$ref": "#/$defs/AttributeType"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "key",
+        "type",
+        "brief",
+        "stability"
+      ]
+    },
+    "AttributeGroup": {
+      "description": "Public attribute group.\n\nAn attribute group is a grouping of attributes that can be leveraged\nin codegen. For example, rather than passing attributes on at a time,\na temporary structure could be made to contain all of them and report\nthe bundle as a group to different signals.",
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "description": "Annotations for the attribute or signal.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/YamlValue"
+          }
+        },
+        "attributes": {
+          "description": "List of attributes and group references that belong to this group",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/AttributeRef"
+          }
+        },
+        "brief": {
+          "description": "A brief description of the attribute or signal.",
+          "type": "string"
+        },
+        "deprecated": {
+          "description": "Specifies if the semantic convention is deprecated. The string\nprovided as description MUST specify why it's deprecated and/or what\nto use instead. See also stability.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Deprecated"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "id": {
+          "description": "The name of the attribute group, must be unique.",
+          "$ref": "#/$defs/SignalId"
+        },
+        "note": {
+          "description": "A more elaborate description of the attribute or signal.\nIt defaults to an empty string.",
+          "type": "string"
+        },
+        "stability": {
+          "description": "Specifies the stability of the attribute or signal.",
+          "$ref": "#/$defs/Stability"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "attributes",
+        "brief",
+        "stability"
+      ]
+    },
+    "AttributeRef": {
+      "description": "Reference to an attribute in the catalog.",
+      "type": "integer",
+      "format": "uint32",
+      "minimum": 0
+    },
+    "AttributeType": {
+      "description": "The different types of attributes (specification).",
+      "anyOf": [
+        {
+          "description": "Primitive or array type.",
+          "$ref": "#/$defs/PrimitiveOrArrayTypeSpec"
+        },
+        {
+          "description": "A template type.",
+          "$ref": "#/$defs/TemplateTypeSpec"
+        },
+        {
+          "description": "An enum definition type.",
+          "type": "object",
+          "properties": {
+            "members": {
+              "description": "List of enum entries.",
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/EnumEntriesSpec"
+              }
+            }
+          },
+          "required": [
+            "members"
+          ]
+        }
+      ]
+    },
+    "BasicRequirementLevelSpec": {
+      "description": "The different types of basic requirement levels.",
+      "oneOf": [
+        {
+          "description": "A required requirement level.",
+          "type": "string",
+          "const": "required"
+        },
+        {
+          "description": "An optional requirement level.",
+          "type": "string",
+          "const": "recommended"
+        },
+        {
+          "description": "An opt-in requirement level.",
+          "type": "string",
+          "const": "opt_in"
+        }
+      ]
+    },
+    "Deprecated": {
+      "description": "The different ways to deprecate an attribute, a metric, ...",
+      "oneOf": [
+        {
+          "description": "The telemetry object containing the deprecated field has been renamed to an\nexisting or a new telemetry object.",
+          "type": "object",
+          "properties": {
+            "note": {
+              "description": "The note to provide more context about the deprecation.",
+              "type": "string"
+            },
+            "reason": {
+              "type": "string",
+              "const": "renamed"
+            },
+            "renamed_to": {
+              "description": "The new name of the telemetry object.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "reason",
+            "renamed_to",
+            "note"
+          ]
+        },
+        {
+          "description": "The telemetry object containing the deprecated field has been obsoleted\nbecause it no longer exists and has no valid replacement.\n\nThe `brief` field should contain the reason why the field has been obsoleted.",
+          "type": "object",
+          "properties": {
+            "note": {
+              "description": "The note to provide more context about the deprecation.",
+              "type": "string"
+            },
+            "reason": {
+              "type": "string",
+              "const": "obsoleted"
+            }
+          },
+          "required": [
+            "reason",
+            "note"
+          ]
+        },
+        {
+          "description": "The telemetry object containing the deprecated field has been deprecated for\ncomplex reasons (split, merge, ...) which are currently not precisely defined\nin the supported deprecation reasons.\n\nThe `brief` field should contain the reason for this uncategorized deprecation.",
+          "type": "object",
+          "properties": {
+            "note": {
+              "description": "The note to provide more context about the deprecation.",
+              "type": "string"
+            },
+            "reason": {
+              "type": "string",
+              "const": "uncategorized"
+            }
+          },
+          "required": [
+            "reason",
+            "note"
+          ]
+        },
+        {
+          "description": "This variant is used to capture old, unstructured deprecated \"string\".\nUsed for backward-compatibility only.",
+          "type": "object",
+          "properties": {
+            "note": {
+              "description": "The note to provide more context about the deprecation.",
+              "type": "string"
+            },
+            "reason": {
+              "type": "string",
+              "const": "unspecified"
+            }
+          },
+          "required": [
+            "reason",
+            "note"
+          ]
+        }
+      ]
+    },
+    "Entity": {
+      "description": "The definition of an Entity signal.",
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "description": "Annotations for the attribute or signal.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/YamlValue"
+          }
+        },
+        "brief": {
+          "description": "A brief description of the attribute or signal.",
+          "type": "string"
+        },
+        "deprecated": {
+          "description": "Specifies if the semantic convention is deprecated. The string\nprovided as description MUST specify why it's deprecated and/or what\nto use instead. See also stability.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Deprecated"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "description": {
+          "description": "The attributes that make the description of the Entity.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/EntityAttributeRef"
+          }
+        },
+        "identity": {
+          "description": "The attributes that make the identity of the Entity.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/EntityAttributeRef"
+          }
+        },
+        "note": {
+          "description": "A more elaborate description of the attribute or signal.\nIt defaults to an empty string.",
+          "type": "string"
+        },
+        "stability": {
+          "description": "Specifies the stability of the attribute or signal.",
+          "$ref": "#/$defs/Stability"
+        },
+        "type": {
+          "description": "The type of the Entity.",
+          "$ref": "#/$defs/SignalId"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "identity",
+        "brief",
+        "stability"
+      ]
+    },
+    "EntityAttributeRef": {
+      "description": "A special type of reference to attributes that remembers entity-specicific information.",
+      "type": "object",
+      "properties": {
+        "base": {
+          "description": "Reference, by index, to the attribute catalog.",
+          "$ref": "#/$defs/AttributeRef"
+        },
+        "requirement_level": {
+          "description": "Specifies if the attribute is mandatory. Can be \"required\",\n\"conditionally_required\", \"recommended\" or \"opt_in\". When omitted,\nthe attribute is \"recommended\". When set to\n\"conditionally_required\", the string provided as `condition` MUST\nspecify the conditions under which the attribute is required.",
+          "$ref": "#/$defs/RequirementLevel"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "base",
+        "requirement_level"
+      ]
+    },
+    "EnumEntriesSpec": {
+      "description": "Possible enum entries.",
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "description": "Annotations for the member.",
+          "type": [
+            "object",
+            "null"
+          ],
+          "additionalProperties": {
+            "$ref": "#/$defs/YamlValue"
+          }
+        },
+        "brief": {
+          "description": "Brief description of the enum entry value.\nIt defaults to the value of id.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "deprecated": {
+          "description": "Deprecation note.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Deprecated"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "id": {
+          "description": "String that uniquely identifies the enum entry.",
+          "type": "string"
+        },
+        "note": {
+          "description": "Longer description.\nIt defaults to an empty string.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "stability": {
+          "description": "Stability of this enum value.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Stability"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "value": {
+          "description": "String, int, or boolean; value of the enum entry.",
+          "$ref": "#/$defs/ValueSpec"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "value"
+      ]
+    },
+    "Event": {
+      "description": "The definition of an Event signal.",
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "description": "Annotations for the attribute or signal.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/YamlValue"
+          }
+        },
+        "attributes": {
+          "description": "List of attributes that belong to this event.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/EventAttributeRef"
+          }
+        },
+        "brief": {
+          "description": "A brief description of the attribute or signal.",
+          "type": "string"
+        },
+        "deprecated": {
+          "description": "Specifies if the semantic convention is deprecated. The string\nprovided as description MUST specify why it's deprecated and/or what\nto use instead. See also stability.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Deprecated"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "entity_associations": {
+          "description": "Which entities this event should be associated with.\n\nThis list is an \"any of\" list, where a event may be associated with one or more entities, but should\nbe associated with at least one in this list.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "name": {
+          "description": "The name of the event.",
+          "$ref": "#/$defs/SignalId"
+        },
+        "note": {
+          "description": "A more elaborate description of the attribute or signal.\nIt defaults to an empty string.",
+          "type": "string"
+        },
+        "stability": {
+          "description": "Specifies the stability of the attribute or signal.",
+          "$ref": "#/$defs/Stability"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "brief",
+        "stability"
+      ]
+    },
+    "EventAttributeRef": {
+      "description": "A special type of reference to attributes that remembers event-specicific information.",
+      "type": "object",
+      "properties": {
+        "base": {
+          "description": "Reference, by index, to the attribute catalog.",
+          "$ref": "#/$defs/AttributeRef"
+        },
+        "requirement_level": {
+          "description": "Specifies if the attribute is mandatory. Can be \"required\",\n\"conditionally_required\", \"recommended\" or \"opt_in\". When omitted,\nthe attribute is \"recommended\". When set to\n\"conditionally_required\", the string provided as `condition` MUST\nspecify the conditions under which the attribute is required.",
+          "$ref": "#/$defs/RequirementLevel"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "base",
+        "requirement_level"
+      ]
+    },
+    "EventRefinement": {
+      "description": "A refinement of an event, for use in code-gen or specific library application.\n\nA refinement represents a \"view\" of a Event that is highly optimised for a particular implementation.\ne.g. for HTTP events, there may be a refinement that provides only the necessary information for dealing with Java's HTTP\nclient library, and drops optional or extraneous information from the underlying http event.",
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "description": "Annotations for the attribute or signal.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/YamlValue"
+          }
+        },
+        "attributes": {
+          "description": "List of attributes that belong to this event.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/EventAttributeRef"
+          }
+        },
+        "brief": {
+          "description": "A brief description of the attribute or signal.",
+          "type": "string"
+        },
+        "deprecated": {
+          "description": "Specifies if the semantic convention is deprecated. The string\nprovided as description MUST specify why it's deprecated and/or what\nto use instead. See also stability.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Deprecated"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "entity_associations": {
+          "description": "Which entities this event should be associated with.\n\nThis list is an \"any of\" list, where a event may be associated with one or more entities, but should\nbe associated with at least one in this list.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "id": {
+          "description": "The identity of the refinement",
+          "$ref": "#/$defs/SignalId"
+        },
+        "name": {
+          "description": "The name of the event.",
+          "$ref": "#/$defs/SignalId"
+        },
+        "note": {
+          "description": "A more elaborate description of the attribute or signal.\nIt defaults to an empty string.",
+          "type": "string"
+        },
+        "stability": {
+          "description": "Specifies the stability of the attribute or signal.",
+          "$ref": "#/$defs/Stability"
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "brief",
+        "stability"
+      ]
+    },
+    "Examples": {
+      "description": "The different types of examples.",
+      "anyOf": [
+        {
+          "description": "A boolean example.",
+          "type": "boolean"
+        },
+        {
+          "description": "A integer example.",
+          "type": "integer",
+          "format": "int64"
+        },
+        {
+          "description": "A double example.",
+          "type": "number",
+          "format": "double"
+        },
+        {
+          "description": "A string example.",
+          "type": "string"
+        },
+        {
+          "description": "A any example.",
+          "$ref": "#/$defs/ValueSpec"
+        },
+        {
+          "description": "A array of integers example.",
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        {
+          "description": "A array of doubles example.",
+          "type": "array",
+          "items": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        {
+          "description": "A array of bools example.",
+          "type": "array",
+          "items": {
+            "type": "boolean"
+          }
+        },
+        {
+          "description": "A array of strings example.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "description": "A array of anys example.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/ValueSpec"
+          }
+        },
+        {
+          "description": "List of arrays of integers example.",
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        },
+        {
+          "description": "List of arrays of doubles example.",
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "number",
+              "format": "double"
+            }
+          }
+        },
+        {
+          "description": "List of arrays of bools example.",
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "boolean"
+            }
+          }
+        },
+        {
+          "description": "List of arrays of strings example.",
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
+    "InstrumentSpec": {
+      "description": "The type of the metric.",
+      "oneOf": [
+        {
+          "description": "An up-down counter metric.",
+          "type": "string",
+          "const": "updowncounter"
+        },
+        {
+          "description": "A counter metric.",
+          "type": "string",
+          "const": "counter"
+        },
+        {
+          "description": "A gauge metric.",
+          "type": "string",
+          "const": "gauge"
+        },
+        {
+          "description": "A histogram metric.",
+          "type": "string",
+          "const": "histogram"
+        }
+      ]
+    },
+    "Metric": {
+      "description": "The definition of a metric signal.",
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "description": "Annotations for the attribute or signal.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/YamlValue"
+          }
+        },
+        "attributes": {
+          "description": "List of attributes that should be included on this metric.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/MetricAttributeRef"
+          }
+        },
+        "brief": {
+          "description": "A brief description of the attribute or signal.",
+          "type": "string"
+        },
+        "deprecated": {
+          "description": "Specifies if the semantic convention is deprecated. The string\nprovided as description MUST specify why it's deprecated and/or what\nto use instead. See also stability.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Deprecated"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "entity_associations": {
+          "description": "Which entities this metric should be associated with.\n\nThis list is an \"any of\" list, where a metric may be associated with one or more entities, but should\nbe associated with at least one in this list.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "instrument": {
+          "description": "The instrument type that should be used to record the metric. Note that\nthe semantic conventions must be written using the names of the\nsynchronous instrument types (counter, gauge, updowncounter and\nhistogram).\nFor more details: [Metrics semantic conventions - Instrument types](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/metrics/semantic_conventions#instrument-types).",
+          "$ref": "#/$defs/InstrumentSpec"
+        },
+        "name": {
+          "description": "The name of the metric.",
+          "$ref": "#/$defs/SignalId"
+        },
+        "note": {
+          "description": "A more elaborate description of the attribute or signal.\nIt defaults to an empty string.",
+          "type": "string"
+        },
+        "stability": {
+          "description": "Specifies the stability of the attribute or signal.",
+          "$ref": "#/$defs/Stability"
+        },
+        "unit": {
+          "description": "The unit in which the metric is measured, which should adhere to the\n[guidelines](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/metrics/semantic_conventions#instrument-units).",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "instrument",
+        "unit",
+        "brief",
+        "stability"
+      ]
+    },
+    "MetricAttributeRef": {
+      "description": "A special type of reference to attributes that remembers metric-specicific information.",
+      "type": "object",
+      "properties": {
+        "base": {
+          "description": "Reference, by index, to the attribute catalog.",
+          "$ref": "#/$defs/AttributeRef"
+        },
+        "requirement_level": {
+          "description": "Specifies if the attribute is mandatory. Can be \"required\",\n\"conditionally_required\", \"recommended\" or \"opt_in\". When omitted,\nthe attribute is \"recommended\". When set to\n\"conditionally_required\", the string provided as `condition` MUST\nspecify the conditions under which the attribute is required.\n\nNote: For attributes that are \"recommended\" or \"opt-in\" - not all metric source will\ncreate timeseries with these attributes, but for any given timeseries instance, the attributes that *were* present\nshould *remain* present. That is - a metric timeseries cannot drop attributes during its lifetime.",
+          "$ref": "#/$defs/RequirementLevel"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "base",
+        "requirement_level"
+      ]
+    },
+    "MetricRefinement": {
+      "description": "A refinement of a metric signal, for use in code-gen or specific library application.\n\nA refinement represents a \"view\" of a Metric that is highly optimised for a particular implementation.\ne.g. for HTTP metrics, there may be a refinement that provides only the necessary information for dealing with Java's HTTP\nclient library, and drops optional or extraneous information from the underlying http metric.",
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "description": "Annotations for the attribute or signal.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/YamlValue"
+          }
+        },
+        "attributes": {
+          "description": "List of attributes that should be included on this metric.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/MetricAttributeRef"
+          }
+        },
+        "brief": {
+          "description": "A brief description of the attribute or signal.",
+          "type": "string"
+        },
+        "deprecated": {
+          "description": "Specifies if the semantic convention is deprecated. The string\nprovided as description MUST specify why it's deprecated and/or what\nto use instead. See also stability.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Deprecated"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "entity_associations": {
+          "description": "Which entities this metric should be associated with.\n\nThis list is an \"any of\" list, where a metric may be associated with one or more entities, but should\nbe associated with at least one in this list.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "id": {
+          "description": "The identity of the refinement.",
+          "$ref": "#/$defs/SignalId"
+        },
+        "instrument": {
+          "description": "The instrument type that should be used to record the metric. Note that\nthe semantic conventions must be written using the names of the\nsynchronous instrument types (counter, gauge, updowncounter and\nhistogram).\nFor more details: [Metrics semantic conventions - Instrument types](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/metrics/semantic_conventions#instrument-types).",
+          "$ref": "#/$defs/InstrumentSpec"
+        },
+        "name": {
+          "description": "The name of the metric.",
+          "$ref": "#/$defs/SignalId"
+        },
+        "note": {
+          "description": "A more elaborate description of the attribute or signal.\nIt defaults to an empty string.",
+          "type": "string"
+        },
+        "stability": {
+          "description": "Specifies the stability of the attribute or signal.",
+          "$ref": "#/$defs/Stability"
+        },
+        "unit": {
+          "description": "The unit in which the metric is measured, which should adhere to the\n[guidelines](https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/metrics/semantic_conventions#instrument-units).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "instrument",
+        "unit",
+        "brief",
+        "stability"
+      ]
+    },
+    "PrimitiveOrArrayTypeSpec": {
+      "description": "Primitive or array types.",
+      "oneOf": [
+        {
+          "description": "A boolean attribute.",
+          "type": "string",
+          "const": "boolean"
+        },
+        {
+          "description": "A integer attribute (signed 64 bit integer).",
+          "type": "string",
+          "const": "int"
+        },
+        {
+          "description": "A double attribute (double precision floating point (IEEE 754-1985)).",
+          "type": "string",
+          "const": "double"
+        },
+        {
+          "description": "A string attribute.",
+          "type": "string",
+          "const": "string"
+        },
+        {
+          "description": "An any type attribute (accepts any valid value).",
+          "type": "string",
+          "const": "any"
+        },
+        {
+          "description": "An array of strings attribute.",
+          "type": "string",
+          "const": "string[]"
+        },
+        {
+          "description": "An array of integer attribute.",
+          "type": "string",
+          "const": "int[]"
+        },
+        {
+          "description": "An array of double attribute.",
+          "type": "string",
+          "const": "double[]"
+        },
+        {
+          "description": "An array of boolean attribute.",
+          "type": "string",
+          "const": "boolean[]"
+        }
+      ]
+    },
+    "Refinements": {
+      "description": "Semantic convention refinements.\n\nRefinements are a specialization of a signal that can be used to optimise documentation,\nor code generation. A refinement will *always* match the conventions defined by the\nsignal it refines. Refinements cannot be inferred from signals over the wire (e.g. OTLP).\nThis is because any identifying feature of a refinement is used purely for codegen but has\nno storage location in OTLP.\n\nNote: Refinements will always include a \"base\" refinement for every signal definition.\n      For example, if a Metric signal named `my_metric` is defined, there will be\n      a metric refinement named `my_metric` as well.\n      This allows code generation to *only* interact with refinements, if desired, to\n      provide optimised methods for generating telemetry signals.",
+      "type": "object",
+      "properties": {
+        "events": {
+          "description": "A  list of event refinements.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/EventRefinement"
+          }
+        },
+        "metrics": {
+          "description": "A  list of metric refinements.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/MetricRefinement"
+          }
+        },
+        "spans": {
+          "description": "A  list of span refinements.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SpanRefinement"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "spans",
+        "metrics",
+        "events"
+      ]
+    },
+    "Registry": {
+      "description": "A semantic convention registry.\n\nThe semantic convention is composed of definitions of\nattributes, metrics, logs, etc. that will be sent over the wire (e.g. OTLP).\n\nNote: The registry does not include signal refinements.",
+      "type": "object",
+      "properties": {
+        "attribute_groups": {
+          "description": "Catalog of (public) attribute groups.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/AttributeGroup"
+          }
+        },
+        "attributes": {
+          "description": "Catalog of attributes definitions.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/AttributeRef"
+          }
+        },
+        "entities": {
+          "description": "A  list of entity signal definitions.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Entity"
+          }
+        },
+        "events": {
+          "description": "A  list of event signal definitions.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Event"
+          }
+        },
+        "metrics": {
+          "description": "A  list of metric signal definitions.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Metric"
+          }
+        },
+        "spans": {
+          "description": "A  list of span signal definitions.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/Span"
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "attributes",
+        "attribute_groups",
+        "spans",
+        "metrics",
+        "events",
+        "entities"
+      ]
+    },
+    "RequirementLevel": {
+      "description": "The different requirement level specifications.",
+      "anyOf": [
+        {
+          "description": "A basic requirement level.",
+          "$ref": "#/$defs/BasicRequirementLevelSpec"
+        },
+        {
+          "description": "A conditional requirement level.",
+          "type": "object",
+          "properties": {
+            "conditionally_required": {
+              "description": "The description of the condition.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "conditionally_required"
+          ]
+        },
+        {
+          "description": "A recommended requirement level.",
+          "type": "object",
+          "properties": {
+            "recommended": {
+              "description": "The description of the recommendation.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "recommended"
+          ]
+        },
+        {
+          "description": "An opt in requirement level.",
+          "type": "object",
+          "properties": {
+            "opt_in": {
+              "description": "The description of the recommendation.",
+              "type": "string"
+            }
+          },
+          "required": [
+            "opt_in"
+          ]
+        }
+      ]
+    },
+    "SchemaUrl": {
+      "description": "Represents the schema URL of a registry, which serves as a unique identifier for the registry\nalong with its version.",
+      "type": "object",
+      "properties": {
+        "url": {
+          "description": "The schema URL string.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "url"
+      ]
+    },
+    "SignalId": {
+      "description": "An identifier for a signal.  Should be `.` separated namespaces and names.",
+      "type": "string"
+    },
+    "Span": {
+      "description": "The definition of a Span signal.",
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "description": "Annotations for the attribute or signal.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/YamlValue"
+          }
+        },
+        "attributes": {
+          "description": "List of attributes that belong to this span.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SpanAttributeRef"
+          }
+        },
+        "brief": {
+          "description": "A brief description of the attribute or signal.",
+          "type": "string"
+        },
+        "deprecated": {
+          "description": "Specifies if the semantic convention is deprecated. The string\nprovided as description MUST specify why it's deprecated and/or what\nto use instead. See also stability.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Deprecated"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "entity_associations": {
+          "description": "Which entities this span should be associated with.\n\nThis list is an \"any of\" list, where a span may be associated with one or more entities, but should\nbe associated with at least one in this list.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "kind": {
+          "description": "Specifies the kind of the span.",
+          "$ref": "#/$defs/SpanKindSpec"
+        },
+        "name": {
+          "description": "The name pattern for the span.",
+          "$ref": "#/$defs/SpanName"
+        },
+        "note": {
+          "description": "A more elaborate description of the attribute or signal.\nIt defaults to an empty string.",
+          "type": "string"
+        },
+        "stability": {
+          "description": "Specifies the stability of the attribute or signal.",
+          "$ref": "#/$defs/Stability"
+        },
+        "type": {
+          "description": "The type of the Span. This denotes the identity\nof the \"shape\" of this span, and must be unique.",
+          "$ref": "#/$defs/SignalId"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "type",
+        "kind",
+        "name",
+        "brief",
+        "stability"
+      ]
+    },
+    "SpanAttributeRef": {
+      "description": "A special type of reference to attributes that remembers span-specicific information.",
+      "type": "object",
+      "properties": {
+        "base": {
+          "description": "Reference, by index, to the attribute catalog.",
+          "$ref": "#/$defs/AttributeRef"
+        },
+        "requirement_level": {
+          "description": "Specifies if the attribute is mandatory. Can be \"required\",\n\"conditionally_required\", \"recommended\" or \"opt_in\". When omitted,\nthe attribute is \"recommended\". When set to\n\"conditionally_required\", the string provided as `condition` MUST\nspecify the conditions under which the attribute is required.",
+          "$ref": "#/$defs/RequirementLevel"
+        },
+        "sampling_relevant": {
+          "description": "Specifies if the attribute is (especially) relevant for sampling\nand thus should be set at span start. It defaults to false.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "base",
+        "requirement_level"
+      ]
+    },
+    "SpanKindSpec": {
+      "description": "The span kind.",
+      "oneOf": [
+        {
+          "description": "An internal span.",
+          "type": "string",
+          "const": "internal"
+        },
+        {
+          "description": "A client span.",
+          "type": "string",
+          "const": "client"
+        },
+        {
+          "description": "A server span.",
+          "type": "string",
+          "const": "server"
+        },
+        {
+          "description": "A producer span.",
+          "type": "string",
+          "const": "producer"
+        },
+        {
+          "description": "A consumer span.",
+          "type": "string",
+          "const": "consumer"
+        }
+      ]
+    },
+    "SpanName": {
+      "description": "Specification of the span name.",
+      "type": "object",
+      "properties": {
+        "note": {
+          "description": "Required description of how a span name should be created.",
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "note"
+      ]
+    },
+    "SpanRefinement": {
+      "description": "A refinement of a span, for use in code-gen or specific library application.\n\nA refinement represents a \"view\" of a Span that is highly optimised for a particular implementation.\ne.g. for HTTP spans, there may be a refinement that provides only the necessary information for dealing with Java's HTTP\nclient library, and drops optional or extraneous information from the underlying http span.",
+      "type": "object",
+      "properties": {
+        "annotations": {
+          "description": "Annotations for the attribute or signal.",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/YamlValue"
+          }
+        },
+        "attributes": {
+          "description": "List of attributes that belong to this span.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/SpanAttributeRef"
+          }
+        },
+        "brief": {
+          "description": "A brief description of the attribute or signal.",
+          "type": "string"
+        },
+        "deprecated": {
+          "description": "Specifies if the semantic convention is deprecated. The string\nprovided as description MUST specify why it's deprecated and/or what\nto use instead. See also stability.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Deprecated"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "entity_associations": {
+          "description": "Which entities this span should be associated with.\n\nThis list is an \"any of\" list, where a span may be associated with one or more entities, but should\nbe associated with at least one in this list.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "id": {
+          "description": "The identity of the refinement",
+          "$ref": "#/$defs/SignalId"
+        },
+        "kind": {
+          "description": "Specifies the kind of the span.",
+          "$ref": "#/$defs/SpanKindSpec"
+        },
+        "name": {
+          "description": "The name pattern for the span.",
+          "$ref": "#/$defs/SpanName"
+        },
+        "note": {
+          "description": "A more elaborate description of the attribute or signal.\nIt defaults to an empty string.",
+          "type": "string"
+        },
+        "stability": {
+          "description": "Specifies the stability of the attribute or signal.",
+          "$ref": "#/$defs/Stability"
+        },
+        "type": {
+          "description": "The type of the Span. This denotes the identity\nof the \"shape\" of this span, and must be unique.",
+          "$ref": "#/$defs/SignalId"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "kind",
+        "name",
+        "brief",
+        "stability"
+      ]
+    },
+    "Stability": {
+      "description": "The level of stability for a definition. Defined in [OTEP-232](https://github.com/open-telemetry/oteps/blob/main/text/0232-maturity-of-otel.md)",
+      "oneOf": [
+        {
+          "description": "A deprecated definition.",
+          "type": "string",
+          "const": "deprecated",
+          "deprecated": true
+        },
+        {
+          "description": "A stable definition.",
+          "type": "string",
+          "const": "stable"
+        },
+        {
+          "description": "A definition in development. Formally known as experimental.",
+          "type": "string",
+          "const": "development"
+        },
+        {
+          "description": "An alpha definition.",
+          "type": "string",
+          "const": "alpha"
+        },
+        {
+          "description": "A beta definition.",
+          "type": "string",
+          "const": "beta"
+        },
+        {
+          "description": "A release candidate definition.",
+          "type": "string",
+          "const": "release_candidate"
+        }
+      ]
+    },
+    "TemplateTypeSpec": {
+      "description": "Template types.",
+      "oneOf": [
+        {
+          "description": "A boolean attribute.",
+          "type": "string",
+          "const": "template[boolean]"
+        },
+        {
+          "description": "A integer attribute.",
+          "type": "string",
+          "const": "template[int]"
+        },
+        {
+          "description": "A double attribute.",
+          "type": "string",
+          "const": "template[double]"
+        },
+        {
+          "description": "A string attribute.",
+          "type": "string",
+          "const": "template[string]"
+        },
+        {
+          "description": "A any attribute.",
+          "type": "string",
+          "const": "template[any]"
+        },
+        {
+          "description": "An array of strings attribute.",
+          "type": "string",
+          "const": "template[string[]]"
+        },
+        {
+          "description": "An array of integer attribute.",
+          "type": "string",
+          "const": "template[int[]]"
+        },
+        {
+          "description": "An array of double attribute.",
+          "type": "string",
+          "const": "template[double[]]"
+        },
+        {
+          "description": "An array of boolean attribute.",
+          "type": "string",
+          "const": "template[boolean[]]"
+        }
+      ]
+    },
+    "ValueSpec": {
+      "description": "The different types of values.",
+      "anyOf": [
+        {
+          "description": "A integer value.",
+          "type": "integer",
+          "format": "int64"
+        },
+        {
+          "description": "A double value.",
+          "type": "number",
+          "format": "double"
+        },
+        {
+          "description": "A string value.",
+          "type": "string"
+        },
+        {
+          "description": "A boolean value.",
+          "type": "boolean"
+        }
+      ]
+    },
+    "YamlValue": {
+      "type": [
+        "null",
+        "boolean",
+        "object",
+        "array",
+        "number",
+        "string"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
### Description

Bugzilla: Bug-2034765

To support client side telemetry reporting to generic [Open Telemetry]([url](https://opentelemetry.io/)) compatible endpoint we need to convert the glean telemetry dictionary information into a [schema that is standardized and well understood](https://opentelemetry.io/docs/concepts/semantic-conventions/). 

This patch sets up a task that generates a [semconv schema](https://github.com/open-telemetry/weaver/blob/173fed70c05bf9c7833f59f80aae09642ac05114/schemas/semconv-syntax.v2.md) from all `metrics.yaml` files and uploads it as an artifact.

You can run the generator manually by running:

```bash
mach glean semconv
```
