### PR TITLE
Bug 2034845 - Fix broken Access Connector on policy modification

### DIFF
--- a/toolkit/components/ipprotection/IPPAutoStart.sys.mjs
+++ b/toolkit/components/ipprotection/IPPAutoStart.sys.mjs
@@ -54,16 +54,15 @@ class IPPAutoStartSingleton {
       false
     );
 
-    this.#handleListChanged = async () => {
+    this.#handleListChanged = () => {
       if (!lazy.IPProtectionServerlist.hasList) {
         return;
       }
-      if (lazy.IPPProxyManager.state === lazy.IPPProxyStates.ACTIVE) {
-        await lazy.IPPProxyManager.stop(false);
-        await lazy.IPPProxyManager.start(
-          false,
-          PrivateBrowsingUtils.permanentPrivateBrowsing
-        );
+      if (
+        this.autoStart &&
+        lazy.IPPProxyManager.state === lazy.IPPProxyStates.ACTIVE
+      ) {
+        lazy.IPPProxyManager.switch();
         return;
       }
       this.init();

--- a/toolkit/components/ipprotection/IPPAutoStart.sys.mjs
+++ b/toolkit/components/ipprotection/IPPAutoStart.sys.mjs
@@ -54,30 +54,30 @@ class IPPAutoStartSingleton {
       false
     );
 
-    this.#handleListChanged = async () => {
+    this.#handleListChanged = () => {
       if (!lazy.IPProtectionServerlist.hasList) {
         return;
       }
       if (this.autoStart) {
         const state = lazy.IPPProxyManager.state;
-        if (state === lazy.IPPProxyStates.ACTIVE) {
-          lazy.IPPProxyManager.switch();
-          return;
-        }
-        if (state === lazy.IPPProxyStates.ERROR) {
-          await lazy.IPPProxyManager.reset();
-          lazy.IPPProxyManager.start(
-            false,
-            PrivateBrowsingUtils.permanentPrivateBrowsing
-          );
-          return;
-        }
-        if (state === lazy.IPPProxyStates.READY) {
-          lazy.IPPProxyManager.start(
-            false,
-            PrivateBrowsingUtils.permanentPrivateBrowsing
-          );
-          return;
+        switch (state) {
+          case lazy.IPPProxyStates.ACTIVE:
+            lazy.IPPProxyManager.switch();
+            return;
+          case lazy.IPPProxyStates.ERROR:
+            lazy.IPPProxyManager.reset().then(() => {
+              lazy.IPPProxyManager.start(
+                false,
+                PrivateBrowsingUtils.permanentPrivateBrowsing
+              );
+            });
+            return;
+          case lazy.IPPProxyStates.READY:
+            lazy.IPPProxyManager.start(
+              false,
+              PrivateBrowsingUtils.permanentPrivateBrowsing
+            );
+            return;
         }
       }
       this.init();

--- a/toolkit/components/ipprotection/IPPAutoStart.sys.mjs
+++ b/toolkit/components/ipprotection/IPPAutoStart.sys.mjs
@@ -4,6 +4,7 @@
 
 import { PrivateBrowsingUtils } from "resource://gre/modules/PrivateBrowsingUtils.sys.mjs";
 import { XPCOMUtils } from "resource://gre/modules/XPCOMUtils.sys.mjs";
+import { IPPEarlyStartupFilter } from "moz-src:///toolkit/components/ipprotection/IPPEarlyStartupFilter.sys.mjs";
 
 const lazy = {};
 
@@ -11,8 +12,6 @@ ChromeUtils.defineESModuleGetters(lazy, {
   IPProtectionServerlist:
     "moz-src:///toolkit/components/ipprotection/IPProtectionServerlist.sys.mjs",
   IPPProxyManager:
-    "moz-src:///toolkit/components/ipprotection/IPPProxyManager.sys.mjs",
-  IPPProxyStates:
     "moz-src:///toolkit/components/ipprotection/IPPProxyManager.sys.mjs",
   IPProtectionService:
     "moz-src:///toolkit/components/ipprotection/IPProtectionService.sys.mjs",
@@ -133,76 +132,9 @@ class IPPAutoStartSingleton {
 
 const IPPAutoStart = new IPPAutoStartSingleton();
 
-/**
- * This class monitors the startup phases and registers/unregisters the channel
- * filter to avoid data leak. The activation of the VPN is done by the
- * IPPAutoStart and IPPAutoRestore objects above.
- */
-class IPPEarlyStartupFilter {
-  #autoStartAndAtStartup = false;
-
-  constructor() {
-    this.handleEvent = this.#handleEvent.bind(this);
-    this.#autoStartAndAtStartup = IPPAutoStart.autoStart;
-  }
-
-  init() {
-    if (this.#autoStartAndAtStartup) {
-      lazy.IPPProxyManager.createChannelFilter();
-
-      lazy.IPProtectionService.addEventListener(
-        "IPProtectionService:StateChanged",
-        this.handleEvent
-      );
-      lazy.IPPProxyManager.addEventListener(
-        "IPPProxyManager:StateChanged",
-        this.handleEvent
-      );
-    }
-  }
-
-  initOnStartupCompleted() {}
-
-  uninit() {
-    if (this.#autoStartAndAtStartup) {
-      this.#autoStartAndAtStartup = false;
-
-      lazy.IPPProxyManager.removeEventListener(
-        "IPPProxyManager:StateChanged",
-        this.handleEvent
-      );
-      lazy.IPProtectionService.removeEventListener(
-        "IPProtectionService:StateChanged",
-        this.handleEvent
-      );
-    }
-  }
-
-  #cancelChannelFilter() {
-    lazy.IPPProxyManager.cancelChannelFilter();
-  }
-
-  #handleEvent(_event) {
-    switch (lazy.IPProtectionService.state) {
-      case lazy.IPProtectionStates.UNAVAILABLE:
-      case lazy.IPProtectionStates.UNAUTHENTICATED:
-        // These states block the auto-start at startup.
-        this.#cancelChannelFilter();
-        this.uninit();
-        break;
-
-      default:
-        // Let's ignoring any other state.
-        break;
-    }
-
-    if (lazy.IPPProxyManager.state === lazy.IPPProxyStates.ACTIVE) {
-      // We have completed our task.
-      this.uninit();
-    }
-  }
-}
-
-const IPPAutoStartHelpers = [IPPAutoStart, new IPPEarlyStartupFilter()];
+const IPPAutoStartHelpers = [
+  IPPAutoStart,
+  new IPPEarlyStartupFilter(() => IPPAutoStart.autoStart),
+];
 
 export { IPPAutoStartHelpers };

--- a/toolkit/components/ipprotection/IPPAutoStart.sys.mjs
+++ b/toolkit/components/ipprotection/IPPAutoStart.sys.mjs
@@ -54,34 +54,7 @@ class IPPAutoStartSingleton {
       false
     );
 
-    this.#handleListChanged = () => {
-      if (!lazy.IPProtectionServerlist.hasList) {
-        return;
-      }
-      if (this.autoStart) {
-        const state = lazy.IPPProxyManager.state;
-        switch (state) {
-          case lazy.IPPProxyStates.ACTIVE:
-            lazy.IPPProxyManager.switch();
-            return;
-          case lazy.IPPProxyStates.ERROR:
-            lazy.IPPProxyManager.reset().then(() => {
-              lazy.IPPProxyManager.start(
-                false,
-                PrivateBrowsingUtils.permanentPrivateBrowsing
-              );
-            });
-            return;
-          case lazy.IPPProxyStates.READY:
-            lazy.IPPProxyManager.start(
-              false,
-              PrivateBrowsingUtils.permanentPrivateBrowsing
-            );
-            return;
-        }
-      }
-      this.init();
-    };
+    this.#handleListChanged = () => this.init();
     lazy.IPProtectionServerlist.addEventListener(
       "IPProtectionServerlist:ListChanged",
       this.#handleListChanged

--- a/toolkit/components/ipprotection/IPPAutoStart.sys.mjs
+++ b/toolkit/components/ipprotection/IPPAutoStart.sys.mjs
@@ -54,16 +54,31 @@ class IPPAutoStartSingleton {
       false
     );
 
-    this.#handleListChanged = () => {
+    this.#handleListChanged = async () => {
       if (!lazy.IPProtectionServerlist.hasList) {
         return;
       }
-      if (
-        this.autoStart &&
-        lazy.IPPProxyManager.state === lazy.IPPProxyStates.ACTIVE
-      ) {
-        lazy.IPPProxyManager.switch();
-        return;
+      if (this.autoStart) {
+        const state = lazy.IPPProxyManager.state;
+        if (state === lazy.IPPProxyStates.ACTIVE) {
+          lazy.IPPProxyManager.switch();
+          return;
+        }
+        if (state === lazy.IPPProxyStates.ERROR) {
+          await lazy.IPPProxyManager.reset();
+          lazy.IPPProxyManager.start(
+            false,
+            PrivateBrowsingUtils.permanentPrivateBrowsing
+          );
+          return;
+        }
+        if (state === lazy.IPPProxyStates.READY) {
+          lazy.IPPProxyManager.start(
+            false,
+            PrivateBrowsingUtils.permanentPrivateBrowsing
+          );
+          return;
+        }
       }
       this.init();
     };

--- a/toolkit/components/ipprotection/IPPAutoStart.sys.mjs
+++ b/toolkit/components/ipprotection/IPPAutoStart.sys.mjs
@@ -54,7 +54,20 @@ class IPPAutoStartSingleton {
       false
     );
 
-    this.#handleListChanged = () => this.init();
+    this.#handleListChanged = async () => {
+      if (!lazy.IPProtectionServerlist.hasList) {
+        return;
+      }
+      if (lazy.IPPProxyManager.state === lazy.IPPProxyStates.ACTIVE) {
+        await lazy.IPPProxyManager.stop(false);
+        await lazy.IPPProxyManager.start(
+          false,
+          PrivateBrowsingUtils.permanentPrivateBrowsing
+        );
+        return;
+      }
+      this.init();
+    };
     lazy.IPProtectionServerlist.addEventListener(
       "IPProtectionServerlist:ListChanged",
       this.#handleListChanged

--- a/toolkit/components/ipprotection/IPPChannelFilter.sys.mjs
+++ b/toolkit/components/ipprotection/IPPChannelFilter.sys.mjs
@@ -423,6 +423,10 @@ export class IPPChannelFilter {
       0 /* unsigned long aPosition */
     );
     this.#active = true;
+    this.#inclusionPrefObserver = () => {
+      this.#inclusionSet = IPPChannelFilter.getInclusionList();
+    };
+    Services.prefs.addObserver(INCLUSION_PREF, this.#inclusionPrefObserver);
   }
 
   /**
@@ -431,6 +435,14 @@ export class IPPChannelFilter {
   stop() {
     if (!this.#active) {
       return;
+    }
+
+    if (this.#inclusionPrefObserver) {
+      Services.prefs.removeObserver(
+        INCLUSION_PREF,
+        this.#inclusionPrefObserver
+      );
+      this.#inclusionPrefObserver = null;
     }
 
     lazy.ProxyService.unregisterChannelFilter(this);
@@ -546,6 +558,7 @@ export class IPPChannelFilter {
   #excludedOrigins = new Set();
   #pendingChannels = [];
   #inclusionSet = new MatchPatternSet([], MATCH_PATTERN_OPTIONS);
+  #inclusionPrefObserver = null;
   #server = null;
 
   static makeIsolationKey() {

--- a/toolkit/components/ipprotection/IPPChannelFilter.sys.mjs
+++ b/toolkit/components/ipprotection/IPPChannelFilter.sys.mjs
@@ -228,6 +228,11 @@ export class IPPChannelFilter {
       MODE_PREF,
       IPPMode.MODE_FULL
     );
+
+    this.#inclusionPrefObserver = () => {
+      this.#inclusionSet = IPPChannelFilter.getInclusionList();
+    };
+    Services.prefs.addObserver(INCLUSION_PREF, this.#inclusionPrefObserver);
   }
 
   /**
@@ -423,10 +428,6 @@ export class IPPChannelFilter {
       0 /* unsigned long aPosition */
     );
     this.#active = true;
-    this.#inclusionPrefObserver = () => {
-      this.#inclusionSet = IPPChannelFilter.getInclusionList();
-    };
-    Services.prefs.addObserver(INCLUSION_PREF, this.#inclusionPrefObserver);
   }
 
   /**

--- a/toolkit/components/ipprotection/IPPEarlyStartupFilter.sys.mjs
+++ b/toolkit/components/ipprotection/IPPEarlyStartupFilter.sys.mjs
@@ -1,0 +1,89 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const lazy = {};
+
+ChromeUtils.defineESModuleGetters(lazy, {
+  IPPProxyManager:
+    "moz-src:///toolkit/components/ipprotection/IPPProxyManager.sys.mjs",
+  IPPProxyStates:
+    "moz-src:///toolkit/components/ipprotection/IPPProxyManager.sys.mjs",
+  IPProtectionService:
+    "moz-src:///toolkit/components/ipprotection/IPProtectionService.sys.mjs",
+  IPProtectionStates:
+    "moz-src:///toolkit/components/ipprotection/IPProtectionService.sys.mjs",
+});
+
+/**
+ * Registers an IPProxyManager channel filter at startup to prevent data leaks
+ * before the proxy connection is fully established. Activates only when the
+ * supplied predicate returns true at init() time, and unregisters itself once
+ * the proxy reaches ACTIVE or the service reports it cannot start.
+ *
+ * @param {() => boolean} shouldActivate
+ *   Called from init(). When false, the filter is not registered and the
+ *   helper becomes a no-op for this session.
+ */
+export class IPPEarlyStartupFilter {
+  #active = false;
+  #shouldActivate;
+
+  constructor(shouldActivate) {
+    this.#shouldActivate = shouldActivate;
+    this.handleEvent = this.#handleEvent.bind(this);
+  }
+
+  init() {
+    if (!this.#shouldActivate()) {
+      return;
+    }
+    this.#active = true;
+
+    lazy.IPPProxyManager.createChannelFilter();
+
+    lazy.IPProtectionService.addEventListener(
+      "IPProtectionService:StateChanged",
+      this.handleEvent
+    );
+    lazy.IPPProxyManager.addEventListener(
+      "IPPProxyManager:StateChanged",
+      this.handleEvent
+    );
+  }
+
+  initOnStartupCompleted() {}
+
+  uninit() {
+    if (!this.#active) {
+      return;
+    }
+    this.#active = false;
+
+    lazy.IPPProxyManager.removeEventListener(
+      "IPPProxyManager:StateChanged",
+      this.handleEvent
+    );
+    lazy.IPProtectionService.removeEventListener(
+      "IPProtectionService:StateChanged",
+      this.handleEvent
+    );
+  }
+
+  #handleEvent() {
+    switch (lazy.IPProtectionService.state) {
+      case lazy.IPProtectionStates.UNAVAILABLE:
+      case lazy.IPProtectionStates.UNAUTHENTICATED:
+        lazy.IPPProxyManager.cancelChannelFilter();
+        this.uninit();
+        break;
+
+      default:
+        break;
+    }
+
+    if (lazy.IPPProxyManager.state === lazy.IPPProxyStates.ACTIVE) {
+      this.uninit();
+    }
+  }
+}

