### PR TITLE
Bug 2027006,2036743: Fetch remote policies on Felt UI before launching Firefox

### DIFF
--- a/browser/extensions/felt/api.js
+++ b/browser/extensions/felt/api.js
@@ -296,7 +296,7 @@ this.felt = class extends ExtensionAPI {
 
       case "FeltParent:FirefoxLaunchFailure": {
         Services.felt.makeBackgroundProcess(false);
-        this.showWindow("felt-browser-error-launch-failure");
+        this.resetToLoginPage("felt-browser-error-launch-failure");
         break;
       }
 
@@ -368,6 +368,14 @@ this.felt = class extends ExtensionAPI {
     this._win.close();
     this._win = null;
     this._winObserver = null;
+  }
+
+  resetToLoginPage(errorMessage = "") {
+    if (!this._win) {
+      this.showWindow(errorMessage);
+      return;
+    }
+    this._win.resetToLoginPage(errorMessage);
   }
 
   showWindow(errorMessage = "") {

--- a/browser/extensions/felt/content/FeltProcessParent.sys.mjs
+++ b/browser/extensions/felt/content/FeltProcessParent.sys.mjs
@@ -437,6 +437,16 @@ export class FeltProcessParent extends JSProcessActorParent {
     }
   }
 
+  _handleFirefoxLaunchFailure() {
+    Services.felt.clearTokens();
+    Services.cookies.removeCookiesWithOriginAttributes(
+      JSON.stringify({
+        privateBrowsingId: lazy.FeltCommon.PRIVATE_BROWSING_ID,
+      })
+    );
+    Services.cpmm.sendAsyncMessage("FeltParent:FirefoxLaunchFailure");
+  }
+
   async startFirefox(startReason, ssoCollectedCookies = []) {
     this.restartReported = false;
     this.logoutReported = false;
@@ -445,6 +455,17 @@ export class FeltProcessParent extends JSProcessActorParent {
     this.extensionReady = false;
     resetFeltFirefoxWindowReady();
     gFeltFirefoxReadyNotified = false;
+
+    let initialPoliciesPayload;
+    try {
+      initialPoliciesPayload = JSON.stringify(
+        await lazy.ConsoleClient.getRemotePolicies()
+      );
+    } catch (err) {
+      lazy.log.error(`Failed to fetch remote policies: ${err}`);
+      this._handleFirefoxLaunchFailure();
+      return;
+    }
 
     // There is no message being sent to the message listener on restart phases
     // whether it is a requested restart from the browser or from a crash.
@@ -474,6 +495,9 @@ export class FeltProcessParent extends JSProcessActorParent {
         await this._applyFirefoxConfigs();
 
         Services.felt.sendCookies(ssoCollectedCookies);
+
+        Services.felt.sendPolicies(initialPoliciesPayload);
+
         Services.felt.sendReady();
         this.firefoxReady = true;
 
@@ -511,7 +535,7 @@ export class FeltProcessParent extends JSProcessActorParent {
         lazy.log.error(
           `Firefox launch failure (${err.result} / ${err.name}): ${err.message}`
         );
-        Services.cpmm.sendAsyncMessage("FeltParent:FirefoxLaunchFailure");
+        this._handleFirefoxLaunchFailure();
       });
   }
 

--- a/browser/extensions/felt/content/window.js
+++ b/browser/extensions/felt/content/window.js
@@ -99,6 +99,22 @@ const ErrorReport = {
   },
 };
 
+/**
+ * Hides the SSO pane, reveals the email login form, and displays an error if provided.
+ *
+ * @param {string} errorType - CSS class name identifying the error type to display.
+ * @param {string|null} details - Additional error details.
+ * @param {string|null} cause - The underlying cause of the error.
+ */
+function resetToLogin(errorType, details = null, cause = null) {
+  document.querySelector(".felt-login__sso").classList.add("is-hidden");
+  document
+    .querySelector(".felt-login__email-pane")
+    .classList.remove("is-hidden");
+  ErrorReport.update(errorType, details, cause);
+  document.getElementById("browser").setAttribute("src", "about:blank");
+}
+
 async function connectToConsole(email) {
   let posture;
   try {
@@ -199,11 +215,7 @@ async function connectToConsole(email) {
         browser.removeProgressListener(progressListener);
       } catch (_) {}
     }
-    document.querySelector(".felt-login__sso").classList.add("is-hidden");
-    document
-      .querySelector(".felt-login__email-pane")
-      .classList.remove("is-hidden");
-    ErrorReport.update(errorType, details, cause);
+    resetToLogin(errorType, details, cause);
   }
 
   let ssoTimeout = setTimeout(() => {
@@ -545,6 +557,7 @@ window.addEventListener(
   () => {
     setBuildVersion();
     ErrorReport.init();
+    window.resetToLoginPage = resetToLogin;
     lazy.Updates.init(document, ErrorReport);
     setupMarionetteEnvironment();
     setupPopupNotifications();

--- a/browser/extensions/felt/rust/nsIFelt.idl
+++ b/browser/extensions/felt/rust/nsIFelt.idl
@@ -76,6 +76,12 @@ interface nsIFelt : nsISupports {
   void openURL(in ACString url, in long disposition);
 
   [must_use]
+  void sendPolicies(in ACString jsonPayload);
+
+  [must_use]
+  ACString getStartupPolicies();
+
+  [must_use]
   ACString getConsoleUrl();
 
   [must_use]

--- a/browser/extensions/felt/rust/src/client.rs
+++ b/browser/extensions/felt/rust/src/client.rs
@@ -395,6 +395,10 @@ impl FeltClientThread {
                                     trace!("FeltClientThread::felt_client::ipc_loop(): Shutdown");
                                     utils::notify_observers("felt-firefox-shutdown".to_string());
                                 },
+                                Ok(FeltMessage::Policies(json_payload)) => {
+                                    trace!("FeltClientThread::felt_client::ipc_loop(): Policies({} bytes)", json_payload.len());
+                                    let _ = utils::set_startup_policies(json_payload);
+                                },
                                 Ok(FeltMessage::OpenURL((url, disposition, focus_hint))) => {
                                     trace!(
                                         "FeltClientThread::felt_client::ipc_loop(): OpenURL({}, {}, {:?})",

--- a/browser/extensions/felt/rust/src/components.rs
+++ b/browser/extensions/felt/rust/src/components.rs
@@ -22,7 +22,7 @@ use log::{error, trace};
 use crate::message::{FeltMessage, FELT_IPC_VERSION};
 #[cfg(target_os = "linux")]
 use crate::utils;
-use crate::utils::{Tokens, CONSOLE_URL, TOKENS, TOKEN_EXPIRY_SKEW};
+use crate::utils::{get_startup_policies, Tokens, CONSOLE_URL, TOKENS, TOKEN_EXPIRY_SKEW};
 
 #[xpcom(implement(nsIFelt), atomic)]
 pub struct FeltXPCOM {
@@ -253,6 +253,24 @@ impl FeltXPCOM {
         } else {
             trace!("FeltXPCOM::SendExtensionReady: not in browser, ignoring");
             NS_OK
+        }
+    }
+
+    fn SendPolicies(&self, json_payload: *const nsACString) -> nserror::nsresult {
+        let payload = unsafe { (*json_payload).to_string() };
+        trace!("FeltXPCOM::SendPolicies");
+        self.send(FeltMessage::Policies(payload))
+    }
+
+    fn GetStartupPolicies(&self, retval: *mut nsACString) -> nserror::nsresult {
+        match get_startup_policies() {
+            Ok(policies) => {
+                unsafe {
+                    (*retval).assign(policies.as_str());
+                }
+                NS_OK
+            }
+            Err(()) => NS_ERROR_FAILURE,
         }
     }
 

--- a/browser/extensions/felt/rust/src/message.rs
+++ b/browser/extensions/felt/rust/src/message.rs
@@ -64,6 +64,7 @@ pub enum FeltMessage {
     Exiting,
     UpdateReady,
     Shutdown,
+    Policies(String),
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/browser/extensions/felt/rust/src/utils.rs
+++ b/browser/extensions/felt/rust/src/utils.rs
@@ -5,12 +5,12 @@
 use nserror::NS_OK;
 use nsstring::nsCString;
 use serde::{Deserialize, Serialize};
-use std::sync::{Arc, LazyLock, OnceLock, RwLock};
+use std::sync::{Arc, LazyLock, Mutex, OnceLock, RwLock};
 use std::{ffi::CString, future::Future};
 use xpcom::interfaces::{nsICookie, nsICookieManager, nsIObserverService, nsIPrefBranch};
 use xpcom::RefPtr;
 
-use log::trace;
+use log::{trace, warn};
 #[cfg(target_os = "linux")]
 use std::os::raw::c_char;
 
@@ -62,6 +62,29 @@ pub static TOKEN_EXPIRY_SKEW: i64 = 5 * 60;
 
 pub static TOKENS: LazyLock<Arc<RwLock<Tokens>>> =
     LazyLock::new(|| Arc::new(RwLock::new(Default::default())));
+pub static INITIAL_POLICIES: OnceLock<Mutex<Option<String>>> = OnceLock::new();
+
+pub fn get_startup_policies() -> Result<String, ()> {
+    let mutex = INITIAL_POLICIES
+        .get()
+        .ok_or(())
+        .inspect_err(|_| warn!("Startup policies not initialized"))?;
+    mutex
+        .lock()
+        .unwrap()
+        .take()
+        .ok_or(())
+        .inspect_err(|_| warn!("Startup policies already taken"))
+}
+
+pub fn set_startup_policies(policies: String) -> Result<(), ()> {
+    INITIAL_POLICIES
+        .set(Mutex::new(Some(policies)))
+        .map_err(|_| {
+            warn!("Startup policies already set");
+        })
+}
+
 pub static CONSOLE_URL: OnceLock<Arc<String>> = OnceLock::new();
 
 pub fn inject_one_cookie(cookie: nsICookieWrapper) {

--- a/testing/enterprise/felt_tests.py
+++ b/testing/enterprise/felt_tests.py
@@ -117,6 +117,11 @@ class LocalHttpRequestHandler(BaseHTTPRequestHandler):
 
 
 class SsoHttpHandler(LocalHttpRequestHandler):
+    def has_session_cookie(self):
+        cookies = self.headers.get("Cookie", "")
+        expected = f"{self.server.cookie_name.value}={self.server.cookie_value.value}"
+        return expected in cookies
+
     def do_GET(self):
         print("GET", self.path)
         m = None
@@ -126,6 +131,19 @@ class SsoHttpHandler(LocalHttpRequestHandler):
         print("path: ", path)
 
         if path == "/sso_url":
+            # Simulate real SSO behavior: if the session cookie from a
+            # previous login is present, skip the login form and redirect
+            # straight to the callback.
+            if self.has_session_cookie():
+                location = (
+                    f"http://localhost:{self.server.console_port}/sso/callback?foo"
+                )
+                self.send_response(302, "Found")
+                self.send_header("Location", location)
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+                return
+
             # Dummy sso login page
             m = """
 <html>
@@ -218,7 +236,9 @@ class ConsoleHttpHandler(LocalHttpRequestHandler):
             m = json.dumps({
                 "learn_more_url": firefox_config["learn_more_url"]["pref_value"],
                 "company_logo_url": "",
-                "policies": {"polling_frequency": 500},
+                "policies": {
+                    "polling_frequency": self.server.config_polling_frequency.value
+                },
                 "services": {
                     "push_url": "",
                     "remote_settings_url": "",
@@ -553,6 +573,7 @@ def serve(
     policy_access_connector=None,
     policies_fail_request=None,
     signout_count=None,
+    config_polling_frequency=None,
     # TODO: Behavior is not yet clearly defined
     # device_posture_reply_forbidden=None,
 ):
@@ -582,6 +603,7 @@ def serve(
         policies_fail_request if policies_fail_request is not None else Value("B", 0)
     )
     httpd.signout_count = signout_count if signout_count is not None else Value("i", 0)
+    httpd.config_polling_frequency = config_polling_frequency
     httpd.serve_updates = False
     httpd.serve_updates_version = ""
     httpd.serve_forced_updates_count = 0
@@ -697,6 +719,7 @@ class FeltTestsBase(ConsoleSSOPortMixin, EnterpriseTestsBase):
         self.policy_access_token = SharedString("")
         self.policy_refresh_token = SharedString("")
         self.signout_count = Value("i", 0)
+        self.config_polling_frequency = Value("i", 500)
 
         self.console_httpd = Process(
             target=serve,
@@ -712,6 +735,7 @@ class FeltTestsBase(ConsoleSSOPortMixin, EnterpriseTestsBase):
                 policy_refresh_token=self.policy_refresh_token,
                 policies_fail_request=self.policies_fail_request,
                 signout_count=self.signout_count,
+                config_polling_frequency=self.config_polling_frequency,
                 # TODO: Behavior is not yet clearly defined
                 # device_posture_reply_forbidden=self.device_posture_reply_forbidden,
             ),

--- a/testing/enterprise/test_felt_browser_init_failures.py
+++ b/testing/enterprise/test_felt_browser_init_failures.py
@@ -6,6 +6,8 @@
 import os
 import sys
 
+import requests
+
 sys.path.append(os.path.dirname(__file__))
 
 from base_test import Environment
@@ -13,13 +15,70 @@ from felt_tests import FeltTests
 
 
 class BrowserInitFailures(FeltTests):
+    def setUp(self):
+        super().setUp()
+        self.config_polling_frequency.value = 600000
+
+    def teardown(self):
+        self.config_polling_frequency.value = 500
+        super().teardown()
+
+    def _assert_no_error_shown(self):
+        with self._driver.using_context("chrome"):
+            is_hidden = self._driver.execute_script(
+                """
+                const wrapper = document.querySelector(".felt-browser-error");
+                return !wrapper || wrapper.classList.contains("is-hidden");
+                """
+            )
+            assert is_hidden, "No error message should be visible before failure"
+
+    def _assert_launch_failure_error_shown(self):
+        with self._driver.using_context("chrome"):
+            error_bar = self.get_elem(".felt-browser-error-launch-failure")
+            heading = error_bar.get_attribute("heading").strip()
+            assert "cannot start" in heading, f"Unexpected error bar heading: {heading}"
+
+    def _get_active_policies_from_child(self):
+        with self._child_driver.using_context("chrome"):
+            return self._child_driver.execute_script(
+                """
+                return Services.policies.getActivePolicies();
+                """
+            )
+
+    def _get_console_policies(self):
+        return requests.get(
+            f"http://localhost:{self.console_port}/api/browser/policies",
+            headers={"Authorization": f"Bearer {self.policy_access_token.value}"},
+        ).json()["policies"]
+
     def test_browser_init_policy_fetch_fail(self):
+        self.force_window()
+        self._assert_no_error_shown()
+
+        # unsuccessful login
         self.policies_fail_request.value = 1
-        # After SSO completion, FELT closes its auth window and spawns the
-        # child Firefox. The child fails its policy fetch and exits, which
-        # causes FELT to re-open a new auth window.
-        with self.expect_new_felt_auth_window():
-            self.run_felt_base()
-            self._manually_closed_child = True
-        self.policies_fail_request.value = 0
+        super().run_felt_base()
+        self.force_window()
+        self._assert_launch_failure_error_shown()
         self.assert_user_signed_out(env=Environment.FELT)
+
+        # successful login after failure
+        self.policies_fail_request.value = 0
+        super().run_felt_base()
+        self._manually_closed_child = False
+        self.connect_child_browser()
+        self.assert_user_signed_in(env=Environment.FIREFOX)
+
+        # Verify remote policies were applied to the child browser
+        server_policies = self._get_console_policies()
+        assert server_policies, "Server should return non-empty policies"
+
+        active_policies = self._get_active_policies_from_child()
+        self._logger.info(f"Server policies: {server_policies}")
+        self._logger.info(f"Active policies: {active_policies}")
+        assert active_policies == server_policies, (
+            f"Active policies {active_policies} do not match "
+            f"server policies {server_policies}"
+        )

--- a/toolkit/components/enterprisepolicies/EnterprisePoliciesParent.sys.mjs
+++ b/toolkit/components/enterprisepolicies/EnterprisePoliciesParent.sys.mjs
@@ -10,8 +10,6 @@ ChromeUtils.defineESModuleGetters(lazy, {
   JsonSchemaValidator:
     "resource://gre/modules/components-utils/JsonSchemaValidator.sys.mjs",
   // eslint-disable-next-line mozilla/no-browser-refs-in-toolkit
-  EnterpriseHandler: "resource:///modules/enterprise/EnterpriseHandler.sys.mjs",
-  // eslint-disable-next-line mozilla/no-browser-refs-in-toolkit
   Policies: "resource:///modules/policies/Policies.sys.mjs",
   WindowsGPOParser: "resource://gre/modules/policies/WindowsGPOParser.sys.mjs",
   macOSPoliciesParser:
@@ -113,7 +111,7 @@ EnterprisePoliciesManager.prototype = {
     }
   },
 
-  async _initialize() {
+  _initialize() {
     this._cleanupPolicies();
 
     const changesHandler = provider => {
@@ -155,7 +153,7 @@ EnterprisePoliciesManager.prototype = {
     this._status = Ci.nsIEnterprisePolicies.INACTIVE;
     Services.prefs.setBoolPref(PREF_POLICIES_APPLIED, false);
 
-    let provider = await this._chooseProvider(changesHandler);
+    let provider = this._chooseProvider(changesHandler);
     if (provider.failed) {
       this._status = Ci.nsIEnterprisePolicies.FAILED;
     }
@@ -166,7 +164,7 @@ EnterprisePoliciesManager.prototype = {
     Glean.policies.isEnterprise.set(this.isEnterprise);
   },
 
-  async _chooseProvider(handler) {
+  _chooseProvider(handler) {
     let platformProvider = null;
     if (AppConstants.platform == "win" && AppConstants.MOZ_SYSTEM_POLICIES) {
       platformProvider = new WindowsGPOPoliciesProvider();
@@ -183,14 +181,6 @@ EnterprisePoliciesManager.prototype = {
     jsonProvider.onPoliciesChanges(handler);
 
     let remoteProvider = RemotePoliciesProvider.createInstance();
-    // Fetch first set of remote policies during the
-    // initialization of the policy engine
-    await remoteProvider.fetchPoliciesOnStartup();
-    if (Services.felt?.isFeltBrowser() && remoteProvider.failed) {
-      // bug 2027006 will move the fetching of policies to felt
-      // and not shutdown will be needed then
-      lazy.EnterpriseHandler.initiateShutdown();
-    }
     remoteProvider.onPoliciesChanges(handler);
 
     if (platformProvider && platformProvider.hasPolicies) {
@@ -446,12 +436,7 @@ EnterprisePoliciesManager.prototype = {
 
     switch (topic) {
       case "policies-startup": {
-        const initializedPromise = this._initialize();
-        // _initialize() does async work (fetching remote policies).
-        // We spin a nested event loop until the promise resolves so
-        // this observer doesn't return before initialization completes.
-        // This keeps startup behavior effectively synchronous.
-        this.spinResolve(initializedPromise);
+        this._initialize();
         this._runPoliciesCallbacks("onBeforeAddons");
         break;
       }
@@ -501,44 +486,6 @@ EnterprisePoliciesManager.prototype = {
         );
 
         break;
-    }
-  },
-
-  /**
-   * Spin the event loop until the passed promise resolves.
-   *
-   * This is used to await the response when fetching remote
-   * policies during the initialization of the policy engine.
-   *
-   * @param {Promise} promise
-   * @returns {any} Result of the resolved promise
-   */
-  spinResolve(promise) {
-    if (!(promise instanceof Promise)) {
-      return promise;
-    }
-    let done = false;
-    let result = null;
-    let error = null;
-    promise
-      .catch(e => {
-        error = e;
-      })
-      .then(r => {
-        result = r;
-        done = true;
-      });
-
-    Services.tm.spinEventLoopUntil(
-      "EnterprisePoliciesManager.sys.mjs:_initialize",
-      () => done
-    );
-    if (!done) {
-      throw new Error("Forcefully exited event loop.");
-    } else if (error) {
-      throw error;
-    } else {
-      return result;
     }
   },
 
@@ -949,6 +896,7 @@ class RemotePoliciesProvider {
     Services.prefs.addObserver(this.POLLING_ENABLED_PREF, this);
     Services.obs.addObserver(this, "xpcom-shutdown");
 
+    this.loadRemotePolicies();
     this.init();
   }
 
@@ -1054,7 +1002,6 @@ class RemotePoliciesProvider {
     if (!this._isPollingEnabled) {
       return;
     }
-    this._performPolling();
     this._poller = lazy.setInterval(
       this._performPolling.bind(this),
       this._pollingFrequency
@@ -1080,20 +1027,20 @@ class RemotePoliciesProvider {
     }
   }
 
-  async fetchPoliciesOnStartup() {
-    if (!this._isPollingEnabled) {
+  loadRemotePolicies() {
+    if (!AppConstants.MOZ_ENTERPRISE || !Services.felt?.isFeltBrowser()) {
       return;
     }
 
     let res;
     try {
-      res = await lazy.ConsoleClient.getRemotePolicies();
+      res = JSON.parse(Services.felt.getStartupPolicies());
     } catch (e) {
       console.error(`Failed to fetch remote policies on startup: ${e}`);
       this._failed = true;
       return;
     }
-    if (!res.policies) {
+    if (!res?.policies) {
       console.error(
         `No policies were found in the response: ${JSON.stringify(res)}.`
       );


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2027006


 - Moves remote policy fetching from Firefox startup to the Felt UI login flow, so policies are available before Firefox launches, and we can avoid extra startups in case of failures                                                                      
  - Fetches user info and remote policies in parallel after SSO authentication completes
  - Passes policies to Firefox via a new IPC message
  -  If either fetch fails, signs the user out, clears SSO cookies, signouts the user, and resets the Felt UI to the login page with a connection error 

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on:

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

---

### Testing <!-- OPTIONAL -->

* [x] Added tests
* [x] Manual testing performed
- I put a throw with a counter (to make it fail only the first time), and see how the sso works but fails on fetch

<!--**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
