### PR TITLE
Bug 2035890 - Fix test assertion in test_sitepolicies.js

### DIFF
--- a/browser/components/enterprisepolicies/tests/xpcshell/test_sitepolicies.js
+++ b/browser/components/enterprisepolicies/tests/xpcshell/test_sitepolicies.js
@@ -342,6 +342,6 @@ add_task(async function test_hasSitePoliciesForURI() {
     },
   });
 
-  assertHasSitePolicy("http://example.com/", true);
+  assertHasSitePolicy("http://example.com/", false);
   assertHasSitePolicy("http://example.net/", false);
 });


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2035890

Fixes test assertion in `browser/components/enterprisepolicies/tests/xpcshell/test_sitepolicies.js` to not expect any policies to be applied for an URI when the policy configuration don't pass any policies.

---

### Testing <!-- OPTIONAL -->

* [ ] Added tests
* [ ] Manual testing performed
* [X] Fixes `browser/components/enterprisepolicies/tests/xpcshell/test_sitepolicies.js`

<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
