### PR TITLE
Bug 2034400 - Lock browser.ipProtection.openedPanelWithLocation with AccessConnector policy to prevent transient VPN button with dot from showing

### DIFF
--- a/browser/components/enterprisepolicies/Policies.sys.mjs
+++ b/browser/components/enterprisepolicies/Policies.sys.mjs
@@ -174,6 +174,14 @@ export var Policies = {
         );
       }
 
+      // Must be set before enabled so the badge dot doesn't flash when
+      // the pref observer triggers IPProtectionService.init().
+      PoliciesUtils.setDefaultPref(
+        "browser.ipProtection.openedPanelWithLocation",
+        true,
+        locked
+      );
+
       // Set enabled last so that all other prefs are in place when
       // the pref observer triggers IPProtectionService.init().
       PoliciesUtils.setDefaultPref(
@@ -188,6 +196,7 @@ export var Policies = {
       unsetAndUnlockPref("browser.ipProtection.autoStartEnabled");
       unsetAndUnlockPref("browser.ipProtection.mode");
       unsetAndUnlockPref("browser.ipProtection.override.serverlist");
+      unsetAndUnlockPref("browser.ipProtection.openedPanelWithLocation");
       if ("MatchPatterns" in oldParams) {
         unsetAndUnlockPref("browser.ipProtection.inclusion.match_patterns");
       }


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

This PR adds an additional pref to the AccessConnector policy to force disable the new transient "attention dot" on the VPN button which is currently being repurposed for AccessConnector. The "attention dot" implementation causes the VPN button to show until this pref is toggled (which happens when a user opens the panel).

> Note: this does _*not*_ fix the AccessConnector connectivity/initialization bug, just the button.

Bugzilla: Bug-2034400

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Change that caused this: https://phabricator.services.mozilla.com/D295063
* Blocks: #785 

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

<img width="277" height="112" alt="image" src="https://github.com/user-attachments/assets/6583f4b2-5166-44dc-b160-4abd0d11fcec" />

_Before locking the pref on a fresh profile_

<img width="277" height="112" alt="image" src="https://github.com/user-attachments/assets/7ccd0cf6-4a58-4b5c-969a-ab1d113cf6dd" />

_After locking the pref on a fresh profile_

---

### Testing <!-- OPTIONAL -->

**Steps to verify changes:**

1. Start with a fresh profile
2. Open the browser
3. Observe a visible disconnected VPN icon with a blue status dot
4. Click the VPN button to show the panel (this toggles the pref)
5. Quit and reopen Firefox Enterprise
6. Observe the original AccessConnector button

**Expected result:**

VPN button is not visible, AccessConnector button is visible.
