### PR TITLE
Bug 2031399 - Restore focus to badge button when signout dialog is dismissed

### DIFF
--- a/browser/components/enterprise/EnterpriseHandler.sys.mjs
+++ b/browser/components/enterprise/EnterpriseHandler.sys.mjs
@@ -123,10 +123,10 @@ export const EnterpriseHandler = {
   _tabCount: null,
 
   /**
-   * Reference to the element that opened the enterprise panel, used to
-   * restore focus if the signout dialog is cancelled. Cleared in onSignOut
-   * regardless of outcome. A weak reference is used so the element is not
-   * kept alive if the panel opener is destroyed before signout completes.
+   * Weak reference to the element that keyboard-activated the enterprise panel,
+   * used to restore focus if the signout dialog is cancelled. Only set for
+   * keyboard activations; null for mouse. Cleared in onSignOut regardless of
+   * outcome.
    *
    * @type {nsIWeakReference | null}
    */
@@ -297,8 +297,14 @@ export const EnterpriseHandler = {
   },
 
   openPanel(element, event) {
-    const win = element.ownerGlobal;
-    this._panelOpenerRef = Cu.getWeakReference(element);
+    const win = element.documentGlobal;
+    const isKeyboardActivation =
+      event?.type === "keypress" ||
+      event?.type === "keydown" ||
+      event?.inputSource === MouseEvent.MOZ_SOURCE_KEYBOARD;
+    this._panelOpenerRef = isKeyboardActivation
+      ? Cu.getWeakReference(element)
+      : null;
     win.PanelUI.showSubView("panelUI-enterprise", element, event);
     const document = element.ownerDocument;
 
@@ -541,7 +547,7 @@ export const EnterpriseHandler = {
     this._panelOpenerRef = null;
 
     if (!(await this.showSignoutPrompt(window))) {
-      // restore focus to the Enterprise Badge button when dismissing the dialog
+      // restore focus to the Enterprise Badge button when dialog is dismissed
       if (prevFocus) {
         prevFocus.setAttribute("tabindex", "-1");
         prevFocus.focus();

--- a/browser/components/enterprise/EnterpriseHandler.sys.mjs
+++ b/browser/components/enterprise/EnterpriseHandler.sys.mjs
@@ -123,6 +123,16 @@ export const EnterpriseHandler = {
   _tabCount: null,
 
   /**
+   * Reference to the element that opened the enterprise panel, used to
+   * restore focus if the signout dialog is cancelled. Cleared in onSignOut
+   * regardless of outcome. A weak reference is used so the element is not
+   * kept alive if the panel opener is destroyed before signout completes.
+   *
+   * @type {nsIWeakReference | null}
+   */
+  _panelOpenerRef: null,
+
+  /**
    * Handles the enterprise state for each new browser window.
    * On first call:
    *    - Make a request to the console to retrieve the user information of the signed in user.
@@ -287,7 +297,8 @@ export const EnterpriseHandler = {
   },
 
   openPanel(element, event) {
-    const win = element.documentGlobal;
+    const win = element.ownerGlobal;
+    this._panelOpenerRef = Cu.getWeakReference(element);
     win.PanelUI.showSubView("panelUI-enterprise", element, event);
     const document = element.ownerDocument;
 
@@ -526,7 +537,20 @@ export const EnterpriseHandler = {
    * @param {Window} window
    */
   async onSignOut(window) {
+    const prevFocus = this._panelOpenerRef?.get();
+    this._panelOpenerRef = null;
+
     if (!(await this.showSignoutPrompt(window))) {
+      // restore focus to the Enterprise Badge button when dismissing the dialog
+      if (prevFocus) {
+        prevFocus.setAttribute("tabindex", "-1");
+        prevFocus.focus();
+        prevFocus.addEventListener(
+          "blur",
+          () => prevFocus.removeAttribute("tabindex"),
+          { once: true }
+        );
+      }
       return;
     }
     await this.initiateShutdown();

--- a/testing/enterprise/manifest.toml
+++ b/testing/enterprise/manifest.toml
@@ -50,6 +50,8 @@ run-if = [
 
 ["test_felt_browser_signout.py"]
 
+["test_felt_browser_signout_cancel.py"]
+
 ["test_felt_browser_signout_on_exit.py"]
 
 ["test_felt_browser_signout_verify.py"]

--- a/testing/enterprise/test_felt_browser_signout.py
+++ b/testing/enterprise/test_felt_browser_signout.py
@@ -30,6 +30,24 @@ class BaseBrowserSignout(FeltTests):
         self._driver.set_context("content")
         return private_cookies
 
+    def _wait_for_signout_dialog(self):
+        self._logger.info("Waiting for the custom signout dialog to open")
+        self._child_wait.until(
+            lambda _: self._child_driver.execute_script(
+                """
+                try {
+                    const dialog = document.getElementById('window-modal-dialog');
+                    return (dialog?.open && dialog.querySelector(".dialogFrame")
+                        ?.contentDocument
+                        ?.getElementById("enterpriseCloseDialog")
+                        ?.getButton('accept') !== null);
+                } catch (e) {
+                    return false;
+                }
+                """
+            )
+        )
+
     def _do_signout(self):
         self.assert_user_signed_in(env=Environment.FIREFOX)
         # Cache email for later use in prefilled email input field assertion
@@ -50,22 +68,7 @@ class BaseBrowserSignout(FeltTests):
         self._logger.info("Clicking signout button in enterprise panel")
         self.get_elem_child(".panelUI-enterprise__sign-out-btn").click()
 
-        self._logger.info("Waiting for the custom signout dialog to open")
-        self._child_wait.until(
-            lambda _: self._child_driver.execute_script(
-                """
-                try {
-                    const dialog = document.getElementById('window-modal-dialog');
-                    return (dialog?.open && dialog.querySelector(".dialogFrame")
-                        ?.contentDocument
-                        ?.getElementById("enterpriseCloseDialog")
-                        ?.getButton('accept') !== null);
-                } catch (e) {
-                    return false;
-                }
-                """
-            )
-        )
+        self._wait_for_signout_dialog()
 
         self._logger.info(
             "Signing out the user by clicking the Signout button in the custom signout dialog"

--- a/testing/enterprise/test_felt_browser_signout_cancel.py
+++ b/testing/enterprise/test_felt_browser_signout_cancel.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import os
+import sys
+
+sys.path.append(os.path.dirname(__file__))
+
+from base_test import Environment
+from test_felt_browser_signout import BaseBrowserSignout
+
+
+class BrowserSignoutCancel(BaseBrowserSignout):
+    def test_badge_signout_dialog_cancel_restores_focus(self):
+        """Dismissing the signout dialog from the badge panel returns focus to the badge button."""
+        super().run_felt_base()
+        self.connect_child_browser(capabilities={"unhandledPromptBehavior": "ignore"})
+        self.assert_user_signed_in(env=Environment.FIREFOX)
+
+        self._child_driver.set_context("chrome")
+
+        self._logger.info("Clicking enterprise badge to open enterprise panel")
+        self.get_elem_child("#enterprise-badge-toolbar-button").click()
+
+        self._logger.info("Clicking signout button in enterprise panel")
+        self.get_elem_child(".panelUI-enterprise__sign-out-btn").click()
+
+        self._wait_for_signout_dialog()
+
+        self._logger.info("Cancelling the signout dialog")
+        self._child_driver.execute_script(
+            """
+            document.getElementById("window-modal-dialog")
+                .querySelector(".dialogFrame")
+                .contentDocument
+                .getElementById("enterpriseCloseDialog")
+                .getButton("cancel")
+                .click();
+            """
+        )
+
+        self._child_wait.until(
+            lambda _: (
+                not self._child_driver.execute_script(
+                    "return window.gDialogBox?.isOpen ?? false;"
+                )
+            )
+        )
+
+        focused_id = self._child_driver.execute_script(
+            "return document.activeElement?.id;"
+        )
+        assert focused_id == "enterprise-badge-toolbar-button", (
+            f"Expected focus on enterprise-badge-toolbar-button, got {focused_id!r}"
+        )
+
+        self.assert_user_signed_in(env=Environment.FIREFOX)

--- a/testing/enterprise/test_felt_browser_signout_cancel.py
+++ b/testing/enterprise/test_felt_browser_signout_cancel.py
@@ -21,8 +21,18 @@ class BrowserSignoutCancel(BaseBrowserSignout):
 
         self._child_driver.set_context("chrome")
 
-        self._logger.info("Clicking enterprise badge to open enterprise panel")
-        self.get_elem_child("#enterprise-badge-toolbar-button").click()
+        self._logger.info(
+            "Focusing and keyboard-activating enterprise badge to open enterprise panel"
+        )
+        self._child_driver.execute_script(
+            """
+            const btn = document.getElementById("enterprise-badge-toolbar-button");
+            Services.focus.setFocus(btn, Services.focus.FLAG_BYKEY);
+            btn.dispatchEvent(
+                new KeyboardEvent("keypress", { key: "Enter", bubbles: true, cancelable: true })
+            );
+            """
+        )
 
         self._logger.info("Clicking signout button in enterprise panel")
         self.get_elem_child(".panelUI-enterprise__sign-out-btn").click()


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

This PR fixes the a11y issue when using the Enterprise Badge button/panel to trigger a signout, and then dismissing or cancelling the dialog. The focus is given to `html:body` by default, the intended behavior is to return focus to the button which triggered the dialog. Since the actual signout button is in the panel, focus is instead returned to the Enterprise Badge button.

- [ ] TODO: Investigate the same focus issue for the "About Firefox Enterprise" dialog

Bugzilla: Bug-2031399

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

<img width="483" height="247" alt="enterprise-badge-focus" src="https://github.com/user-attachments/assets/f9007a12-5c9f-4983-a449-2bf7a2f73af4" />

_Enterprise Badge with focus after cancelling signout_

---

### Testing <!-- OPTIONAL -->

* [x] Added tests
* [x] Manual testing performed


**Steps to verify changes:**

1. While using a screen reader, activate the "Firefox Enterprise" button using keyboard navigation
2. In the panel, activate the "Sign out…"
3. In the resulting Sign-Out Confirmation modal dialog, dismiss the dialog using either the "Close" buttons or the Esc key

**Expected result:**

For the Sign-Out Confirmation dialog, when the dialog closes, focus returns to the button that opened the dialog. Because the button that opened the dialog is in the "Company Menu" dropdown that closed, the focus returns to the "Firefox Enterprise" button that opened the "Company Menu" dropdown.
