### PR TITLE
Bug 2035477 - Fix l10n issues in the signout and close dialog (release uplift)

### DIFF
--- a/browser/locales/en-US/browser/enterprise/enterprise.ftl
+++ b/browser/locales/en-US/browser/enterprise/enterprise.ftl
@@ -18,7 +18,6 @@ enterprise-panel-sign-out-btn =
 # $tabCount (Number) - the number of open tabs
 enterprise-signout-prompt-title2 =
     { $tabCount ->
-        [0] Sign out of { -brand-short-name }?
         [one] Sign out of { -brand-short-name }?
        *[other] Sign out and close { $tabCount } tabs?
     }


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Removes the redundant `[0]` FTL selector. When tabCount is 0, the signout prompt should use the singular form, which is already handled by the `[one]` selector.

Uplift does not need the string splitting in #802 since it does not yet use the custom signout dialog.

Bugzilla: Bug-2035477

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Uplift of: #802
* https://github.com/mozilla-l10n/enterprise-firefox-l10n/pull/10
