### PR TITLE
Bug 2036024: fix browser_ClientEnvironment.js distribution test for enterprise builds

### DIFF
--- a/toolkit/components/normandy/test/browser/browser_ClientEnvironment.js
+++ b/toolkit/components/normandy/test/browser/browser_ClientEnvironment.js
@@ -63,14 +63,16 @@ add_task(async function testUserId() {
 
 add_task(async function testDistribution() {
   // distribution id defaults to "default" for most builds,
-  // "mozilla-MSIX" for MSIX builds, and "mozilla-official" for
-  // official Mozilla builds.
+  // "mozilla-MSIX" for MSIX builds, "mozilla-official" for
+  // official Mozilla builds, and "enterprise-local" for enterprise builds.
   let expectedDistribution = "default";
   if (
     AppConstants.platform === "win" &&
     Services.sysinfo.getProperty("hasWinPackageId")
   ) {
     expectedDistribution = "mozilla-MSIX";
+  } else if (AppConstants.MOZ_ENTERPRISE) {
+    expectedDistribution = "enterprise-local";
   } else if (AppConstants.BUILT_BY_MOZILLA) {
     expectedDistribution = "mozilla-official";
   }


### PR DESCRIPTION


<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2036024

The test fails with ```TEST-UNEXPECTED-FAIL | toolkit/components/normandy/test/browser/browser_ClientEnvironment.js | testDistribution - distribution has a default value - Got "enterprise-local", expected "default```

The fix is just adding the enterprise-local distribution into the expected distributions

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on:

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

---

### Testing <!-- OPTIONAL -->

* [ ] Added tests
* [x] Manual testing performed
[See without the changes](https://treeherder.mozilla.org/logviewer?job_id=563518495&repo=enterprise-firefox-pr&task=FH62ZRaSROmEWBXGIAl8Rg.0&lineNumber=188349)
[See test pass with changes](https://treeherder.mozilla.org/logviewer?job_id=563549565&repo=enterprise-firefox-pr&task=E5c-C8L3RkK9IeaS4HUK7w.0&lineNumber=29461)

<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
