### PR TITLE
Bug 2035426 - Enterprise: add missing mozconfig

### DIFF
--- a/browser/config/mozconfigs/linux64/beta-enterprise
+++ b/browser/config/mozconfigs/linux64/beta-enterprise
@@ -1,0 +1,5 @@
+. "$topsrcdir/browser/config/mozconfigs/linux64/common-opt"
+
+ac_add_options --enable-enterprise
+
+. "$topsrcdir/build/mozconfig.common.override"

--- a/browser/config/mozconfigs/macosx64-aarch64/beta-enterprise
+++ b/browser/config/mozconfigs/macosx64-aarch64/beta-enterprise
@@ -1,0 +1,5 @@
+. "$topsrcdir/browser/config/mozconfigs/macosx64-aarch64/common-opt"
+
+ac_add_options --enable-enterprise
+
+. "$topsrcdir/build/mozconfig.common.override"

--- a/browser/config/mozconfigs/macosx64/beta-enterprise
+++ b/browser/config/mozconfigs/macosx64/beta-enterprise
@@ -1,0 +1,5 @@
+. "$topsrcdir/browser/config/mozconfigs/macosx64/common-opt"
+
+ac_add_options --enable-enterprise
+
+. "$topsrcdir/build/mozconfig.common.override"

--- a/browser/config/mozconfigs/win64/beta-enterprise
+++ b/browser/config/mozconfigs/win64/beta-enterprise
@@ -1,0 +1,7 @@
+. "$topsrcdir/build/mozconfig.win-common"
+. "$topsrcdir/browser/config/mozconfigs/win64/common-win64"
+. "$topsrcdir/browser/config/mozconfigs/win64/common-opt"
+
+ac_add_options --enable-enterprise
+
+. "$topsrcdir/build/mozconfig.common.override"


### PR DESCRIPTION
The beta builds were missing their mozconfig file for opt builds failing everywhere. Not caught earlier because of broken treeherder display.

Bugzilla: Bug-2035426

### Testing <!-- OPTIONAL -->

* [ ] Manual testing performed

Testing by pusing to CI