### PR TITLE
Bug 2028025: Fix xpcshell test_BackupService_crossProfileTypeRecovery.js on enterprise builds

### DIFF
--- a/browser/components/backup/tests/xpcshell/test_BackupService_crossProfileTypeRecovery.js
+++ b/browser/components/backup/tests/xpcshell/test_BackupService_crossProfileTypeRecovery.js
@@ -7,6 +7,10 @@ const { SelectableProfileBackupResource } = ChromeUtils.importESModule(
   "resource:///modules/backup/SelectableProfileBackupResource.sys.mjs"
 );
 
+const { AppConstants } = ChromeUtils.importESModule(
+  "resource://gre/modules/AppConstants.sys.mjs"
+);
+
 const lazy = {};
 ChromeUtils.defineESModuleGetters(lazy, {
   SelectableProfileService:
@@ -15,6 +19,27 @@ ChromeUtils.defineESModuleGetters(lazy, {
 
 add_setup(() => {
   setupProfile();
+
+  if (AppConstants.MOZ_ENTERPRISE) {
+    // Enterprise branding defaults browser.profiles.enabled to false.
+    // Override the default branch (not the user branch) so that
+    // clearUserPref() falls back to true, matching mozilla-central's
+    // default. This cannot be done via toml prefs because those set
+    // user prefs, which clearUserPref() removes.
+    const defaultBranch = Services.prefs.getDefaultBranch("");
+    const originalDefault = defaultBranch.getBoolPref(
+      "browser.profiles.enabled"
+    );
+    Assert.equal(
+      originalDefault,
+      false,
+      "Enterprise branding should default browser.profiles.enabled to false"
+    );
+    defaultBranch.setBoolPref("browser.profiles.enabled", true);
+    registerCleanupFunction(() => {
+      defaultBranch.setBoolPref("browser.profiles.enabled", originalDefault);
+    });
+  }
 });
 
 /**


### PR DESCRIPTION

<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2028025

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

Enterprise branding sets browser.profiles.enabled to false on the default pref branch (via firefox-enterprise.js). The test's createBackupAndRecover helper calls clearUserPref("browser.profiles.enabled") during cleanup, which removes the user pref and falls back to the default branch value. On mozilla-central the default is true, so this is transparent. On enterprise the default is false, which causes SelectableProfileService.isEnabled to return false unexpectedly. Setting the pref in the test's xpcshell.toml doesn't help because toml prefs are set on the user branch. clearUserPref removes them, falling back to the enterprise default of false. 

The fix overrides the default branch in add_setup so that clearUserPref falls back to true, matching mozilla-central's behavior.

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on:

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

---

### Testing <!-- OPTIONAL -->

* [ ] Added tests
* [x] Manual testing performed
[see test failing without the fix](https://treeherder.mozilla.org/logviewer?job_id=563487967&repo=enterprise-firefox-pr&task=TWRib8MSTd--3fRl7TS-Kg.0&lineNumber=10686)
[see test pass](https://treeherder.mozilla.org/logviewer?job_id=563373137&repo=enterprise-firefox-pr&task=Hhk9hTiXRnKkM4Q6ZhZATw.0&lineNumber=3350)
<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
