### PR TITLE
Bug 2036114 - Enterprise: Add enterprise-repack-completion task

### DIFF
--- a/taskcluster/docs/kinds.rst
+++ b/taskcluster/docs/kinds.rst
@@ -966,6 +966,10 @@ enterprise-repack
 -----------------
 Generates customized versions of releases for enterprises.
 
+enterprise-repack-completion
+----------------------------
+No-op task that depends on all repacks, used to get a state of completion when all repacks are done.
+
 enterprise-repack-repackage
 ---------------------------
 Repackage customized versions of releases for enterprises.

--- a/taskcluster/gecko_taskgraph/target_tasks.py
+++ b/taskcluster/gecko_taskgraph/target_tasks.py
@@ -497,6 +497,9 @@ def target_tasks_enterprise_firefox_with_tests(
     )
 
     def filter(task):
+        if "shippable" in task.label:
+            return True
+
         # Enabling tests suites triggers many jobs not required, limit execution
         # to enterprise builds for now
         if task.kind in ["test", "mochitest"] and "enterprise" not in task.label:

--- a/taskcluster/gecko_taskgraph/transforms/enterprise_repack_completion.py
+++ b/taskcluster/gecko_taskgraph/transforms/enterprise_repack_completion.py
@@ -1,0 +1,18 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from taskgraph.transforms.base import TransformSequence
+
+transforms = TransformSequence()
+
+
+@transforms.add
+def add_dependencies(config, jobs):
+    for job in jobs:
+        job.setdefault("dependencies", {})
+        job["dependencies"] = {
+            dep_task.kind: label
+            for (label, dep_task) in config.kind_dependencies_tasks.items()
+        }
+        yield job

--- a/taskcluster/gecko_taskgraph/util/verify.py
+++ b/taskcluster/gecko_taskgraph/util/verify.py
@@ -221,7 +221,7 @@ def verify_task_graph_symbol_enterprise(
             symbol = treeherder.get("symbol")
 
             if "enterprise" in task.label:
-                if not "enterprise" in platform:
+                if not "enterprise" in platform and "gecko-decision" not in platform:
                     raise Exception(
                         f"Enterprise job `{task.label}` should have enterprise platform: {platform}"
                     )

--- a/taskcluster/kinds/enterprise-repack-completion/kind.yml
+++ b/taskcluster/kinds/enterprise-repack-completion/kind.yml
@@ -1,0 +1,55 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+loader: taskgraph.loader.transform:loader
+
+transforms:
+    - gecko_taskgraph.transforms.enterprise_repack_completion:transforms
+    - gecko_taskgraph.transforms.job:transforms
+    - gecko_taskgraph.transforms.task:transforms
+
+kind-dependencies:
+    - repackage-deb
+    - repackage-msi
+    - repackage-signing-msi
+    - enterprise-repack-mac-signing
+    - enterprise-repack-mac-notarization
+
+only-for-build-platforms:
+    - linux64-enterprise-shippable/opt
+    - linux64-aarch64-enterprise-shippable/opt
+    - macosx64-enterprise-shippable/opt
+    - win64-enterprise-shippable/opt
+
+
+task-defaults:
+    run-on-projects: ["enterprise-firefox"]
+    worker-type: b-linux
+    shipping-product: firefox-enterprise
+    shipping-phase: build
+    treeherder:
+        kind: other
+        tier: 1
+        platform: gecko-decision/opt
+    worker:
+        docker-image:
+            in-tree: debian12-base
+        max-run-time: 600
+    run:
+        using: run-task
+        checkout: false
+        command: /bin/true
+
+tasks:
+    complete:
+        label: enterprise-repack-completion
+        description: Enterprise repacks completion
+
+        treeherder:
+            symbol: Rpk-Ent-Comp
+
+        index:
+            product: firefox
+            job-name: repack-completion
+            type: shippable


### PR DESCRIPTION
Add a new task kind that will wait on completion of the task repacks so that updates can be properly pulled from taskcluster.

Bugzilla: Bug-2036114