### PR TITLE
Bug 2036752: Use correct registry path for PreXULSkeletonUI in enterprise builds and allow skeleton UI when MOZ_BYPASS_FELT is set

### DIFF
--- a/mozglue/misc/PreXULSkeletonUI.cpp
+++ b/mozglue/misc/PreXULSkeletonUI.cpp
@@ -1656,13 +1656,22 @@ static Result<Ok, PreXULSkeletonUIError> ValidateCmdlineArguments(
     }
   }
 
+#if defined(MOZ_ENTERPRISE)
+  // If there is MOZ_BYPASS_FELT environment variable, then likely tests are
+  // executing and thus no `-felt <socket>` argument can be found to verify if
+  // this is running a browser. By essence of that variable it is known the
+  // browser is running and not Felt UI so explicitely use the PreSkeletonUI
+  // in this case.
+  if (EnvHasValue("MOZ_BYPASS_FELT")) {
+    return Ok();
+  }
+
   // When starting FELT, disable the PreXULSkeletonUI. Checking with
   // is_felt_browser() is not doable here because this symbol is defined in
   // libxul however the present code runs in firefox.exe. Hence checking the
   // existence of "-felt" as is_felt_browser() would be doing, so
   // PreXULSkeletonUI is kept for normal browser, just disabled for FELT
   // window.
-#if defined(MOZ_ENTERPRISE)
   if (!hasFeltFlag) {
     return Err(PreXULSkeletonUIError::Cmdline);
   }

--- a/testing/enterprise/manifest.toml
+++ b/testing/enterprise/manifest.toml
@@ -87,6 +87,11 @@ run-if = [
   "buildapp == 'browser'", # browser specific: enterprise panel
 ]
 
+["test_felt_browser_skeleton_ui.py"]
+run-if = [
+  "os == 'win'",
+]
+
 ["test_felt_browser_starts.py"]
 run-if = [
   "buildapp == 'browser'", # open new tab

--- a/testing/enterprise/test_felt_browser_skeleton_ui.py
+++ b/testing/enterprise/test_felt_browser_skeleton_ui.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import os
+import sys
+
+sys.path.append(os.path.dirname(__file__))
+
+from test_felt_browser_signout import BaseBrowserSignout
+
+
+class BrowserSkeletonUI(BaseBrowserSignout):
+    def test_skeleton_ui_not_shown_for_felt(self):
+        self.run_check_skeleton_ui(self._driver, expected=False)
+
+        super().run_felt_base()
+        self.connect_child_browser(
+            capabilities={
+                # Do not auto-handle prompts.
+                "unhandledPromptBehavior": "ignore"
+            }
+        )
+        # Skeleton UI is not shown for the child browser either, which is
+        # expected since we use FELT and don't need it.
+        self.run_check_skeleton_ui(self._child_driver, expected=False)
+        self._do_signout()
+
+        self._logger.info("Restarting felt out-of-process")
+        self.marionette.restart(in_app=False)
+        self._logger.info("Felt restarted")
+        self.run_check_skeleton_ui(self._driver, expected=False)
+        self._manually_closed_child = True
+
+    def run_check_skeleton_ui(self, driver, expected):
+        with driver.using_context(driver.CONTEXT_CHROME):
+            showed = driver.execute_script(
+                "return Services.startup.showedPreXULSkeletonUI;"
+            )
+        self._logger.info(f"showedPreXULSkeletonUI: {showed}")
+
+        assert showed == expected, (
+            f"Expected showedPreXULSkeletonUI to be {expected}, got {showed}"
+        )


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2036752

In enterprise builds, the PreXULSkeletonUI startup check requires the -felt flag to be present, but mochitests don't pass this flag, so adding MOZ_BYPASS_FELT as an alternative allows the skeleton UI to run during tests and prevents browser_preXULSkeletonUIRegistry from failing on enterprise builds.

Additionally the MOZ_APP_BASENAME is used in C++ to compute the registry path, vs a hardcoded "firefox" on the test, which fails on enterprise

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on: https://phabricator.services.mozilla.com/D298838 landing on enterprise

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

---

### Testing <!-- OPTIONAL -->

* [ ] Added tests
* [x] Manual testing performed
[See test pass with latest changes](https://treeherder.mozilla.org/logviewer?job_id=566227017&repo=enterprise-firefox-pr&task=RUDVu4nyTxqH7VeP9PXY_A.0&lineNumber=2623)
[See test fail without changes](https://treeherder.mozilla.org/logviewer?job_id=564334446&repo=enterprise-firefox-pr&task=RrHrCFPbS0Cdj04UeirgMA.0&lineNumber=2984)

<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
