### PR TITLE
Add Github workflow to automatically create uplift PRs

### DIFF
--- a/.github/workflows/uplift.yml
+++ b/.github/workflows/uplift.yml
@@ -18,6 +18,7 @@ jobs:
   build-matrix:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -59,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -188,15 +189,17 @@ jobs:
         if: steps.uplift.outputs.branch != ''
         env:
           GH_TOKEN: ${{ github.token }}
+          COMMIT_SUMMARY: ${{ steps.uplift.outputs.summary }}
         run: |
           BRANCH="${{ steps.uplift.outputs.branch }}"
 
-          cat <<'EOF' > pr_body.txt
+          DELIM="PR_BODY_$(uuidgen)"
+          cat <<$DELIM > pr_body.txt
           Uplift from #${{ env.PR_NUMBER }}
 
           ## Commits
-          ${{ steps.uplift.outputs.summary }}
-          EOF
+          $COMMIT_SUMMARY
+          $DELIM
 
           PR_URL=$(gh pr create \
             --base "${{ matrix.target }}" \

--- a/.github/workflows/uplift.yml
+++ b/.github/workflows/uplift.yml
@@ -103,7 +103,7 @@ jobs:
             COMMITS=$SHA
           fi
 
-          APPLIED=0
+          HAS_APPLIED_COMMITS=0
 
           for commit in $COMMITS; do
             SHORT=$(git rev-parse --short $commit)
@@ -136,10 +136,10 @@ jobs:
               echo "- [$SHORT]($LINK) $MSG" >> $SUMMARY_FILE
             fi
 
-            APPLIED=1
+            HAS_APPLIED_COMMITS=1
           done
 
-          if [ "$APPLIED" -eq 0 ]; then
+          if [ "$HAS_APPLIED_COMMITS" -eq 0 ]; then
             echo "No new commits applied"
             echo "summary=All commits already exist in $TARGET." >> $GITHUB_OUTPUT
             echo "branch=" >> $GITHUB_OUTPUT

--- a/.github/workflows/uplift.yml
+++ b/.github/workflows/uplift.yml
@@ -191,7 +191,7 @@ jobs:
         run: |
           BRANCH="${{ steps.uplift.outputs.branch }}"
 
-          cat <<EOF > pr_body.txt
+          cat <<'EOF' > pr_body.txt
           Uplift from #${{ env.PR_NUMBER }}
 
           ## Commits
@@ -209,15 +209,15 @@ jobs:
           gh pr edit "$PR_URL" --add-reviewer "mozilla/enterprise-firefox-engineering"
 
           if [ "${{ steps.uplift.outputs.has_conflicts }}" = "true" ]; then
-            cat <<EOF >> comment_body.txt
+            cat <<'EOF' >> comment_body.txt
             ⚠️ Commits marked with conflicts require manual resolution, by rebasing locally to edit the commits or by recreating the branch. **DO NOT** fix up by adding an extra commit, only resolve conflicts directly on the cherry-pick commit(s).
 
             To recreate this branch manually:
-            \`\`\`
+            ```
             git fetch enterprise-firefox ${{ matrix.target }}
             git checkout -b ${{ steps.uplift.outputs.branch }} enterprise-firefox/${{ matrix.target }}
             git cherry-pick ${{ steps.uplift.outputs.commits }}
-            \`\`\`
+            ```
             EOF
 
             gh pr comment "$PR_URL" --body-file comment_body.txt

--- a/.github/workflows/uplift.yml
+++ b/.github/workflows/uplift.yml
@@ -222,7 +222,8 @@ jobs:
 
           gh pr edit "$PR_URL" --add-reviewer "mozilla/enterprise-firefox-engineering"
 
-          # Add original author if conflicts happened, since manual resolution is required
+          # If there are conflicts, add original author and mark PR as draft since manual resolution is required
           if [ "${{ steps.uplift.outputs.has_conflicts }}" = "true" ]; then
             gh pr edit "$PR_URL" --add-reviewer "${{ github.event.pull_request.user.login }}"
+            gh pr ready "$PR_URL" --undo
           fi

--- a/.github/workflows/uplift.yml
+++ b/.github/workflows/uplift.yml
@@ -5,8 +5,7 @@ on:
   # of the source PR [0], as it could risk leaking the GH_TOKENs.
   #
   # In this case, we do it as the job needs to run within the context of the
-  # target repo, so it can get a GH_TOKEN which it can use to comment on and
-  # update the PR.
+  # target repo, so it can get a GH_TOKEN which it can use to create a PR.
   #
   # Crucially, no external code is loaded or run as part of this workflow.
   #
@@ -19,7 +18,8 @@ jobs:
   uplift:
     if: >
       github.event.pull_request.merged == true &&
-      github.event.pull_request.base.ref == 'enterprise-main'
+      github.event.pull_request.base.ref == matrix.source &&
+      contains(github.event.pull_request.labels.*.name, matrix.trigger_label)
 
     runs-on: ubuntu-latest
 
@@ -31,36 +31,37 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - target: enterprise-beta
-            label_check: uplift-to-beta
-            label: branch:beta
-          - target: enterprise-release
-            label_check: uplift-to-release
-            label: branch:release
+          - source: enterprise-main
+            target: enterprise-beta
+            trigger_label: uplift-to-beta
+            target_label: branch:beta
+          - source: enterprise-main
+            target: enterprise-release
+            trigger_label: uplift-to-release
+            target_label: branch:release
+          - source: enterprise-beta
+            target: enterprise-release
+            trigger_label: uplift-to-release
+            target_label: branch:release
 
     env:
       MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
       PR_TITLE: ${{ github.event.pull_request.title }}
       REPO_URL: https://github.com/${{ github.repository }}
-      TARGET: ${{ matrix.target }}
-      PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
 
     steps:
       - name: Checkout
-        if: contains(env.PR_LABELS, matrix.label_check)
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Configure git
-        if: contains(env.PR_LABELS, matrix.label_check)
         run: |
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
 
       - name: Create uplift script
-        if: contains(env.PR_LABELS, matrix.label_check)
         run: |
           cat << 'EOF' > uplift.sh
           set -e
@@ -165,14 +166,11 @@ jobs:
 
       - name: Uplift
         id: uplift
-        if: contains(env.PR_LABELS, matrix.label_check)
         run: |
-          bash uplift.sh $TARGET $MERGE_SHA
+          bash uplift.sh ${{ matrix.target }} $MERGE_SHA
 
       - name: Create PR
-        if: >
-          contains(env.PR_LABELS, matrix.label_check) &&
-          steps.uplift.outputs.branch != ''
+        if: steps.uplift.outputs.branch != ''
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -188,10 +186,10 @@ jobs:
           EOF
 
           gh pr create \
-            --base "$TARGET" \
+            --base "${{ matrix.target }}" \
             --head "$BRANCH" \
-            --title "[$TARGET uplift] ${{ env.PR_TITLE }}" \
+            --title "[${{ matrix.target }} uplift] $PR_TITLE" \
             --body-file pr_body.txt \
-            --label "${{ matrix.label }}" \
+            --label "${{ matrix.target_label }}" \
             --label "uplift" \
             --reviewer "mozilla/enterprise-firefox-engineering"

--- a/.github/workflows/uplift.yml
+++ b/.github/workflows/uplift.yml
@@ -109,7 +109,7 @@ jobs:
               fi
 
               set +e
-              git cherry-pick -x -X theirs $commit
+              git cherry-pick -x $commit
               STATUS=$?
               set -e
 
@@ -142,7 +142,7 @@ jobs:
             LINK="$REPO_URL/commit/$SHA"
 
             set +e
-            git cherry-pick -x -X theirs $SHA
+            git cherry-pick -x $SHA
             STATUS=$?
             set -e
 

--- a/.github/workflows/uplift.yml
+++ b/.github/workflows/uplift.yml
@@ -95,58 +95,36 @@ jobs:
 
           if [ "$COUNT" -eq 3 ]; then
             echo "Merge commit → multi-commit mode"
-
             COMMITS=$(git log --reverse --no-merges --pretty=format:"%H" $SHA^1..$SHA^2)
-
-            for commit in $COMMITS; do
-              SHORT=$(git rev-parse --short $commit)
-              MSG=$(git log -1 --pretty=format:"%s" $commit)
-              LINK="$REPO_URL/commit/$commit"
-
-              if git branch -r --contains $commit | grep -q "origin/$TARGET"; then
-                echo "- [$SHORT]($LINK) $MSG (already in branch)" >> $SUMMARY_FILE
-                continue
-              fi
-
-              set +e
-              git cherry-pick -x $commit
-              STATUS=$?
-              set -e
-
-              if [ $STATUS -ne 0 ]; then
-                # Check if it's an empty cherry-pick
-                if git diff --cached --quiet && git diff --quiet; then
-                  echo "Empty cherry-pick for $commit → skipping"
-
-                  git cherry-pick --skip
-
-                  echo "- [$SHORT]($LINK) $MSG (already applied)" >> $SUMMARY_FILE
-                  continue
-                fi
-
-                git add -A
-                git cherry-pick --continue
-                echo "- [$SHORT]($LINK) $MSG (⚠️ conflict)" >> $SUMMARY_FILE
-              else
-                echo "- [$SHORT]($LINK) $MSG" >> $SUMMARY_FILE
-              fi
-
-              APPLIED=1
-            done
-
           else
             echo "Single commit mode"
+            COMMITS=$SHA
+          fi
 
-            SHORT=$(git rev-parse --short $SHA)
-            MSG=$(git log -1 --pretty=format:"%s" $SHA)
-            LINK="$REPO_URL/commit/$SHA"
+          for commit in $COMMITS; do
+            SHORT=$(git rev-parse --short $commit)
+            MSG=$(git log -1 --pretty=format:"%s" $commit)
+            LINK="$REPO_URL/commit/$commit"
+
+            if git branch -r --contains $commit | grep -q "origin/$TARGET"; then
+              echo "- [$SHORT]($LINK) $MSG (already in branch)" >> $SUMMARY_FILE
+              continue
+            fi
 
             set +e
-            git cherry-pick -x $SHA
+            git cherry-pick -x $commit
             STATUS=$?
             set -e
 
             if [ $STATUS -ne 0 ]; then
+              # Detect empty cherry-pick
+              if git diff --cached --quiet && git diff --quiet; then
+                echo "Empty cherry-pick for $commit → skipping"
+                git cherry-pick --skip
+                echo "- [$SHORT]($LINK) $MSG (already applied)" >> $SUMMARY_FILE
+                continue
+              fi
+
               git add -A
               git cherry-pick --continue
               echo "- [$SHORT]($LINK) $MSG (⚠️ conflict)" >> $SUMMARY_FILE
@@ -155,7 +133,7 @@ jobs:
             fi
 
             APPLIED=1
-          fi
+          done
 
           if [ "$APPLIED" -eq 0 ]; then
             echo "No new commits applied"

--- a/.github/workflows/uplift.yml
+++ b/.github/workflows/uplift.yml
@@ -97,7 +97,7 @@ jobs:
           COUNT=$(echo $PARENTS | wc -w)
           if [ "$COUNT" -gt 2 ]; then
             echo "Merge commit → multi-commit mode"
-            COMMITS=$(git log --reverse --no-merges --pretty=format:"%H" $SHA^1..$SHA^2)
+            COMMITS=$(git rev-list --reverse --no-merges $SHA^1..$SHA)
           else
             echo "Single commit mode"
             COMMITS=$SHA

--- a/.github/workflows/uplift.yml
+++ b/.github/workflows/uplift.yml
@@ -1,0 +1,216 @@
+name: Auto Uplift
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  uplift:
+    if: >
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'enterprise-main'
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    env:
+      MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      PR_TITLE: ${{ github.event.pull_request.title }}
+      REPO_URL: https://github.com/${{ github.repository }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+
+      - name: Read labels
+        id: labels
+        run: |
+          labels='${{ toJson(github.event.pull_request.labels.*.name) }}'
+
+          [[ "$labels" == *"uplift-to-beta"* ]] && echo "beta=true" >> $GITHUB_OUTPUT
+          [[ "$labels" == *"uplift-to-release"* ]] && echo "release=true" >> $GITHUB_OUTPUT
+
+      # ----------------------------------------
+      # Shared uplift script
+      # ----------------------------------------
+      - name: Create uplift script
+        run: |
+          cat << 'EOF' > uplift.sh
+          set -e
+
+          TARGET=$1
+          SHA=$2
+
+          BRANCH="uplift-${TARGET}-${SHA}"
+          SUMMARY_FILE=summary.txt
+
+          echo "---- Uplifting to $TARGET ----"
+
+          git fetch origin $TARGET
+
+          # Skip entire operation if merge commit already in branch
+          if git branch -r --contains $SHA | grep -q "origin/$TARGET"; then
+            echo "Already fully present in $TARGET"
+            echo "summary=Already present, nothing to uplift." >> $GITHUB_OUTPUT
+            echo "branch=" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Avoid duplicate branch
+          if git ls-remote --heads origin $BRANCH | grep -q $BRANCH; then
+            echo "Branch already exists, skipping"
+            echo "summary=Uplift branch already exists." >> $GITHUB_OUTPUT
+            echo "branch=" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          git checkout -b $BRANCH origin/$TARGET
+
+          touch $SUMMARY_FILE
+
+          PARENTS=$(git rev-list --parents -n 1 $SHA)
+          COUNT=$(echo $PARENTS | wc -w)
+
+          APPLIED=0
+
+          if [ "$COUNT" -eq 3 ]; then
+            echo "Merge commit → multi-commit mode"
+
+            COMMITS=$(git log --reverse --no-merges --pretty=format:"%H" $SHA^1..$SHA^2)
+
+            for commit in $COMMITS; do
+              SHORT=$(git rev-parse --short $commit)
+              MSG=$(git log -1 --pretty=format:"%s" $commit)
+              LINK="$REPO_URL/commit/$commit"
+
+              if git branch -r --contains $commit | grep -q "origin/$TARGET"; then
+                echo "- [$SHORT]($LINK) $MSG (already in branch)" >> $SUMMARY_FILE
+                continue
+              fi
+
+              set +e
+              git cherry-pick -x -X theirs $commit
+              STATUS=$?
+              set -e
+
+              if [ $STATUS -ne 0 ]; then
+                # Check if it's an empty cherry-pick
+                if git diff --cached --quiet && git diff --quiet; then
+                  echo "Empty cherry-pick for $commit → skipping"
+
+                  git cherry-pick --skip
+
+                  echo "- [$SHORT]($LINK) $MSG (already applied)" >> $SUMMARY_FILE
+                  continue
+                fi
+
+                git add -A
+                git commit -m "Cherry-pick $commit with conflicts"
+                echo "- [$SHORT]($LINK) $MSG (⚠️ conflict)" >> $SUMMARY_FILE
+              else
+                echo "- [$SHORT]($LINK) $MSG" >> $SUMMARY_FILE
+              fi
+
+              APPLIED=1
+            done
+
+          else
+            echo "Single commit mode"
+
+            SHORT=$(git rev-parse --short $SHA)
+            MSG=$(git log -1 --pretty=format:"%s" $SHA)
+            LINK="$REPO_URL/commit/$SHA"
+
+            set +e
+            git cherry-pick -x -X theirs $SHA
+            STATUS=$?
+            set -e
+
+            if [ $STATUS -ne 0 ]; then
+              git add -A
+              git commit -m "Cherry-pick $SHA with conflicts"
+              echo "- [$SHORT]($LINK) $MSG (⚠️ conflict)" >> $SUMMARY_FILE
+            else
+              echo "- [$SHORT]($LINK) $MSG" >> $SUMMARY_FILE
+            fi
+
+            APPLIED=1
+          fi
+
+          if [ "$APPLIED" -eq 0 ]; then
+            echo "No new commits applied"
+            echo "summary=All commits already exist in $TARGET." >> $GITHUB_OUTPUT
+            echo "branch=" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          git push origin $BRANCH
+
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+
+          DELIM="GITHUB_OUTPUT_$(uuidgen)"
+          echo "summary<<$DELIM" >> $GITHUB_OUTPUT
+          cat $SUMMARY_FILE >> $GITHUB_OUTPUT
+          echo "$DELIM" >> $GITHUB_OUTPUT
+          EOF
+
+      # ----------------------------------------
+      # BETA
+      # ----------------------------------------
+      - name: Uplift to enterprise-beta
+        if: steps.labels.outputs.beta == 'true'
+        id: beta_uplift
+        run: |
+          bash uplift.sh enterprise-beta $MERGE_SHA
+
+      - name: Create PR (enterprise-beta)
+        if: steps.labels.outputs.beta == 'true' && steps.beta_uplift.outputs.branch != ''
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: ${{ steps.beta_uplift.outputs.branch }}
+          base: enterprise-beta
+          title: "[enterprise-beta uplift] ${{ env.PR_TITLE }}"
+          labels: branch:beta,uplift
+          body: |
+            Uplift from #${{ env.PR_NUMBER }}
+
+            ## Commits
+            ${{ steps.beta_uplift.outputs.summary }}
+
+            ⚠️ Commits marked with conflicts require manual resolution.
+          team-reviewers: enterprise-firefox-engineering
+
+      # ----------------------------------------
+      # RELEASE
+      # ----------------------------------------
+      - name: Uplift to enterprise-release
+        if: steps.labels.outputs.release == 'true'
+        id: rel_uplift
+        run: |
+          bash uplift.sh enterprise-release $MERGE_SHA
+
+      - name: Create PR (enterprise-release)
+        if: steps.labels.outputs.release == 'true' && steps.rel_uplift.outputs.branch != ''
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: ${{ steps.rel_uplift.outputs.branch }}
+          base: enterprise-release
+          title: "[enterprise-release uplift] ${{ env.PR_TITLE }}"
+          labels: branch:release,uplift
+          body: |
+            Uplift from #${{ env.PR_NUMBER }}
+
+            ## Commits
+            ${{ steps.rel_uplift.outputs.summary }}
+
+            ⚠️ Commits marked with conflicts require manual resolution.
+          team-reviewers: enterprise-firefox-engineering

--- a/.github/workflows/uplift.yml
+++ b/.github/workflows/uplift.yml
@@ -198,20 +198,6 @@ jobs:
           ${{ steps.uplift.outputs.summary }}
           EOF
 
-          if [ "${{ steps.uplift.outputs.has_conflicts }}" = "true" ]; then
-            cat <<EOF >> pr_body.txt
-
-            ⚠️ Commits marked with conflicts require manual resolution, by rebasing locally to edit the commits or by recreating the branch. **DO NOT** fix up by adding an extra commit, only resolve conflicts directly on the cherry-pick commit(s).
-
-            To recreate this branch manually:
-            \`\`\`
-            git fetch enterprise-firefox ${{ matrix.target }}
-            git checkout -b ${{ steps.uplift.outputs.branch }} enterprise-firefox/${{ matrix.target }}
-            git cherry-pick ${{ steps.uplift.outputs.commits }}
-            \`\`\`
-            EOF
-          fi
-
           PR_URL=$(gh pr create \
             --base "${{ matrix.target }}" \
             --head "$BRANCH" \
@@ -222,8 +208,21 @@ jobs:
 
           gh pr edit "$PR_URL" --add-reviewer "mozilla/enterprise-firefox-engineering"
 
-          # If there are conflicts, add original author and mark PR as draft since manual resolution is required
           if [ "${{ steps.uplift.outputs.has_conflicts }}" = "true" ]; then
+            cat <<EOF >> comment_body.txt
+            ⚠️ Commits marked with conflicts require manual resolution, by rebasing locally to edit the commits or by recreating the branch. **DO NOT** fix up by adding an extra commit, only resolve conflicts directly on the cherry-pick commit(s).
+
+            To recreate this branch manually:
+            \`\`\`
+            git fetch enterprise-firefox ${{ matrix.target }}
+            git checkout -b ${{ steps.uplift.outputs.branch }} enterprise-firefox/${{ matrix.target }}
+            git cherry-pick ${{ steps.uplift.outputs.commits }}
+            \`\`\`
+            EOF
+
+            gh pr comment "$PR_URL" --body-file comment_body.txt
+
+            # Add original author and mark PR as draft since manual resolution is required
             gh pr edit "$PR_URL" --add-reviewer "${{ github.event.pull_request.user.login }}"
             gh pr ready "$PR_URL" --undo
           fi

--- a/.github/workflows/uplift.yml
+++ b/.github/workflows/uplift.yml
@@ -88,18 +88,22 @@ jobs:
 
           touch $SUMMARY_FILE
 
+          # rev-list --parents outputs:
+          # <commit> <parent1> [parent2 ...]
+          # So:
+          # 2 fields → normal commit (1 parent)
+          # >2 fields → merge commit (2+ parents)
           PARENTS=$(git rev-list --parents -n 1 $SHA)
           COUNT=$(echo $PARENTS | wc -w)
-
-          APPLIED=0
-
-          if [ "$COUNT" -eq 3 ]; then
+          if [ "$COUNT" -gt 2 ]; then
             echo "Merge commit → multi-commit mode"
             COMMITS=$(git log --reverse --no-merges --pretty=format:"%H" $SHA^1..$SHA^2)
           else
             echo "Single commit mode"
             COMMITS=$SHA
           fi
+
+          APPLIED=0
 
           for commit in $COMMITS; do
             SHORT=$(git rev-parse --short $commit)

--- a/.github/workflows/uplift.yml
+++ b/.github/workflows/uplift.yml
@@ -47,8 +47,8 @@ jobs:
         run: |
           labels='${{ toJson(github.event.pull_request.labels.*.name) }}'
 
-          [[ "$labels" == *"uplift-to-beta"* ]] && echo "beta=true" >> $GITHUB_OUTPUT
-          [[ "$labels" == *"uplift-to-release"* ]] && echo "release=true" >> $GITHUB_OUTPUT
+          [[ "$labels" == *'"uplift-to-beta"'* ]] && echo "beta=true" >> $GITHUB_OUTPUT
+          [[ "$labels" == *'"uplift-to-release"'* ]] && echo "release=true" >> $GITHUB_OUTPUT
 
       # ----------------------------------------
       # Shared uplift script

--- a/.github/workflows/uplift.yml
+++ b/.github/workflows/uplift.yml
@@ -15,35 +15,42 @@ on:
     types: [closed]
 
 jobs:
-  uplift:
-    if: >
-      github.event.pull_request.merged == true &&
-      github.event.pull_request.base.ref == matrix.source &&
-      contains(github.event.pull_request.labels.*.name, matrix.trigger_label)
-
+  build-matrix:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Set matrix
+        id: set-matrix
+        run: |
+          # Define all possible uplift paths
+          ALL_ENTRIES='[
+            {"source": "enterprise-main", "target": "enterprise-beta", "trigger_label": "uplift-to-beta", "target_label": "branch:beta"},
+            {"source": "enterprise-main", "target": "enterprise-release", "trigger_label": "uplift-to-release", "target_label": "branch:release"},
+            {"source": "enterprise-beta", "target": "enterprise-release", "trigger_label": "uplift-to-release", "target_label": "branch:release"}
+          ]'
+          
+          # Filter based on PR base ref and labels
+          BASE_REF='${{ github.event.pull_request.base.ref }}'
+          LABELS='${{ toJson(github.event.pull_request.labels.*.name) }}'
 
+          # Use jq to filter entries where source matches base.ref AND trigger_label is in labels
+          FILTERED=$(echo "$ALL_ENTRIES" | jq --arg base "$BASE_REF" --argjson labels "$LABELS" '[.[] | select(.source == $base and (.trigger_label | IN($labels[])))]')
+          
+          echo "matrix=$(echo $FILTERED | jq -c .)" >> $GITHUB_OUTPUT
+
+  uplift:
+    needs: build-matrix
+    if: fromJson(needs.build-matrix.outputs.matrix).length > 0
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
-
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - source: enterprise-main
-            target: enterprise-beta
-            trigger_label: uplift-to-beta
-            target_label: branch:beta
-          - source: enterprise-main
-            target: enterprise-release
-            trigger_label: uplift-to-release
-            target_label: branch:release
-          - source: enterprise-beta
-            target: enterprise-release
-            trigger_label: uplift-to-release
-            target_label: branch:release
-
+        include: ${{ fromJson(needs.build-matrix.outputs.matrix) }}
     env:
       MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
       PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/uplift.yml
+++ b/.github/workflows/uplift.yml
@@ -46,29 +46,23 @@ jobs:
       PR_TITLE: ${{ github.event.pull_request.title }}
       REPO_URL: https://github.com/${{ github.repository }}
       TARGET: ${{ matrix.target }}
+      PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        if: contains(env.PR_LABELS, matrix.label_check)
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Configure git
+        if: contains(env.PR_LABELS, matrix.label_check)
         run: |
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
 
-      - name: Check label
-        id: label_check
-        run: |
-          labels='${{ toJson(github.event.pull_request.labels.*.name) }}'
-
-          if [[ "$labels" == *"${{ matrix.label_check }}"* ]]; then
-            echo "run=true" >> $GITHUB_OUTPUT
-          else
-            echo "run=false" >> $GITHUB_OUTPUT
-          fi
-
       - name: Create uplift script
+        if: contains(env.PR_LABELS, matrix.label_check)
         run: |
           cat << 'EOF' > uplift.sh
           set -e
@@ -172,13 +166,15 @@ jobs:
           EOF
 
       - name: Uplift
-        if: steps.label_check.outputs.run == 'true'
         id: uplift
+        if: contains(env.PR_LABELS, matrix.label_check)
         run: |
           bash uplift.sh $TARGET $MERGE_SHA
 
       - name: Create PR
-        if: steps.label_check.outputs.run == 'true' && steps.uplift.outputs.branch != ''
+        if: >
+          contains(env.PR_LABELS, matrix.label_check) &&
+          steps.uplift.outputs.branch != ''
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/uplift.yml
+++ b/.github/workflows/uplift.yml
@@ -114,7 +114,7 @@ jobs:
                 fi
 
                 git add -A
-                git commit -m "Cherry-pick $commit with conflicts"
+                git cherry-pick --continue
                 echo "- [$SHORT]($LINK) $MSG (⚠️ conflict)" >> $SUMMARY_FILE
               else
                 echo "- [$SHORT]($LINK) $MSG" >> $SUMMARY_FILE
@@ -137,7 +137,7 @@ jobs:
 
             if [ $STATUS -ne 0 ]; then
               git add -A
-              git commit -m "Cherry-pick $SHA with conflicts"
+              git cherry-pick --continue
               echo "- [$SHORT]($LINK) $MSG (⚠️ conflict)" >> $SUMMARY_FILE
             else
               echo "- [$SHORT]($LINK) $MSG" >> $SUMMARY_FILE

--- a/.github/workflows/uplift.yml
+++ b/.github/workflows/uplift.yml
@@ -30,13 +30,13 @@ jobs:
             {"source": "enterprise-main", "target": "enterprise-release", "trigger_label": "uplift-to-release", "target_label": "branch:release"},
             {"source": "enterprise-beta", "target": "enterprise-release", "trigger_label": "uplift-to-release", "target_label": "branch:release"}
           ]'
-          
+
           # Filter based on PR base ref and labels
           BASE_REF='${{ github.event.pull_request.base.ref }}'
           LABELS='${{ toJson(github.event.pull_request.labels.*.name) }}'
 
           # Use jq to filter entries where source matches base.ref AND trigger_label is in labels
-          FILTERED=$(echo "$ALL_ENTRIES" | jq --arg base "$BASE_REF" --argjson labels "$LABELS" '[.[] | select(.source == $base and (.trigger_label | IN($labels[])))]')
+          FILTERED=$(echo "$ALL_ENTRIES" | jq --arg base "$BASE_REF" --argjson labels "$LABELS" '[.[] | select(.source == $base and (.trigger_label as $tl | $labels | index($tl) != null))]')
           
           echo "matrix=$(echo $FILTERED | jq -c .)" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/uplift.yml
+++ b/.github/workflows/uplift.yml
@@ -212,11 +212,17 @@ jobs:
             EOF
           fi
 
-          gh pr create \
+          PR_URL=$(gh pr create \
             --base "${{ matrix.target }}" \
             --head "$BRANCH" \
             --title "[${{ matrix.target }} uplift] $PR_TITLE" \
             --body-file pr_body.txt \
             --label "${{ matrix.target_label }}" \
-            --label "uplift" \
-            --reviewer "mozilla/enterprise-firefox-engineering"
+            --label "uplift")
+
+          gh pr edit "$PR_URL" --add-reviewer "mozilla/enterprise-firefox-engineering"
+
+          # Add original author if conflicts happened, since manual resolution is required
+          if [ "${{ steps.uplift.outputs.has_conflicts }}" = "true" ]; then
+            gh pr edit "$PR_URL" --add-reviewer "${{ github.event.pull_request.user.login }}"
+          fi

--- a/.github/workflows/uplift.yml
+++ b/.github/workflows/uplift.yml
@@ -34,11 +34,9 @@ jobs:
           - target: enterprise-beta
             label_check: uplift-to-beta
             label: branch:beta
-            title_prefix: "[enterprise-beta uplift]"
           - target: enterprise-release
             label_check: uplift-to-release
             label: branch:release
-            title_prefix: "[enterprise-release uplift]"
 
     env:
       MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
@@ -192,7 +190,7 @@ jobs:
           gh pr create \
             --base "$TARGET" \
             --head "$BRANCH" \
-            --title "${{ matrix.title_prefix }} ${{ env.PR_TITLE }}" \
+            --title "[$TARGET uplift] ${{ env.PR_TITLE }}" \
             --body-file pr_body.txt \
             --label "${{ matrix.label }}" \
             --label "uplift" \

--- a/.github/workflows/uplift.yml
+++ b/.github/workflows/uplift.yml
@@ -20,17 +20,32 @@ jobs:
     if: >
       github.event.pull_request.merged == true &&
       github.event.pull_request.base.ref == 'enterprise-main'
+
     runs-on: ubuntu-latest
 
     permissions:
       contents: write
       pull-requests: write
 
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: enterprise-beta
+            label_check: uplift-to-beta
+            label: branch:beta
+            title_prefix: "[enterprise-beta uplift]"
+          - target: enterprise-release
+            label_check: uplift-to-release
+            label: branch:release
+            title_prefix: "[enterprise-release uplift]"
+
     env:
       MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
       PR_TITLE: ${{ github.event.pull_request.title }}
       REPO_URL: https://github.com/${{ github.repository }}
+      TARGET: ${{ matrix.target }}
 
     steps:
       - uses: actions/checkout@v4
@@ -42,17 +57,17 @@ jobs:
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
 
-      - name: Read labels
-        id: labels
+      - name: Check label
+        id: label_check
         run: |
           labels='${{ toJson(github.event.pull_request.labels.*.name) }}'
 
-          [[ "$labels" == *'"uplift-to-beta"'* ]] && echo "beta=true" >> $GITHUB_OUTPUT
-          [[ "$labels" == *'"uplift-to-release"'* ]] && echo "release=true" >> $GITHUB_OUTPUT
+          if [[ "$labels" == *"${{ matrix.label_check }}"* ]]; then
+            echo "run=true" >> $GITHUB_OUTPUT
+          else
+            echo "run=false" >> $GITHUB_OUTPUT
+          fi
 
-      # ----------------------------------------
-      # Shared uplift script
-      # ----------------------------------------
       - name: Create uplift script
         run: |
           cat << 'EOF' > uplift.sh
@@ -156,68 +171,33 @@ jobs:
           echo "$DELIM" >> $GITHUB_OUTPUT
           EOF
 
-      # ----------------------------------------
-      # BETA
-      # ----------------------------------------
-      - name: Uplift to enterprise-beta
-        if: steps.labels.outputs.beta == 'true'
-        id: beta_uplift
+      - name: Uplift
+        if: steps.label_check.outputs.run == 'true'
+        id: uplift
         run: |
-          bash uplift.sh enterprise-beta $MERGE_SHA
+          bash uplift.sh $TARGET $MERGE_SHA
 
-      - name: Create PR (enterprise-beta)
-        if: steps.labels.outputs.beta == 'true' && steps.beta_uplift.outputs.branch != ''
+      - name: Create PR
+        if: steps.label_check.outputs.run == 'true' && steps.uplift.outputs.branch != ''
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          BRANCH="${{ steps.beta_uplift.outputs.branch }}"
+          BRANCH="${{ steps.uplift.outputs.branch }}"
 
           cat <<EOF > pr_body.txt
           Uplift from #${{ env.PR_NUMBER }}
 
           ## Commits
-          ${{ steps.beta_uplift.outputs.summary }}
+          ${{ steps.uplift.outputs.summary }}
 
           ⚠️ Commits marked with conflicts require manual resolution.
           EOF
 
           gh pr create \
-            --base enterprise-beta \
+            --base "$TARGET" \
             --head "$BRANCH" \
-            --title "[enterprise-beta uplift] ${{ env.PR_TITLE }}" \
+            --title "${{ matrix.title_prefix }} ${{ env.PR_TITLE }}" \
             --body-file pr_body.txt \
-            --label "branch:beta,uplift" \
-            --reviewer "mozilla/enterprise-firefox-engineering"
-
-      # ----------------------------------------
-      # RELEASE
-      # ----------------------------------------
-      - name: Uplift to enterprise-release
-        if: steps.labels.outputs.release == 'true'
-        id: rel_uplift
-        run: |
-          bash uplift.sh enterprise-release $MERGE_SHA
-
-      - name: Create PR (enterprise-release)
-        if: steps.labels.outputs.release == 'true' && steps.rel_uplift.outputs.branch != ''
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          BRANCH="${{ steps.rel_uplift.outputs.branch }}"
-
-          cat <<EOF > pr_body.txt
-          Uplift from #${{ env.PR_NUMBER }}
-
-          ## Commits
-          ${{ steps.rel_uplift.outputs.summary }}
-
-          ⚠️ Commits marked with conflicts require manual resolution.
-          EOF
-
-          gh pr create \
-            --base enterprise-release \
-            --head "$BRANCH" \
-            --title "[enterprise-release uplift] ${{ env.PR_TITLE }}" \
-            --body-file pr_body.txt \
-            --label "branch:release,uplift" \
+            --label "${{ matrix.label }}" \
+            --label "uplift" \
             --reviewer "mozilla/enterprise-firefox-engineering"

--- a/.github/workflows/uplift.yml
+++ b/.github/workflows/uplift.yml
@@ -167,20 +167,27 @@ jobs:
 
       - name: Create PR (enterprise-beta)
         if: steps.labels.outputs.beta == 'true' && steps.beta_uplift.outputs.branch != ''
-        uses: peter-evans/create-pull-request@v6
-        with:
-          branch: ${{ steps.beta_uplift.outputs.branch }}
-          base: enterprise-beta
-          title: "[enterprise-beta uplift] ${{ env.PR_TITLE }}"
-          labels: branch:beta,uplift
-          body: |
-            Uplift from #${{ env.PR_NUMBER }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          BRANCH="${{ steps.beta_uplift.outputs.branch }}"
 
-            ## Commits
-            ${{ steps.beta_uplift.outputs.summary }}
+          cat <<EOF > pr_body.txt
+          Uplift from #${{ env.PR_NUMBER }}
 
-            ⚠️ Commits marked with conflicts require manual resolution.
-          team-reviewers: enterprise-firefox-engineering
+          ## Commits
+          ${{ steps.beta_uplift.outputs.summary }}
+
+          ⚠️ Commits marked with conflicts require manual resolution.
+          EOF
+
+          gh pr create \
+            --base enterprise-beta \
+            --head "$BRANCH" \
+            --title "[enterprise-beta uplift] ${{ env.PR_TITLE }}" \
+            --body-file pr_body.txt \
+            --label "branch:beta,uplift" \
+            --reviewer "mozilla/enterprise-firefox-engineering"
 
       # ----------------------------------------
       # RELEASE
@@ -193,17 +200,24 @@ jobs:
 
       - name: Create PR (enterprise-release)
         if: steps.labels.outputs.release == 'true' && steps.rel_uplift.outputs.branch != ''
-        uses: peter-evans/create-pull-request@v6
-        with:
-          branch: ${{ steps.rel_uplift.outputs.branch }}
-          base: enterprise-release
-          title: "[enterprise-release uplift] ${{ env.PR_TITLE }}"
-          labels: branch:release,uplift
-          body: |
-            Uplift from #${{ env.PR_NUMBER }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          BRANCH="${{ steps.rel_uplift.outputs.branch }}"
 
-            ## Commits
-            ${{ steps.rel_uplift.outputs.summary }}
+          cat <<EOF > pr_body.txt
+          Uplift from #${{ env.PR_NUMBER }}
 
-            ⚠️ Commits marked with conflicts require manual resolution.
-          team-reviewers: enterprise-firefox-engineering
+          ## Commits
+          ${{ steps.rel_uplift.outputs.summary }}
+
+          ⚠️ Commits marked with conflicts require manual resolution.
+          EOF
+
+          gh pr create \
+            --base enterprise-release \
+            --head "$BRANCH" \
+            --title "[enterprise-release uplift] ${{ env.PR_TITLE }}" \
+            --body-file pr_body.txt \
+            --label "branch:release,uplift" \
+            --reviewer "mozilla/enterprise-firefox-engineering"

--- a/.github/workflows/uplift.yml
+++ b/.github/workflows/uplift.yml
@@ -119,6 +119,7 @@ jobs:
           fi
 
           HAS_APPLIED_COMMITS=0
+          HAS_CONFLICTS=0
 
           for commit in $COMMITS; do
             SHORT=$(git rev-parse --short $commit)
@@ -147,6 +148,7 @@ jobs:
               git add -A
               git cherry-pick --continue
               echo "- [$SHORT]($LINK) $MSG (⚠️ conflict)" >> $SUMMARY_FILE
+              HAS_CONFLICTS=1
             else
               echo "- [$SHORT]($LINK) $MSG" >> $SUMMARY_FILE
             fi
@@ -164,6 +166,12 @@ jobs:
           git push origin $BRANCH
 
           echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+          echo "commits=$(echo $COMMITS | tr '\n' ' ')" >> $GITHUB_OUTPUT
+          if [ "$HAS_CONFLICTS" -eq 1 ]; then
+            echo "has_conflicts=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_conflicts=false" >> $GITHUB_OUTPUT
+          fi
 
           DELIM="GITHUB_OUTPUT_$(uuidgen)"
           echo "summary<<$DELIM" >> $GITHUB_OUTPUT
@@ -188,9 +196,21 @@ jobs:
 
           ## Commits
           ${{ steps.uplift.outputs.summary }}
-
-          ⚠️ Commits marked with conflicts require manual resolution.
           EOF
+
+          if [ "${{ steps.uplift.outputs.has_conflicts }}" = "true" ]; then
+            cat <<EOF >> pr_body.txt
+
+            ⚠️ Commits marked with conflicts require manual resolution, by rebasing locally to edit the commits or by recreating the branch. **DO NOT** fix up by adding an extra commit, only resolve conflicts directly on the cherry-pick commit(s).
+
+            To recreate this branch manually:
+            \`\`\`
+            git fetch enterprise-firefox ${{ matrix.target }}
+            git checkout -b ${{ steps.uplift.outputs.branch }} enterprise-firefox/${{ matrix.target }}
+            git cherry-pick ${{ steps.uplift.outputs.commits }}
+            \`\`\`
+            EOF
+          fi
 
           gh pr create \
             --base "${{ matrix.target }}" \

--- a/.github/workflows/uplift.yml
+++ b/.github/workflows/uplift.yml
@@ -1,7 +1,18 @@
 name: Auto Uplift
 
 on:
-  pull_request:
+  # WARNING: pull_request_target MUST NOT be used if running code under control
+  # of the source PR [0], as it could risk leaking the GH_TOKENs.
+  #
+  # In this case, we do it as the job needs to run within the context of the
+  # target repo, so it can get a GH_TOKEN which it can use to comment on and
+  # update the PR.
+  #
+  # Crucially, no external code is loaded or run as part of this workflow.
+  #
+  # [0] https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target:~:text=Warning-,Running,websitehttps://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target:~:text=Warning-,Running,website
+  #
+  pull_request_target:
     types: [closed]
 
 jobs:


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-TODO
Adds a workflow that:
- triggers when a PR is merged
- checks whether labels `uplift-to-beta` or `uplift-to-release` are present in the PR and if the PR's target branch is one we would uplift from (`enterprise-main` for beta or release, and `enterprise-beta` for release)
- if so, cherry-picks the commit(s) from the merge into the `enterprise-beta`/`enterprise-release` branch(es) and creates uplift PR(s)
   - if the PR was done as a merge, cherry-picks the individual commits
   - if the PR was done as a squash, cherry-picks the squash commit
- if a conflict is encountered during a cherry-pick, the created uplift PR is changed to a Draft, and the original author is added as a reviewer with a comment for resolution instructions

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Testing <!-- OPTIONAL -->

TODO??
* [ ] Added tests
* [ ] Manual testing performed

<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