--- a/toolkit/components/ipprotection/IPProtectionActivator.sys.mjs
+++ b/toolkit/components/ipprotection/IPProtectionActivator.sys.mjs
@@ -26,9 +26,9 @@ const coreHelpers = [
   IPProtectionServerlist,
   IPPProxyManager,
   IPPSessionPrefManager,
-  IPPAutoRestoreHelper,
-  ...IPPAutoStartHelpers,
-  ...(AppConstants.MOZ_ENTERPRISE ? lazy.IPPAlwaysOnHelpers : []),
+  ...(AppConstants.MOZ_ENTERPRISE
+    ? lazy.IPPAlwaysOnHelpers
+    : [IPPAutoRestoreHelper, ...IPPAutoStartHelpers]),
   IPPNimbusHelper,
 ];
 

--- a/toolkit/components/ipprotection/IPProtectionActivator.sys.mjs
+++ b/toolkit/components/ipprotection/IPProtectionActivator.sys.mjs
@@ -2,6 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { AppConstants } from "resource://gre/modules/AppConstants.sys.mjs";
 import { IPProtectionService } from "moz-src:///toolkit/components/ipprotection/IPProtectionService.sys.mjs";
 import { IPPProxyManager } from "moz-src:///toolkit/components/ipprotection/IPPProxyManager.sys.mjs";
 import { IPPAutoRestoreHelper } from "moz-src:///toolkit/components/ipprotection/IPPAutoRestore.sys.mjs";
