### PR TITLE
Bug 2035901 - Revert policy filter in EnterprisePoliciesParent

### DIFF
--- a/toolkit/components/enterprisepolicies/EnterprisePoliciesParent.sys.mjs
+++ b/toolkit/components/enterprisepolicies/EnterprisePoliciesParent.sys.mjs
@@ -217,16 +217,6 @@ EnterprisePoliciesManager.prototype = {
     const policyNames = Object.keys(unparsedPolicies || {});
 
     for (let policyName of policyNames) {
-      if (AppConstants.MOZ_ENTERPRISE) {
-        if (
-          ["DisableAccounts", "DisableFirefoxAccounts"].includes(policyName)
-        ) {
-          lazy.log.warn(
-            "Disabling accounts is unavailable in Firefox Enterprise."
-          );
-          continue;
-        }
-      }
       let policySchema = schema.properties[policyName];
       let policyParameters = unparsedPolicies[policyName];
 


### PR DESCRIPTION


<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2035901

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

Reverts filtering out the policies `DisableAccounts` and `DisableFirefoxAccounts` during the policy activation process in enterprise builds. This also fixes `browser/components/enterprisepolicies/tests/browserbrowser_policy_disable_fxaccounts.js`

---

### Testing <!-- OPTIONAL -->

* [ ] Added tests
* [ ] Manual testing performed
* [X] Fixes `browser/components/enterprisepolicies/tests/browser/browser_policy_disable_fxaccounts.js`

<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
