### PR TITLE
Bug 2033768: Use port 0 for test HTTP servers to avoid port races

### DIFF
--- a/testing/enterprise/felt_tests.py
+++ b/testing/enterprise/felt_tests.py
@@ -58,6 +58,31 @@ class SharedString:
             self._array._obj.value = encoded
 
 
+class ConsoleSSOPortMixin:
+    """Provides console_port/sso_port properties that block until the
+    server processes have bound to their OS-assigned ports (port 0).
+    Expects _console_port and _sso_port to be multiprocessing.Value("i", 0)."""
+
+    def _wait_for_port(self, val):
+        for _ in range(40):
+            if val.value != 0:
+                return val.value
+            time.sleep(0.5)
+        raise RuntimeError("Server failed to start")
+
+    @property
+    def console_port(self):
+        return self._wait_for_port(self._console_port)
+
+    @property
+    def sso_port(self):
+        return self._wait_for_port(self._sso_port)
+
+
+class ConsoleSSOHTTPServer(ConsoleSSOPortMixin, HTTPServer):
+    pass
+
+
 class LocalHttpRequestHandler(BaseHTTPRequestHandler):
     def reply(self, payload, code=200, status="Success", contentType=None):
         self.send_response(code, status)
@@ -486,10 +511,10 @@ class ConsoleHttpHandler(LocalHttpRequestHandler):
 
 
 def serve(
-    port,
     classname,
     sso_port,
     console_port,
+    is_console,
     cookie_name=None,
     cookie_value=None,
     policy_block_about_config=None,
@@ -501,9 +526,14 @@ def serve(
     # TODO: Behavior is not yet clearly defined
     # device_posture_reply_forbidden=None,
 ):
-    httpd = HTTPServer(("", port), classname)
-    httpd.sso_port = sso_port
-    httpd.console_port = console_port
+    httpd = ConsoleSSOHTTPServer(("", 0), classname)
+    if is_console:
+        console_port.value = httpd.server_address[1]
+    else:
+        sso_port.value = httpd.server_address[1]
+    # There's a getter on the Mixin for these
+    httpd._sso_port = sso_port
+    httpd._console_port = console_port
     if cookie_name is not None:
         httpd.cookie_name = cookie_name
     if cookie_value is not None:
@@ -529,11 +559,11 @@ def serve(
         httpd.device_posture_reply_forbidden = device_posture_reply_forbidden
     """
     print(
-        f"Serving localhost:{port} SSO={sso_port} CONSOLE={console_port} with {classname}"
+        f"Serving localhost:{httpd.server_address[1]} SSO={httpd.sso_port} CONSOLE={httpd.console_port} with {classname}"
     )
     httpd.serve_forever()
     print(
-        f"Stopped serving localhost:{port} SSO={sso_port} CONSOLE={console_port} with {classname}"
+        f"Stopped serving localhost:{httpd.server_address[1]} SSO={httpd.sso_port} CONSOLE={httpd.console_port} with {classname}"
     )
 
 
@@ -613,15 +643,16 @@ def find_free_port():
         return s.getsockname()[1]
 
 
-class FeltTestsBase(EnterpriseTestsBase):
+class FeltTestsBase(ConsoleSSOPortMixin, EnterpriseTestsBase):
     EXTRA_ENV = {}
 
     def setUp(self):
         # test_prefs = kwargs.get("test_prefs", [])
 
         self._manually_closed_child = False
-        self.console_port = find_free_port()
-        self.sso_port = find_free_port()
+        # Private; use console_port and sso_port properties from ConsoleSSOPortMixin instead
+        self._console_port = Value("i", 0)
+        self._sso_port = Value("i", 0)
         self.policy_block_about_config = Value("b", 1)
         self.policy_extensions = Value("B", 0)
         self.policies_fail_request = Value("B", 0)
@@ -636,10 +667,11 @@ class FeltTestsBase(EnterpriseTestsBase):
 
         self.console_httpd = Process(
             target=serve,
-            args=(self.console_port, ConsoleHttpHandler),
+            args=(ConsoleHttpHandler,),
             kwargs=dict(
-                sso_port=self.sso_port,
-                console_port=self.console_port,
+                sso_port=self._sso_port,
+                console_port=self._console_port,
+                is_console=True,
                 policy_block_about_config=self.policy_block_about_config,
                 policy_extensions=self.policy_extensions,
                 policy_access_token=self.policy_access_token,
@@ -656,10 +688,11 @@ class FeltTestsBase(EnterpriseTestsBase):
         self.cookie_value = SharedString(str(uuid.uuid4()).split("-")[4])
         self.sso_httpd = Process(
             target=serve,
-            args=(self.sso_port, SsoHttpHandler),
+            args=(SsoHttpHandler,),
             kwargs=dict(
-                sso_port=self.sso_port,
-                console_port=self.console_port,
+                sso_port=self._sso_port,
+                console_port=self._console_port,
+                is_console=False,
                 cookie_name=self.cookie_name,
                 cookie_value=self.cookie_value,
             ),


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2033768

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

Basically we can run into cases currently the port is in usage in the server setup, this was actually introduced by myself trying to solve another issue where port 10080 is perma blocked.

[PR 719](https://github.com/mozilla/enterprise-firefox/pull/719)


Here is the new issue

```
[task 2026-04-21T08:32:06.981+00:00] 08:32:06     INFO - TEST-START | testing/enterprise/test_felt_browser_context_menu.py BrowserContextMenu.test_browser_context_menu
[task 2026-04-21T08:32:06.984+00:00] 08:32:06     INFO -  Serving localhost:35799 SSO=35799 CONSOLE=35799 with <class 'felt_tests.ConsoleHttpHandler'>
[task 2026-04-21T08:32:06.986+00:00] 08:32:06     INFO -  Process Process-16:
[task 2026-04-21T08:32:06.987+00:00] 08:32:06     INFO - Application command: /builds/worker/workspace/build/application/firefox/firefox -marionette -remote-allow-system-access -profile /tmp/tmp2fu8e8i4.mozrunner
[task 2026-04-21T08:32:06.987+00:00] 08:32:06     INFO -  Traceback (most recent call last):
[task 2026-04-21T08:32:06.988+00:00] 08:32:06     INFO -    File "/usr/lib/python3.12/multiprocessing/process.py", line 314, in _bootstrap
[task 2026-04-21T08:32:06.988+00:00] 08:32:06     INFO -      self.run()
[task 2026-04-21T08:32:06.988+00:00] 08:32:06     INFO -    File "/usr/lib/python3.12/multiprocessing/process.py", line 108, in run
[task 2026-04-21T08:32:06.988+00:00] 08:32:06     INFO -      self._target(*self._args, **self._kwargs)
[task 2026-04-21T08:32:06.988+00:00] 08:32:06     INFO -    File "/builds/worker/workspace/build/tests/marionette/tests/testing/enterprise/felt_tests.py", line 504, in serve
[task 2026-04-21T08:32:06.989+00:00] 08:32:06     INFO -      httpd = HTTPServer(("", port), classname)
[task 2026-04-21T08:32:06.989+00:00] 08:32:06     INFO -              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[task 2026-04-21T08:32:06.989+00:00] 08:32:06     INFO -    File "/usr/lib/python3.12/socketserver.py", line 457, in __init__
[task 2026-04-21T08:32:06.989+00:00] 08:32:06     INFO -      self.server_bind()
[task 2026-04-21T08:32:06.989+00:00] 08:32:06     INFO -    File "/usr/lib/python3.12/http/server.py", line 136, in server_bind
[task 2026-04-21T08:32:06.989+00:00] 08:32:06     INFO -      socketserver.TCPServer.server_bind(self)
[task 2026-04-21T08:32:06.990+00:00] 08:32:06     INFO -    File "/usr/lib/python3.12/socketserver.py", line 473, in server_bind
[task 2026-04-21T08:32:06.990+00:00] 08:32:06     INFO -      self.socket.bind(self.server_address)
[task 2026-04-21T08:32:06.990+00:00] 08:32:06     INFO -  OSError: [Errno 98] Address already in use
```

In the PR basically we let the server take any free port using 0 as port. We need to make sure to have some "busy port getters" cause currently we are using the ports in different places.


---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on:

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

---

### Testing <!-- OPTIONAL -->

* [ ] Added tests
* [x] Manual testing performed

[Here](https://firefox-ci-tc.services.mozilla.com/tasks/groups/ScNbbtKAQD6k0SPhw5KkHA#marionette) I ran 20 x 4, 79/80, the test that failed was unrelated to this


<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
