### PR TITLE
Bug 2031652 - Enterprise: queue opening new window on remoting call of Felt

### DIFF
--- a/browser/components/BrowserContentHandler.sys.mjs
+++ b/browser/components/BrowserContentHandler.sys.mjs
@@ -1669,6 +1669,8 @@ nsDefaultCommandLineHandler.prototype = {
     // window. Instead, forward any URLs to be opened in the real Firefox.
     if (Services.felt && Services.felt.isFeltUI()) {
       console.debug(`Felt: Found FeltUI in BrowserContentHandler.`);
+      const wasPreventDefault = cmdLine.preventDefault;
+
       cmdLine.preventDefault = true;
 
       // Consume Felt-specific flags that don't take parameters
@@ -1712,6 +1714,13 @@ nsDefaultCommandLineHandler.prototype = {
             });
           }
         }
+      } else if (
+        !wasPreventDefault &&
+        cmdLine.state != Ci.nsICommandLine.STATE_INITIAL_LAUNCH
+      ) {
+        queueFeltURL({
+          disposition: FELT_OPEN_WINDOW_DISPOSITION.NEW_WINDOW,
+        });
       }
       return;
     }

--- a/testing/enterprise/test_felt_browser_new_window_from_cli.py
+++ b/testing/enterprise/test_felt_browser_new_window_from_cli.py
@@ -109,37 +109,49 @@ class FeltNewWindowFromCli(FeltTests):
     def test_new_window_from_cli(self):
         super().run_felt_base()
         self.connect_child_browser()
+        self.run_felt_open_new_window_from_cli(
+            f"http://localhost:{self.console_port}/ping"
+        )
         self.run_felt_open_new_window_from_cli()
+        self.run_felt_open_private_window_from_cli(
+            f"http://localhost:{self.sso_port}/sso_url"
+        )
         self.run_felt_open_private_window_from_cli()
 
-    def run_felt_open_new_window_from_cli(self):
-        url = f"http://localhost:{self.console_port}/ping"
+    def run_felt_open_new_window_from_cli(self, url=None):
+        """
+        If launching with no URL and no --new-window, this is mostly similar as
+        testing DBus's Freedesktop Activate but during tests there are no
+        .desktop file registered.  So just launch the binary as it would have
+        been from .desktop definition.
+        """
+
         windows = self._get_child_windows()
         initial_count = len(windows)
         args = [
             f"{self._driver.instance.binary}",
             "-profile",
-            self._child_profile_path,
-            "--new-window",
-            url,
+            self._driver.profile,
         ]
+        if url:
+            args += ["--new-window", url]
         subprocess.check_call(args, shell=False)
 
         self._wait_for_window_count(initial_count + 1)
-        self._wait_for_window_with_url(url, is_private=False)
+        self._wait_for_window_with_url(url or "about:blank", is_private=False)
 
-    def run_felt_open_private_window_from_cli(self):
-        url = f"http://localhost:{self.sso_port}/sso_url"
+    def run_felt_open_private_window_from_cli(self, url=None):
         windows = self._get_child_windows()
         initial_count = len(windows)
         args = [
             f"{self._driver.instance.binary}",
             "-profile",
-            self._child_profile_path,
+            self._driver.profile,
             "--private-window",
-            url,
         ]
+        if url:
+            args += [url]
         subprocess.check_call(args, shell=False)
 
         self._wait_for_window_count(initial_count + 1)
-        self._wait_for_window_with_url(url, is_private=True)
+        self._wait_for_window_with_url(url or "about:privatebrowsing", is_private=True)

--- a/testing/enterprise/test_felt_browser_rapid_new_windows_from_cli.py
+++ b/testing/enterprise/test_felt_browser_rapid_new_windows_from_cli.py
@@ -30,7 +30,7 @@ class FeltRapidNewWindowsFromCli(FeltNewWindowFromCli):
             args = [
                 f"{self._driver.instance.binary}",
                 "-profile",
-                self._child_profile_path,
+                self._driver.profile,
                 "--new-window",
                 url,
             ]


### PR DESCRIPTION
Interacting from Linux' dock or others over DBus to open a new window launches "firefox" without any parameter. This results in Felt being shown instead of opening a new window. Check in browser's command line handler section of Felt, and if there is no URL list for a **non initial launch** (i.e. a remoted call) then pass over queueing a new window.

<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2031652

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Testing <!-- OPTIONAL -->

* [x] Added tests
* [x] Manual testing performed

**Steps to verify changes:**
1. Download deb package from CI and install
1. OR: `mach build && mach package && .mach repackage deb --input obj-felt-dbg/dist/firefox-*.en-US.linux-x86_64.tar.bz2 --output obj-felt-dbg/dist/firefox-152.0a1.en-US.linux-x86_64.deb --arch x86_64 --build-number $(grep "BuildID" obj-felt-dbg/dist/bin/application.ini | cut -d'=' -f2 | tr -d '\n') --version $(grep "^Version=" obj-felt-dbg/dist/bin/application.ini | cut -d'=' -f2 | tr -d '\n') --templates ./browser/installer/linux/app/debian/ --release-product firefox --release-type nightly`
2. Launch, identify and get browser
3. Right click on the dock icon, "new window"

**Expected result:**
A new window is opened