### PR TITLE
Bug 2035477 - Fix l10n issues in the signout and close dialog

### DIFF
--- a/browser/components/enterprise/EnterpriseHandler.sys.mjs
+++ b/browser/components/enterprise/EnterpriseHandler.sys.mjs
@@ -344,7 +344,7 @@ export const EnterpriseHandler = {
 
     let titleId, messageId;
     if (hasTabsWarning) {
-      const warnSuffix = warnOnSignout ? "-warn" : "";
+      const warnSuffix = warnOnSignout ? "-and-signout-warning" : "";
       titleId = {
         id: `enterprise-close-prompt-title-with-tabcount${warnSuffix}`,
         args: { tabCount },

--- a/browser/components/enterprise/EnterpriseHandler.sys.mjs
+++ b/browser/components/enterprise/EnterpriseHandler.sys.mjs
@@ -344,9 +344,15 @@ export const EnterpriseHandler = {
 
     let titleId, messageId;
     if (hasTabsWarning) {
-      const args = { tabCount, warnSignout: warnOnSignout.toString() };
-      titleId = { id: "enterprise-close-prompt-title-with-tabcount", args };
-      messageId = { id: "enterprise-close-prompt-message-with-tabcount", args };
+      const warnSuffix = warnOnSignout ? "-warn" : "";
+      titleId = {
+        id: `enterprise-close-prompt-title-with-tabcount${warnSuffix}`,
+        args: { tabCount },
+      };
+      messageId = {
+        id: `enterprise-close-prompt-message-with-tabcount${warnSuffix}`,
+        args: warnOnSignout ? { tabCount } : {},
+      };
     } else {
       titleId = { id: "enterprise-close-prompt-title" };
       messageId = { id: "enterprise-close-prompt-message" };

--- a/browser/locales/en-US/browser/enterprise/enterprise.ftl
+++ b/browser/locales/en-US/browser/enterprise/enterprise.ftl
@@ -19,7 +19,7 @@ enterprise-close-prompt-title = Close { -brand-short-name }?
 
 # Variables:
 #   $tabCount (Number): The number of tabs to be closed.
-enterprise-close-prompt-title-with-tabcount-warn =
+enterprise-close-prompt-title-with-tabcount-and-signout-warning =
     { $tabCount ->
         [one] Close { -brand-short-name } and { $tabCount } tab?
        *[other] Close { -brand-short-name } and { $tabCount } tabs?
@@ -37,7 +37,7 @@ enterprise-close-prompt-message = You’re about to sign out of { -brand-short-n
 
 # Variables:
 #   $tabCount (Number): The number of tabs to be closed.
-enterprise-close-prompt-message-with-tabcount-warn =
+enterprise-close-prompt-message-with-tabcount-and-signout-warning =
     { $tabCount ->
         [one] You’re about to sign out of { -brand-short-name } and close { $tabCount } tab.
        *[other] You’re about to sign out of { -brand-short-name } and close { $tabCount } tabs.

--- a/browser/locales/en-US/browser/enterprise/enterprise.ftl
+++ b/browser/locales/en-US/browser/enterprise/enterprise.ftl
@@ -19,34 +19,31 @@ enterprise-close-prompt-title = Close { -brand-short-name }?
 
 # Variables:
 #   $tabCount (Number): The number of tabs to be closed.
-#   $warnSignout (String): "true" when the sign-out warning is shown.
-enterprise-close-prompt-title-with-tabcount =
-    { $warnSignout ->
-        [true]
-            { $tabCount ->
-                [one] Close { -brand-short-name } and { $tabCount } tab?
-               *[other] Close { -brand-short-name } and { $tabCount } tabs?
-            }
-       *[false]
-            { $tabCount ->
-                [one] Close { $tabCount } tab?
-               *[other] Close { $tabCount } tabs?
-            }
+enterprise-close-prompt-title-with-tabcount-warn =
+    { $tabCount ->
+        [one] Close { -brand-short-name } and { $tabCount } tab?
+       *[other] Close { -brand-short-name } and { $tabCount } tabs?
     }
+
+# Variables:
+#   $tabCount (Number): The number of tabs to be closed.
+enterprise-close-prompt-title-with-tabcount =
+    { $tabCount ->
+        [one] Close { $tabCount } tab?
+       *[other] Close { $tabCount } tabs?
+    }
+
 enterprise-close-prompt-message = You’re about to sign out of { -brand-short-name } and end your session.
 
 # Variables:
 #   $tabCount (Number): The number of tabs to be closed.
-#   $warnSignout (String): "true" when the sign-out warning is shown.
-enterprise-close-prompt-message-with-tabcount =
-    { $warnSignout ->
-        [true]
-            { $tabCount ->
-                [one] You’re about to sign out of { -brand-short-name } and close { $tabCount } tab.
-               *[other] You’re about to sign out of { -brand-short-name } and close { $tabCount } tabs.
-            }
-       *[false] Closing { -brand-short-name } will also sign you out.
+enterprise-close-prompt-message-with-tabcount-warn =
+    { $tabCount ->
+        [one] You’re about to sign out of { -brand-short-name } and close { $tabCount } tab.
+       *[other] You’re about to sign out of { -brand-short-name } and close { $tabCount } tabs.
     }
+
+enterprise-close-prompt-message-with-tabcount = Closing { -brand-short-name } will also sign you out.
 enterprise-close-prompt-message-reauth = To use { -brand-short-name } again, you’ll need to reauthenticate through your organization’s SSO provider.
 enterprise-close-prompt-checkbox-label = Warn me when closing { -brand-short-name } signs me out
 enterprise-close-prompt-tabs-checkbox-label = Warn me when closing multiple tabs


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Splits warnOnSignout to use two separate FTL strings instead of a FTL variant. Using an FTL variant in this way is an antipattern and should be avoided.

Bugzilla: Bug-2035477

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* https://github.com/mozilla-l10n/enterprise-firefox-l10n/pull/10
