### PR TITLE
Bug 2035477 - Split quit shortcut prompt title into separate FTL strings

### DIFF
--- a/browser/components/BrowserGlue.sys.mjs
+++ b/browser/components/BrowserGlue.sys.mjs
@@ -1695,12 +1695,12 @@ BrowserGlue.prototype = {
     let message = null;
 
     if (AppConstants.MOZ_ENTERPRISE && shouldWarnForShortcut) {
+      const entTitleId = showCloseCurrentTabOption
+        ? "enterprise-quit-shortcut-prompt-title-with-tabs"
+        : "enterprise-quit-shortcut-prompt-title";
       const [entTitle, entMessage, entQuitButtonLabel] =
         lazy.localization.formatValuesSync([
-          {
-            id: "enterprise-quit-shortcut-prompt-title",
-            args: { withTabs: showCloseCurrentTabOption ? "true" : "false" },
-          },
+          entTitleId,
           "enterprise-quit-shortcut-prompt-message",
           "enterprise-quit-shortcut-prompt-primary-btn-label",
         ]);

--- a/browser/locales/en-US/browser/enterprise/enterprise.ftl
+++ b/browser/locales/en-US/browser/enterprise/enterprise.ftl
@@ -49,13 +49,8 @@ enterprise-close-prompt-checkbox-label = Warn me when closing { -brand-short-nam
 enterprise-close-prompt-tabs-checkbox-label = Warn me when closing multiple tabs
 enterprise-close-prompt-primary-btn-label = Close and sign out
 
-# Variables:
-#   $withTabs (String): "true" when showing the option to close the current tab instead of quitting.
-enterprise-quit-shortcut-prompt-title =
-    { $withTabs ->
-        [true] Quit { -brand-short-name } or close current tab?
-       *[false] Close window and quit { -brand-short-name }?
-    }
+enterprise-quit-shortcut-prompt-title-with-tabs = Quit { -brand-short-name } or close current tab?
+enterprise-quit-shortcut-prompt-title = Close window and quit { -brand-short-name }?
 enterprise-quit-shortcut-prompt-message = Quitting will sign you out of your session. You’ll need to reauthenticate through your organization’s SSO provider.
 enterprise-quit-shortcut-prompt-primary-btn-label = Quit and sign out
 


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Splits `enterprise-quit-shortcut-prompt-title` into two separate FTL strings instead of using a FTL variant. Using an FTL variant in this way is an antipattern and should be avoided.

Bugzilla: Bug-2035477

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* https://github.com/mozilla-l10n/enterprise-firefox-l10n/pull/10
* #802 