@@ -11,6 +12,15 @@ import { IPProtectionServerlist } from "moz-src:///toolkit/components/ipprotecti
 import { IPPStartupCache } from "moz-src:///toolkit/components/ipprotection/IPPStartupCache.sys.mjs";
 import { IPPSessionPrefManager } from "moz-src:///toolkit/components/ipprotection/IPPSessionPrefManager.sys.mjs";
 
+const lazy = {};
+
+if (AppConstants.MOZ_ENTERPRISE) {
+  ChromeUtils.defineESModuleGetters(lazy, {
+    IPPAlwaysOnHelpers:
+      "moz-src:///toolkit/components/ipprotection/enterprise/IPPAlwaysOn.sys.mjs",
+  });
+}
+
 const coreHelpers = [
   IPPStartupCache,
   IPProtectionServerlist,
@@ -18,6 +28,7 @@ const coreHelpers = [
   IPPSessionPrefManager,
   IPPAutoRestoreHelper,
   ...IPPAutoStartHelpers,
+  ...(AppConstants.MOZ_ENTERPRISE ? lazy.IPPAlwaysOnHelpers : []),
   IPPNimbusHelper,
 ];
 

--- a/toolkit/components/ipprotection/IPProtectionServerlist.sys.mjs
+++ b/toolkit/components/ipprotection/IPProtectionServerlist.sys.mjs
@@ -391,6 +391,7 @@ export class RemoteSettingsServerlist extends IPProtectionServerlistBase {
  */
 export class PrefServerList extends IPProtectionServerlistBase {
   #observer = null;
+  #previousList = null;
 
   constructor() {
     super();
@@ -410,19 +411,21 @@ export class PrefServerList extends IPProtectionServerlistBase {
   }
 
   async initOnStartupCompleted() {
-    Services.prefs.addObserver(
-      IPProtectionServerlist.PREF_NAME,
-      this.#observer
-    );
+    Services.prefs.addObserver(PrefServerList.PREF_NAME, this.#observer);
   }
 
   uninit() {
-    Services.prefs.removeObserver(
-      IPProtectionServerlist.PREF_NAME,
-      this.#observer
-    );
+    Services.prefs.removeObserver(PrefServerList.PREF_NAME, this.#observer);
   }
+
   maybeFetchList(_forceUpdate = false) {
+    const newList = Services.prefs.getStringPref(PrefServerList.PREF_NAME, "");
+
+    // If the list hasn't changed, we don't need to fetch it again.
+    if (!_forceUpdate && newList === this.#previousList) {
+      return Promise.resolve();
+    }
+    this.#previousList = newList;
     this.__list = IPProtectionServerlistBase.dataToList(
       PrefServerList.prefValue
     );

--- a/toolkit/components/ipprotection/IPProtectionServerlist.sys.mjs
+++ b/toolkit/components/ipprotection/IPProtectionServerlist.sys.mjs
@@ -412,17 +412,20 @@ export class PrefServerList extends IPProtectionServerlistBase {
 
   async initOnStartupCompleted() {
     Services.prefs.addObserver(PrefServerList.PREF_NAME, this.#observer);
+    // If the pref changed between startup and registering the observer we have
+    // not handled it yet. If the value hasn't actually changed, this is a no-op.
+    this.maybeFetchList();
   }
 
   uninit() {
     Services.prefs.removeObserver(PrefServerList.PREF_NAME, this.#observer);
   }
 
-  maybeFetchList(_forceUpdate = false) {
+  maybeFetchList(forceUpdate = false) {
     const newList = Services.prefs.getStringPref(PrefServerList.PREF_NAME, "");
 
     // If the list hasn't changed, we don't need to fetch it again.
-    if (!_forceUpdate && newList === this.#previousList) {
+    if (!forceUpdate && newList === this.#previousList) {
       return Promise.resolve();
     }
     this.#previousList = newList;

--- a/toolkit/components/ipprotection/enterprise/IPPAlwaysOn.sys.mjs
+++ b/toolkit/components/ipprotection/enterprise/IPPAlwaysOn.sys.mjs
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import { PrivateBrowsingUtils } from "resource://gre/modules/PrivateBrowsingUtils.sys.mjs";
+import { IPPEarlyStartupFilter } from "moz-src:///toolkit/components/ipprotection/IPPEarlyStartupFilter.sys.mjs";
 
 const lazy = {};
 
@@ -109,7 +110,10 @@ class IPPAlwaysOnSingleton {
     if (this.#startPending) {
       return;
     }
-    if (lazy.IPPProxyManager.state === lazy.IPPProxyStates.ACTIVE) {
+    if (
+      lazy.IPPProxyManager.state === lazy.IPPProxyStates.ACTIVE &&
+      lazy.IPPProxyManager.channelFilter()?.proxyInfo
+    ) {
       return;
     }
     if (!lazy.IPProtectionServerlist.hasList) {
@@ -240,72 +244,9 @@ class IPPAlwaysOnSingleton {
 
 const IPPAlwaysOn = new IPPAlwaysOnSingleton();
 
-/**
- * Registers the channel filter at startup to prevent data leaks before the
- * proxy connection is fully established in always-on mode. Mirrors
- * IPPEarlyStartupFilter from IPPAutoStart but uses the AlwaysOn policy check.
- */
-class IPPAlwaysOnEarlyStartupFilter {
-  #alwaysOnAtStartup = false;
-
-  constructor() {
-    this.handleEvent = this.#handleEvent.bind(this);
-  }
-
-  init() {
-    if (!IPPAlwaysOn.alwaysOnEnabled) {
-      return;
-    }
-    this.#alwaysOnAtStartup = true;
-
-    lazy.IPPProxyManager.createChannelFilter();
-
-    lazy.IPProtectionService.addEventListener(
-      "IPProtectionService:StateChanged",
-      this.handleEvent
-    );
-    lazy.IPPProxyManager.addEventListener(
-      "IPPProxyManager:StateChanged",
-      this.handleEvent
-    );
-  }
-
-  initOnStartupCompleted() {}
-
-  uninit() {
-    if (!this.#alwaysOnAtStartup) {
-      return;
-    }
-    this.#alwaysOnAtStartup = false;
-
-    lazy.IPPProxyManager.removeEventListener(
-      "IPPProxyManager:StateChanged",
-      this.handleEvent
-    );
-    lazy.IPProtectionService.removeEventListener(
-      "IPProtectionService:StateChanged",
-      this.handleEvent
-    );
-  }
-
-  #handleEvent() {
-    switch (lazy.IPProtectionService.state) {
-      case lazy.IPProtectionStates.UNAVAILABLE:
-      case lazy.IPProtectionStates.UNAUTHENTICATED:
-        lazy.IPPProxyManager.cancelChannelFilter();
-        this.uninit();
-        break;
-
-      default:
-        break;
-    }
-
-    if (lazy.IPPProxyManager.state === lazy.IPPProxyStates.ACTIVE) {
-      this.uninit();
-    }
-  }
-}
-
-const IPPAlwaysOnHelpers = [IPPAlwaysOn, new IPPAlwaysOnEarlyStartupFilter()];
+const IPPAlwaysOnHelpers = [
+  IPPAlwaysOn,
+  new IPPEarlyStartupFilter(() => IPPAlwaysOn.alwaysOnEnabled),
+];
 
 export { IPPAlwaysOnHelpers, IPPAlwaysOnSingleton };

--- a/toolkit/components/ipprotection/enterprise/IPPAlwaysOn.sys.mjs
+++ b/toolkit/components/ipprotection/enterprise/IPPAlwaysOn.sys.mjs
@@ -50,11 +50,6 @@ class IPPAlwaysOnSingleton {
     this.handleServerlistEvent = this.#handleServerlistEvent.bind(this);
   }
 
-  /**
-   * True when the AccessConnector policy is active.
-   *
-   * @returns {boolean}
-   */
   get alwaysOnEnabled() {
     return !!Services.policies.getActivePolicies()?.AccessConnector;
   }
@@ -149,7 +144,10 @@ class IPPAlwaysOnSingleton {
   }
 
   #handleProxyEvent() {
-    if (!this.#shouldBeRunning) {
+    // alwaysOnEnabled flips to false synchronously when the policy is removed,
+    // before uninit() runs. Bail out so we don't restart in response to the
+    // ACTIVE->READY transition produced by teardown.
+    if (!this.#shouldBeRunning || !this.alwaysOnEnabled) {
       return;
     }
 
@@ -167,7 +165,7 @@ class IPPAlwaysOnSingleton {
         this.#startPending = false;
         lazy.IPPProxyManager.stop(false).then(
           () => {
-            if (this.#shouldBeRunning) {
+            if (this.#shouldBeRunning && this.alwaysOnEnabled) {
               this.#tryStart();
             }
           },
@@ -181,9 +179,11 @@ class IPPAlwaysOnSingleton {
   }
 
   #handleServerlistEvent() {
+    if (!this.alwaysOnEnabled) {
+      return;
+    }
     if (!lazy.IPProtectionServerlist.hasList) {
-      // Serverlist was cleared (e.g. policy removed). Stop any active
-      // connection so we don't try to connect to a server that no longer exists.
+      // Serverlist cleared (e.g. policy removed); stop any active connection.
       const state = lazy.IPPProxyManager.state;
       if (
         state === lazy.IPPProxyStates.ACTIVE ||
@@ -196,14 +196,13 @@ class IPPAlwaysOnSingleton {
     const state = lazy.IPPProxyManager.state;
     switch (state) {
       case lazy.IPPProxyStates.ACTIVE: {
-        // Switch to a server from the updated list without dropping the connection.
+        // Hot-swap without dropping the connection.
         lazy.logConsole.debug("Switching to updated server");
         const { error } = lazy.IPPProxyManager.switch();
         if (error) {
-          // switch() failed (e.g. new server is invalid); stop and restart.
           lazy.IPPProxyManager.stop(false).then(
             () => {
-              if (this.#shouldBeRunning) {
+              if (this.#shouldBeRunning && this.alwaysOnEnabled) {
                 this.#tryStart();
               }
             },
@@ -218,7 +217,7 @@ class IPPAlwaysOnSingleton {
         if (this.#shouldBeRunning) {
           lazy.IPPProxyManager.stop(false).then(
             () => {
-              if (this.#shouldBeRunning) {
+              if (this.#shouldBeRunning && this.alwaysOnEnabled) {
                 this.#tryStart();
               }
             },

--- a/toolkit/components/ipprotection/enterprise/IPPAlwaysOn.sys.mjs
+++ b/toolkit/components/ipprotection/enterprise/IPPAlwaysOn.sys.mjs
@@ -1,0 +1,312 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { PrivateBrowsingUtils } from "resource://gre/modules/PrivateBrowsingUtils.sys.mjs";
+
+const lazy = {};
+
+ChromeUtils.defineESModuleGetters(lazy, {
+  IPProtectionServerlist:
+    "moz-src:///toolkit/components/ipprotection/IPProtectionServerlist.sys.mjs",
+  IPPProxyManager:
+    "moz-src:///toolkit/components/ipprotection/IPPProxyManager.sys.mjs",
+  IPPProxyStates:
+    "moz-src:///toolkit/components/ipprotection/IPPProxyManager.sys.mjs",
+  IPProtectionService:
+    "moz-src:///toolkit/components/ipprotection/IPProtectionService.sys.mjs",
+  IPProtectionStates:
+    "moz-src:///toolkit/components/ipprotection/IPProtectionService.sys.mjs",
+});
+
+ChromeUtils.defineLazyGetter(lazy, "logConsole", () =>
+  console.createInstance({
+    prefix: "IPPAlwaysOn",
+    maxLogLevel: Services.prefs.getBoolPref("browser.ipProtection.log", false)
+      ? "Debug"
+      : "Warn",
+  })
+);
+
+/**
+ * Keeps the proxy connection alive on enterprise builds where the
+ * AccessConnector policy is active. Unlike IPPAutoStart, this class:
+ *
+ *  - Recovers from ERROR states by stopping and restarting immediately.
+ *  - Restarts immediately when the proxy stops unexpectedly.
+ *  - Switches to a new server when the server list is updated.
+ *
+ * Because this is policy-driven there is no user-facing toggle; the proxy
+ * runs whenever the service is ready and the policy is set.
+ */
+class IPPAlwaysOnSingleton {
+  #initialized = false;
+  #shouldBeRunning = false;
+  #startPending = false;
+
+  constructor() {
+    this.handleServiceEvent = this.#handleServiceEvent.bind(this);
+    this.handleProxyEvent = this.#handleProxyEvent.bind(this);
+    this.handleServerlistEvent = this.#handleServerlistEvent.bind(this);
+  }
+
+  /**
+   * True when the AccessConnector policy is active.
+   *
+   * @returns {boolean}
+   */
+  get alwaysOnEnabled() {
+    return !!Services.policies.getActivePolicies()?.AccessConnector;
+  }
+
+  init() {
+    if (this.#initialized || !this.alwaysOnEnabled) {
+      lazy.logConsole.debug(
+        "init() skipped — initialized:",
+        this.#initialized,
+        "alwaysOnEnabled:",
+        this.alwaysOnEnabled
+      );
+      return;
+    }
+    lazy.logConsole.info("Initialized");
+    this.#initialized = true;
+
+    lazy.IPProtectionService.addEventListener(
+      "IPProtectionService:StateChanged",
+      this.handleServiceEvent
+    );
+    lazy.IPPProxyManager.addEventListener(
+      "IPPProxyManager:StateChanged",
+      this.handleProxyEvent
+    );
+    lazy.IPProtectionServerlist.addEventListener(
+      "IPProtectionServerlist:ListChanged",
+      this.handleServerlistEvent
+    );
+  }
+
+  initOnStartupCompleted() {}
+
+  uninit() {
+    if (!this.#initialized) {
+      return;
+    }
+    this.#initialized = false;
+    this.#shouldBeRunning = false;
+    this.#startPending = false;
+
+    lazy.IPProtectionService.removeEventListener(
+      "IPProtectionService:StateChanged",
+      this.handleServiceEvent
+    );
+    lazy.IPPProxyManager.removeEventListener(
+      "IPPProxyManager:StateChanged",
+      this.handleProxyEvent
+    );
+    lazy.IPProtectionServerlist.removeEventListener(
+      "IPProtectionServerlist:ListChanged",
+      this.handleServerlistEvent
+    );
+  }
+
+  #tryStart() {
+    if (this.#startPending) {
+      return;
+    }
+    if (lazy.IPPProxyManager.state === lazy.IPPProxyStates.ACTIVE) {
+      return;
+    }
+    if (!lazy.IPProtectionServerlist.hasList) {
+      return;
+    }
+    lazy.logConsole.info("Starting proxy");
+    this.#startPending = true;
+    lazy.IPPProxyManager.start(
+      false,
+      PrivateBrowsingUtils.permanentPrivateBrowsing
+    );
+  }
+
+  #handleServiceEvent() {
+    const serviceState = lazy.IPProtectionService.state;
+    switch (serviceState) {
+      case lazy.IPProtectionStates.UNINITIALIZED:
+      case lazy.IPProtectionStates.UNAVAILABLE:
+      case lazy.IPProtectionStates.UNAUTHENTICATED:
+        this.#shouldBeRunning = false;
+        this.#startPending = false;
+        break;
+
+      case lazy.IPProtectionStates.READY:
+        this.#shouldBeRunning = true;
+        this.#tryStart();
+        break;
+
+      default:
+        break;
+    }
+  }
+
+  #handleProxyEvent() {
+    if (!this.#shouldBeRunning) {
+      return;
+    }
+
+    switch (lazy.IPPProxyManager.state) {
+      case lazy.IPPProxyStates.ACTIVE:
+        this.#startPending = false;
+        break;
+
+      case lazy.IPPProxyStates.READY:
+        this.#startPending = false;
+        this.#tryStart();
+        break;
+
+      case lazy.IPPProxyStates.ERROR:
+        this.#startPending = false;
+        lazy.IPPProxyManager.stop(false).then(
+          () => {
+            if (this.#shouldBeRunning) {
+              this.#tryStart();
+            }
+          },
+          e => lazy.logConsole.error("Failed to stop proxy:", e)
+        );
+        break;
+
+      default:
+        break;
+    }
+  }
+
+  #handleServerlistEvent() {
+    if (!lazy.IPProtectionServerlist.hasList) {
+      // Serverlist was cleared (e.g. policy removed). Stop any active
+      // connection so we don't try to connect to a server that no longer exists.
+      const state = lazy.IPPProxyManager.state;
+      if (
+        state === lazy.IPPProxyStates.ACTIVE ||
+        state === lazy.IPPProxyStates.ERROR
+      ) {
+        lazy.IPPProxyManager.stop(false);
+      }
+      return;
+    }
+    const state = lazy.IPPProxyManager.state;
+    switch (state) {
+      case lazy.IPPProxyStates.ACTIVE: {
+        // Switch to a server from the updated list without dropping the connection.
+        lazy.logConsole.debug("Switching to updated server");
+        const { error } = lazy.IPPProxyManager.switch();
+        if (error) {
+          // switch() failed (e.g. new server is invalid); stop and restart.
+          lazy.IPPProxyManager.stop(false).then(
+            () => {
+              if (this.#shouldBeRunning) {
+                this.#tryStart();
+              }
+            },
+            e => lazy.logConsole.error("Failed to stop proxy:", e)
+          );
+        }
+        break;
+      }
+
+      case lazy.IPPProxyStates.ERROR:
+        // A fresh server list may resolve the error; stop and restart immediately.
+        if (this.#shouldBeRunning) {
+          lazy.IPPProxyManager.stop(false).then(
+            () => {
+              if (this.#shouldBeRunning) {
+                this.#tryStart();
+              }
+            },
+            e => lazy.logConsole.error("Failed to stop proxy:", e)
+          );
+        }
+        break;
+
+      case lazy.IPPProxyStates.READY:
+        if (this.#shouldBeRunning && !this.#startPending) {
+          this.#tryStart();
+        }
+        break;
+
+      default:
+        break;
+    }
+  }
+}
+
+const IPPAlwaysOn = new IPPAlwaysOnSingleton();
+
+/**
+ * Registers the channel filter at startup to prevent data leaks before the
+ * proxy connection is fully established in always-on mode. Mirrors
+ * IPPEarlyStartupFilter from IPPAutoStart but uses the AlwaysOn policy check.
+ */
+class IPPAlwaysOnEarlyStartupFilter {
+  #alwaysOnAtStartup = false;
+
+  constructor() {
+    this.handleEvent = this.#handleEvent.bind(this);
+  }
+
+  init() {
+    if (!IPPAlwaysOn.alwaysOnEnabled) {
+      return;
+    }
+    this.#alwaysOnAtStartup = true;
+
+    lazy.IPPProxyManager.createChannelFilter();
+
+    lazy.IPProtectionService.addEventListener(
+      "IPProtectionService:StateChanged",
+      this.handleEvent
+    );
+    lazy.IPPProxyManager.addEventListener(
+      "IPPProxyManager:StateChanged",
+      this.handleEvent
+    );
+  }
+
+  initOnStartupCompleted() {}
+
+  uninit() {
+    if (!this.#alwaysOnAtStartup) {
+      return;
+    }
+    this.#alwaysOnAtStartup = false;
+
+    lazy.IPPProxyManager.removeEventListener(
+      "IPPProxyManager:StateChanged",
+      this.handleEvent
+    );
+    lazy.IPProtectionService.removeEventListener(
+      "IPProtectionService:StateChanged",
+      this.handleEvent
+    );
+  }
+
+  #handleEvent() {
+    switch (lazy.IPProtectionService.state) {
+      case lazy.IPProtectionStates.UNAVAILABLE:
+      case lazy.IPProtectionStates.UNAUTHENTICATED:
+        lazy.IPPProxyManager.cancelChannelFilter();
+        this.uninit();
+        break;
+
+      default:
+        break;
+    }
+
+    if (lazy.IPPProxyManager.state === lazy.IPPProxyStates.ACTIVE) {
+      this.uninit();
+    }
+  }
+}
+
+const IPPAlwaysOnHelpers = [IPPAlwaysOn, new IPPAlwaysOnEarlyStartupFilter()];
+
+export { IPPAlwaysOnHelpers, IPPAlwaysOnSingleton };

--- a/toolkit/components/ipprotection/moz.build
+++ b/toolkit/components/ipprotection/moz.build
@@ -14,13 +14,13 @@ if CONFIG["MOZ_WIDGET_TOOLKIT"] == "android":
 
 if CONFIG["MOZ_ENTERPRISE"]:
     MOZ_SRC_FILES += [
-        "enterprise/IPPEnterpriseAuthProvider.sys.mjs",
         "enterprise/IPPAlwaysOn.sys.mjs",
+        "enterprise/IPPEnterpriseAuthProvider.sys.mjs",
     ]
 
 TESTING_JS_MODULES.ipprotection += [
-    "enterprise/IPPEnterpriseAuthProvider.sys.mjs",
     "enterprise/IPPAlwaysOn.sys.mjs",
+    "enterprise/IPPEnterpriseAuthProvider.sys.mjs",
     "gpi/IPPGpiAuthProvider.sys.mjs",
 ]
 
@@ -35,6 +35,7 @@ MOZ_SRC_FILES += [
     "IPPAutoRestore.sys.mjs",
     "IPPAutoStart.sys.mjs",
     "IPPChannelFilter.sys.mjs",
+    "IPPEarlyStartupFilter.sys.mjs",
     "IPPExceptionsManager.sys.mjs",
     "IPPNetworkErrorObserver.sys.mjs",
     "IPPNetworkUtils.sys.mjs",

--- a/toolkit/components/ipprotection/moz.build
+++ b/toolkit/components/ipprotection/moz.build
@@ -15,10 +15,12 @@ if CONFIG["MOZ_WIDGET_TOOLKIT"] == "android":
 if CONFIG["MOZ_ENTERPRISE"]:
     MOZ_SRC_FILES += [
         "enterprise/IPPEnterpriseAuthProvider.sys.mjs",
+        "enterprise/IPPAlwaysOn.sys.mjs",
     ]
 
 TESTING_JS_MODULES.ipprotection += [
     "enterprise/IPPEnterpriseAuthProvider.sys.mjs",
+    "enterprise/IPPAlwaysOn.sys.mjs",
     "gpi/IPPGpiAuthProvider.sys.mjs",
 ]
 

--- a/toolkit/components/ipprotection/tests/xpcshell/test_IPPAlwaysOn.js
+++ b/toolkit/components/ipprotection/tests/xpcshell/test_IPPAlwaysOn.js
@@ -1,0 +1,296 @@
+/* Any copyright is dedicated to the Public Domain.
+https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+const { IPPAlwaysOnSingleton } = ChromeUtils.importESModule(
+  "moz-src:///toolkit/components/ipprotection/enterprise/IPPAlwaysOn.sys.mjs"
+);
+const { IPProtectionServerlist, PrefServerList } = ChromeUtils.importESModule(
+  "moz-src:///toolkit/components/ipprotection/IPProtectionServerlist.sys.mjs"
+);
+
+const TEST_SERVER = {
+  hostname: "proxy.example.com",
+  port: 443,
+  quarantined: false,
+};
+const TEST_COUNTRY = {
+  name: "United States",
+  code: "US",
+  cities: [{ name: "Test City", code: "TC", servers: [TEST_SERVER] }],
+};
+
+add_setup(async function () {
+  // IPProtectionServerlist is a PrefServerList on enterprise builds; populate
+  // the pref so hasList is true. RS-based setup would be silently ignored.
+  Services.prefs.setCharPref(
+    PrefServerList.PREF_NAME,
+    JSON.stringify([TEST_COUNTRY])
+  );
+  await IPProtectionServerlist.maybeFetchList();
+
+  registerCleanupFunction(() => {
+    Services.prefs.clearUserPref(PrefServerList.PREF_NAME);
+  });
+});
+
+/**
+ * Creates a fresh IPPAlwaysOnSingleton with alwaysOnEnabled stubbed.
+ *
+ * @param {object} sandbox - Sinon sandbox
+ * @param {object} [opts]
+ * @param {boolean} [opts.enabled=true] - Value for the alwaysOnEnabled getter
+ */
+function makeAlwaysOn(sandbox, { enabled = true } = {}) {
+  const alwaysOn = new IPPAlwaysOnSingleton();
+  sandbox.stub(alwaysOn, "alwaysOnEnabled").get(() => enabled);
+  return alwaysOn;
+}
+
+/**
+ * Registers `alwaysOn` as a service helper so that IPProtectionService calls
+ * its init() in the correct order (after IPPProxyManager). This is needed
+ * because IPPAlwaysOn reacts to service state changes, and IPPProxyManager
+ * must be READY before IPPAlwaysOn's listener fires.
+ *
+ * @param {IPPAlwaysOnSingleton} alwaysOn
+ */
+function registerAsHelper(alwaysOn) {
+  IPProtectionActivator.addHelpers([alwaysOn]);
+  IPProtectionActivator.setupHelpers();
+}
+
+/**
+ * Restores the helper list to the state established in head.js.
+ */
+function restoreHelpers() {
+  IPProtectionActivator.removeHelpers();
+  IPProtectionActivator.addHelpers(IPPFxaAuthProvider.helpers);
+  IPProtectionActivator.setupHelpers();
+}
+
+add_task(async function test_init_skipped_without_policy() {
+  const sandbox = sinon.createSandbox();
+  setupStubs(sandbox);
+
+  // Ordering doesn't matter here — init() returns immediately when policy is absent.
+  const alwaysOn = makeAlwaysOn(sandbox, { enabled: false });
+  alwaysOn.init();
+
+  const waitForReady = waitForEvent(
+    IPProtectionService,
+    "IPProtectionService:StateChanged",
+    () => IPProtectionService.state === IPProtectionStates.READY
+  );
+  IPProtectionService.init();
+  await waitForReady;
+
+  Assert.notEqual(
+    IPPProxyManager.state,
+    IPPProxyStates.ACTIVATING,
+    "Proxy should not start when the AccessConnector policy is absent"
+  );
+
+  IPProtectionService.uninit();
+  sandbox.restore();
+});
+
+add_task(async function test_proxy_starts_on_service_ready() {
+  const sandbox = sinon.createSandbox();
+  setupStubs(sandbox);
+
+  const alwaysOn = makeAlwaysOn(sandbox);
+  // Register as a helper so alwaysOn.init() is called after IPPProxyManager.init(),
+  // ensuring IPPProxyManager is READY when alwaysOn reacts to the service READY event.
+  registerAsHelper(alwaysOn);
+
+  const waitForActive = waitForEvent(
+    IPPProxyManager,
+    "IPPProxyManager:StateChanged",
+    () => IPPProxyManager.state === IPPProxyStates.ACTIVE
+  );
+  IPProtectionService.init();
+  await waitForActive;
+
+  Assert.equal(
+    IPPProxyManager.state,
+    IPPProxyStates.ACTIVE,
+    "Proxy should become active once the service is ready"
+  );
+
+  alwaysOn.uninit();
+  await IPPProxyManager.stop(false);
+  IPProtectionService.uninit();
+  restoreHelpers();
+  sandbox.restore();
+});
+
+add_task(async function test_proxy_restarts_on_unexpected_stop() {
+  const sandbox = sinon.createSandbox();
+  setupStubs(sandbox);
+
+  const alwaysOn = makeAlwaysOn(sandbox);
+  registerAsHelper(alwaysOn);
+
+  const waitForActive = waitForEvent(
+    IPPProxyManager,
+    "IPPProxyManager:StateChanged",
+    () => IPPProxyManager.state === IPPProxyStates.ACTIVE
+  );
+  IPProtectionService.init();
+  await waitForActive;
+
+  // Stop the proxy externally — alwaysOn's #shouldBeRunning is still true,
+  // so it should restart immediately. The proxy may advance past ACTIVATING to
+  // ACTIVE before the assertion runs (all stubs are synchronous), so accept both.
+  const waitForRestart = waitForEvent(
+    IPPProxyManager,
+    "IPPProxyManager:StateChanged",
+    () =>
+      IPPProxyManager.state === IPPProxyStates.ACTIVATING ||
+      IPPProxyManager.state === IPPProxyStates.ACTIVE
+  );
+  await IPPProxyManager.stop(false);
+  await waitForRestart;
+
+  Assert.ok(
+    IPPProxyManager.state === IPPProxyStates.ACTIVATING ||
+      IPPProxyManager.state === IPPProxyStates.ACTIVE,
+    "Proxy should restart immediately after an unexpected stop"
+  );
+
+  // Uninit alwaysOn before stopping to prevent it from restarting the proxy
+  // during cleanup. With #pass cached from the first activation, #startInternal
+  // resolves faster on the restart path and could clear #activatingPromise
+  // before uninit() runs, causing a missing-activation-promise rejection.
+  alwaysOn.uninit();
+  await IPPProxyManager.stop(false);
+  IPProtectionService.uninit();
+  restoreHelpers();
+  sandbox.restore();
+});
+
+add_task(async function test_proxy_not_restarted_when_service_unavailable() {
+  const sandbox = sinon.createSandbox();
+  setupStubs(sandbox);
+
+  const alwaysOn = makeAlwaysOn(sandbox);
+  registerAsHelper(alwaysOn);
+
+  const waitForActive = waitForEvent(
+    IPPProxyManager,
+    "IPPProxyManager:StateChanged",
+    () => IPPProxyManager.state === IPPProxyStates.ACTIVE
+  );
+  IPProtectionService.init();
+  await waitForActive;
+
+  // Uniniting the service uninits alwaysOn, setting #shouldBeRunning = false.
+  // The proxy may transiently re-enter ACTIVATING during uninit due to helper
+  // ordering; stop() handles it before we assert.
+  IPProtectionService.uninit();
+  await IPPProxyManager.stop(false);
+
+  Assert.notEqual(
+    IPPProxyManager.state,
+    IPPProxyStates.ACTIVATING,
+    "Proxy should not restart once the service becomes unavailable"
+  );
+
+  restoreHelpers();
+  sandbox.restore();
+});
+
+add_task(async function test_serverlist_change_calls_switch_when_active() {
+  const sandbox = sinon.createSandbox();
+  setupStubs(sandbox);
+  sandbox.stub(IPPProxyManager, "switch").returns({ error: null });
+
+  const alwaysOn = makeAlwaysOn(sandbox);
+  registerAsHelper(alwaysOn);
+
+  const waitForActive = waitForEvent(
+    IPPProxyManager,
+    "IPPProxyManager:StateChanged",
+    () => IPPProxyManager.state === IPPProxyStates.ACTIVE
+  );
+  IPProtectionService.init();
+  await waitForActive;
+
+  // Trigger IPProtectionServerlist:ListChanged by updating the pref. The pref
+  // observer (registered during initOnStartupCompleted) fires synchronously.
+  const updatedServer = {
+    hostname: "proxy2.example.com",
+    port: 443,
+    quarantined: false,
+  };
+  const updatedCountry = {
+    ...TEST_COUNTRY,
+    cities: [{ name: "Test City", code: "TC", servers: [updatedServer] }],
+  };
+  Services.prefs.setCharPref(
+    PrefServerList.PREF_NAME,
+    JSON.stringify([updatedCountry])
+  );
+
+  Assert.ok(
+    IPPProxyManager.switch.calledOnce,
+    "switch() should be called when the serverlist changes while the proxy is active"
+  );
+
+  alwaysOn.uninit();
+  await IPPProxyManager.stop(false);
+  IPProtectionService.uninit();
+  restoreHelpers();
+  sandbox.restore();
+});
+
+add_task(async function test_serverlist_cleared_stops_proxy() {
+  const sandbox = sinon.createSandbox();
+  setupStubs(sandbox);
+
+  const alwaysOn = makeAlwaysOn(sandbox);
+  registerAsHelper(alwaysOn);
+
+  const waitForActive = waitForEvent(
+    IPPProxyManager,
+    "IPPProxyManager:StateChanged",
+    () => IPPProxyManager.state === IPPProxyStates.ACTIVE
+  );
+  IPProtectionService.init();
+  await waitForActive;
+
+  // Clearing the pref empties the serverlist synchronously; alwaysOn stops the
+  // proxy, and stop() runs synchronously for an ACTIVE connection.
+  const waitForReady = waitForEvent(
+    IPPProxyManager,
+    "IPPProxyManager:StateChanged",
+    () => IPPProxyManager.state === IPPProxyStates.READY
+  );
+  Services.prefs.clearUserPref(PrefServerList.PREF_NAME);
+  await waitForReady;
+
+  Assert.equal(
+    IPPProxyManager.state,
+    IPPProxyStates.READY,
+    "Proxy should stop when the serverlist is cleared"
+  );
+  Assert.notEqual(
+    IPPProxyManager.state,
+    IPPProxyStates.ACTIVATING,
+    "Proxy should not attempt to restart with an empty serverlist"
+  );
+
+  IPProtectionService.uninit();
+  restoreHelpers();
+
+  // Restore the serverlist for subsequent tests.
+  Services.prefs.setCharPref(
+    PrefServerList.PREF_NAME,
+    JSON.stringify([TEST_COUNTRY])
+  );
+  await IPProtectionServerlist.maybeFetchList(true);
+
+  sandbox.restore();
+});

--- a/toolkit/components/ipprotection/tests/xpcshell/test_IPPAlwaysOn.js
+++ b/toolkit/components/ipprotection/tests/xpcshell/test_IPPAlwaysOn.js
@@ -6,6 +6,9 @@ https://creativecommons.org/publicdomain/zero/1.0/ */
 const { IPPAlwaysOnSingleton } = ChromeUtils.importESModule(
   "moz-src:///toolkit/components/ipprotection/enterprise/IPPAlwaysOn.sys.mjs"
 );
+const { IPPEarlyStartupFilter } = ChromeUtils.importESModule(
+  "moz-src:///toolkit/components/ipprotection/IPPEarlyStartupFilter.sys.mjs"
+);
 const { IPProtectionServerlist, PrefServerList } = ChromeUtils.importESModule(
   "moz-src:///toolkit/components/ipprotection/IPProtectionServerlist.sys.mjs"
 );
@@ -120,6 +123,56 @@ add_task(async function test_proxy_starts_on_service_ready() {
   );
 
   alwaysOn.uninit();
+  await IPPProxyManager.stop(false);
+  IPProtectionService.uninit();
+  restoreHelpers();
+  sandbox.restore();
+});
+
+add_task(async function test_proxy_starts_when_early_filter_marked_active() {
+  const sandbox = sinon.createSandbox();
+  setupStubs(sandbox);
+
+  // Regression test for a bug where IPPProxyManager.updateState() transitioned
+  // proxy state to ACTIVE solely because IPPEarlyStartupFilter had registered
+  // the channel filter (connection.active === true), before start() had ever
+  // been called and before proxyInfo was initialized. IPPAlwaysOn's tryStart()
+  // saw state === ACTIVE and bailed, so start() was never invoked, proxyInfo
+  // stayed null, and any channel matching the inclusion patterns was queued
+  // in #pendingChannels forever — pages hung indefinitely.
+  //
+  // The fix: tryStart() distinguishes "filter registered" from "truly active"
+  // by also checking channelFilter()?.proxyInfo before bailing on ACTIVE.
+  const alwaysOn = makeAlwaysOn(sandbox);
+  const earlyFilter = new IPPEarlyStartupFilter(() => alwaysOn.alwaysOnEnabled);
+  IPProtectionActivator.addHelpers([alwaysOn, earlyFilter]);
+  IPProtectionActivator.setupHelpers();
+
+  // Wait for the *real* ACTIVE — both state ACTIVE and proxyInfo set. The
+  // premature ACTIVE (filter-registered only) would also fire StateChanged
+  // with state === ACTIVE, but with proxyInfo still null.
+  const waitForTrulyActive = waitForEvent(
+    IPPProxyManager,
+    "IPPProxyManager:StateChanged",
+    () =>
+      IPPProxyManager.state === IPPProxyStates.ACTIVE &&
+      !!IPPProxyManager.channelFilter()?.proxyInfo
+  );
+  IPProtectionService.init();
+  await waitForTrulyActive;
+
+  Assert.equal(
+    IPPProxyManager.state,
+    IPPProxyStates.ACTIVE,
+    "Proxy should be ACTIVE"
+  );
+  Assert.ok(
+    IPPProxyManager.channelFilter()?.proxyInfo,
+    "Proxy should be fully initialized — proxyInfo set, not just filter-registered"
+  );
+
+  alwaysOn.uninit();
+  earlyFilter.uninit();
   await IPPProxyManager.stop(false);
   IPProtectionService.uninit();
   restoreHelpers();

--- a/toolkit/components/ipprotection/tests/xpcshell/test_IPPAlwaysOn.js
+++ b/toolkit/components/ipprotection/tests/xpcshell/test_IPPAlwaysOn.js
@@ -171,6 +171,43 @@ add_task(async function test_proxy_restarts_on_unexpected_stop() {
   sandbox.restore();
 });
 
+add_task(async function test_proxy_not_restarted_during_policy_removal() {
+  const sandbox = sinon.createSandbox();
+  setupStubs(sandbox);
+
+  // Mirror what happens when the AccessConnector policy is removed live:
+  // _activatePolicies clears _parsedPolicies (so alwaysOnEnabled is already
+  // false) before onRemove runs, then onRemove's first
+  // unsetAndUnlockPref("browser.ipProtection.enabled") synchronously triggers
+  // the uninit cascade. IPPProxyManager.uninit() runs before IPPAlwaysOn's,
+  // and its stop() fires an ACTIVE->READY transition while our listeners are
+  // still attached — which used to trigger a zombie #tryStart().
+  const alwaysOn = new IPPAlwaysOnSingleton();
+  let policyActive = true;
+  sandbox.stub(alwaysOn, "alwaysOnEnabled").get(() => policyActive);
+  registerAsHelper(alwaysOn);
+
+  const waitForActive = waitForEvent(
+    IPPProxyManager,
+    "IPPProxyManager:StateChanged",
+    () => IPPProxyManager.state === IPPProxyStates.ACTIVE
+  );
+  IPProtectionService.init();
+  await waitForActive;
+
+  policyActive = false;
+  IPProtectionService.uninit();
+
+  Assert.notEqual(
+    IPPProxyManager.state,
+    IPPProxyStates.ACTIVATING,
+    "Proxy must not restart during the policy-removal uninit cascade"
+  );
+
+  restoreHelpers();
+  sandbox.restore();
+});
+
 add_task(async function test_proxy_not_restarted_when_service_unavailable() {
   const sandbox = sinon.createSandbox();
   setupStubs(sandbox);

--- a/toolkit/components/ipprotection/tests/xpcshell/test_IPProtectionServerlist.js
+++ b/toolkit/components/ipprotection/tests/xpcshell/test_IPProtectionServerlist.js
@@ -347,6 +347,44 @@ add_task(async function test_PrefServerList() {
   Assert.deepEqual(city, TEST_US_CITY, "The US city should be returned.");
 });
 
+add_task(async function test_PrefServerList_prefChangeTriggersListChanged() {
+  registerCleanupFunction(() => {
+    Services.prefs.clearUserPref(PrefServerList.PREF_NAME);
+  });
+
+  Services.prefs.setCharPref(
+    PrefServerList.PREF_NAME,
+    JSON.stringify(TEST_COUNTRIES)
+  );
+
+  const serverList = new PrefServerList();
+  await serverList.initOnStartupCompleted();
+  Assert.ok(serverList.hasList, "Initial list should be loaded.");
+
+  let listChangedFired = false;
+  serverList.addEventListener("IPProtectionServerlist:ListChanged", () => {
+    listChangedFired = true;
+  });
+
+  const updatedList = [
+    {
+      code: "US",
+      cities: [{ servers: [{ host: "updated.example.com", port: "9090" }] }],
+    },
+  ];
+  Services.prefs.setCharPref(
+    PrefServerList.PREF_NAME,
+    JSON.stringify(updatedList)
+  );
+
+  Assert.ok(
+    listChangedFired,
+    "ListChanged should fire when the serverlist pref changes."
+  );
+
+  serverList.uninit();
+});
+
 add_task(async function test_IPProtectionServerlistFactory() {
   registerCleanupFunction(() => {
     Services.prefs.clearUserPref(PrefServerList.PREF_NAME);

--- a/toolkit/components/ipprotection/tests/xpcshell/xpcshell.toml
+++ b/toolkit/components/ipprotection/tests/xpcshell/xpcshell.toml
@@ -33,4 +33,10 @@ prefs = [
 
 ["test_IPProtectionStates.js"]
 
+# On non-enterprise builds IPProtectionServerlist is RemoteSettingsServerlist and
+# ignores the pref-based server list set up in add_setup, so hasList stays false
+# and proxy activation tests time out.
+["test_IPPAlwaysOn.js"]
+run-if = ["enterprise"]
+
 ["test_IPProxyManager.js"]


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

This PR fixes an issue that occurs when the `AccessConnector` policy is modified in-place (not added/removed). This results in a broken access connector due to the `#inclusionList` not being updated when `MatchPatterns` changes, and the connection not being re-initialized with the new server when the serverlist changes (host/port in policy)

Bugzilla: Bug-2034845

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

- `IPProtectionServerlist.sys.mjs`: fix `PrefServerList` pref observer registration (was referencing instance instead of class), skip in maybeFetchList() when pref value is unchanged
- `IPPChannelFilter.sys.mjs`: register/unregister pref observer to refresh `#inclusionSet` when changed
- `IPPProxyManager.sys.mjs`: add `reconnect` method for reconnecting to the recommended server from the updated list
- `IPPAutoStart.sys.mjs`: add logic to `#handleListChanged` to reconnect on live changes

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Related: #788 

---

### Testing <!-- OPTIONAL -->

* [x] Manual testing performed

**Steps to verify changes:**

1. Enable AccessConnector policy
2. Launch browser and navigate to a matching URL
3. Observe active AccessConnector state
4. Remove or change matching URL from `MatchPatterns`
    - This updates the icon live without requiring new navigation or refresh 
6. Observe inactive AccessConnector state
7. Repeat above for host or port
    - Serverlist changes require new navigation to update
    - Previously new navigation used the old server
    - Changing to an invalid port will result in broken proxy, changing back should fix it

**Expected result:**

AccessConnector shows active/inactive properly when modifying policy