### PR TITLE
Bug 2034591 - Enterprise: make sure to properly react to policy changes for Access Connectors

### DIFF
--- a/toolkit/components/ipprotection/IPPAutoStart.sys.mjs
+++ b/toolkit/components/ipprotection/IPPAutoStart.sys.mjs
@@ -30,6 +30,7 @@ const AUTOSTART_PREF = "browser.ipProtection.autoStartEnabled";
  */
 class IPPAutoStartSingleton {
   #shouldStartWhenReady = false;
+  #handleListChanged = null;
 
   constructor() {
     XPCOMUtils.defineLazyPreferenceGetter(
@@ -52,6 +53,22 @@ class IPPAutoStartSingleton {
       AUTOSTART_FEATURE_ENABLE_PREF,
       false
     );
+
+    this.#handleListChanged = () => this.init();
+    lazy.IPProtectionServerlist.addEventListener(
+      "IPProtectionServerlist:ListChanged",
+      this.#handleListChanged
+    );
+  }
+
+  destroy() {
+    if (this.#handleListChanged) {
+      lazy.IPProtectionServerlist.removeEventListener(
+        "IPProtectionServerlist:ListChanged",
+        this.#handleListChanged
+      );
+      this.#handleListChanged = null;
+    }
   }
 
   init() {

--- a/toolkit/components/ipprotection/IPProtectionServerlist.sys.mjs
+++ b/toolkit/components/ipprotection/IPProtectionServerlist.sys.mjs
@@ -437,6 +437,9 @@ export class PrefServerList extends IPProtectionServerlistBase {
     );
   }
   static get prefValue() {
+    if (!PrefServerList.hasPrefValue) {
+      return null;
+    }
     try {
       const value = Services.prefs.getStringPref(this.PREF_NAME);
       return JSON.parse(value);

--- a/toolkit/components/ipprotection/IPProtectionServerlist.sys.mjs
+++ b/toolkit/components/ipprotection/IPProtectionServerlist.sys.mjs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { AppConstants } from "resource://gre/modules/AppConstants.sys.mjs";
+
 /**
  * This file contains functions that work on top of the RemoteSettings
  * Bucket for the IP Protection server list.
@@ -451,6 +453,9 @@ export class PrefServerList extends IPProtectionServerlistBase {
  * @returns {IPProtectionServerlistBase} - The appropriate serverlist implementation.
  */
 export function IPProtectionServerlistFactory() {
+  if (AppConstants.MOZ_ENTERPRISE) {
+    return new PrefServerList();
+  }
   return PrefServerList.hasPrefValue
     ? new PrefServerList()
     : new RemoteSettingsServerlist();

--- a/toolkit/components/ipprotection/fxa/IPPSignInWatcher.sys.mjs
+++ b/toolkit/components/ipprotection/fxa/IPPSignInWatcher.sys.mjs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { AppConstants } from "resource://gre/modules/AppConstants.sys.mjs";
+
 const lazy = {};
 
 ChromeUtils.defineESModuleGetters(lazy, {
@@ -18,6 +20,9 @@ class IPPSignInWatcherSingleton extends EventTarget {
   #signedIn = false;
 
   get isSignedIn() {
+    if (AppConstants.MOZ_ENTERPRISE) {
+      return true;
+    }
     return this.#signedIn;
   }
 


### PR DESCRIPTION
Starting the browser with policy disabled and then live enable, or starting with the policy enabled, then live disable and then live enable again would result in the Access Connector feature not working anymore.

Second set of steps is handled by making sure isSignedIn() always returns true on enterprise builds.

First set of steps is handled by making sure enterprise builds do not rely on remote settings serverlist but just rely on prefs, and then also making sure there is no race condition between the values of preferences that controls the featuure enabling and the server list: this last one is getting modified at the same time but the code checks for the IPProtectionServerlist's ingestion of the pref, that delays things a bit. Rely on its event to ensure things are processed correctly.

<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2034591

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on:

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

---

### Testing <!-- OPTIONAL -->

* [ ] Manual testing performed

**Steps to verify changes:**
1. Disable policy on staging server
2. Start browser
3. Check Access Connector is disabled
4. Enable policy on server
5. Check Access Connector is enabled
6. Disable policy again
7. Check Access Connector is disabled
8. Enable policy again
9. Check Access Connector is enabled