### PR TITLE
Bug 2034487 - Initialize IPProtectionService on startup when feature is enabled but cache state is empty

### DIFF
--- a/toolkit/components/ipprotection/IPPStartupCache.sys.mjs
+++ b/toolkit/components/ipprotection/IPPStartupCache.sys.mjs
@@ -113,7 +113,9 @@ class IPPStartupCacheSingleton {
     this.#stateFromCache = null;
 
     if (
-      lazy.IPProtectionService.state !== lazy.IPProtectionStates.UNINITIALIZED
+      lazy.IPProtectionService.state !==
+        lazy.IPProtectionStates.UNINITIALIZED ||
+      lazy.IPProtectionService.featureEnabled
     ) {
       await lazy.IPProtectionService.initOnStartupCompleted();
     }


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

In addition to the Access Connector icon not being displayed when launching with a fresh profile, the feature is entirely broken on first run. This is due to a conditional that was added in `IPPStartupCache.sys.mjs` which prevents the `IPProtectionService` from being initialized.

Bugzilla: Bug-2034487

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on: #784

---

### Testing <!-- OPTIONAL -->

**Steps to verify changes:**

1. Start with a fresh profile
2. Open the browser
3. Navigate to a protected page
4. Observe an inactive Access Connector

**Expected result:**

Access connector is visible and active