### PR TITLE
Revert "Bug 2034394: unlock captivedetect.canonicalURL for captive portal tests on enterprise builds"

### DIFF
--- a/browser/base/content/test/captivePortal/head.js
+++ b/browser/base/content/test/captivePortal/head.js
@@ -1,14 +1,3 @@
-// Enterprise builds lock captivedetect.canonicalURL. Unlock it so tests can set it to a local server.
-if (
-  AppConstants.MOZ_ENTERPRISE &&
-  Services.prefs.prefIsLocked("captivedetect.canonicalURL")
-) {
-  Services.prefs.unlockPref("captivedetect.canonicalURL");
-  registerCleanupFunction(() => {
-    Services.prefs.lockPref("captivedetect.canonicalURL");
-  });
-}
-
 XPCOMUtils.defineLazyServiceGetter(
   this,
   "cps",


### PR DESCRIPTION
Reverts mozilla/enterprise-firefox#775