### PR TITLE
Bug 2036167 - Enterprise: Access Connector testing

### DIFF
--- a/testing/enterprise/felt_tests.py
+++ b/testing/enterprise/felt_tests.py
@@ -3,6 +3,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import base64
 import ctypes
 import datetime
 import json
@@ -243,6 +244,17 @@ class ConsoleHttpHandler(LocalHttpRequestHandler):
                     "BlockAboutConfig": self.server.policy_block_about_config.value == 1
                 })
 
+            if self.server.policy_access_connector.value == 1:
+                policy_content.update({
+                    "AccessConnector": {
+                        "Host": "proxy",
+                        "MatchPatterns": [
+                            "https://*.mozilla.org",
+                        ],
+                        "Port": 18443,
+                    }
+                })
+
             if self.server.policy_extensions.value == 1:
                 policy_content.update({
                     "ExtensionSettings": {
@@ -326,6 +338,23 @@ class ConsoleHttpHandler(LocalHttpRequestHandler):
                 self.server.serve_forced_updates_count += 1
 
             contentType = "text/xml"
+
+        elif path == "/api/v1/fpn/token":
+            now = int(time.time())
+            body = {
+                "sub": "test",
+                "aud": f"http://localhost:{self.server.console_port}",
+                "iat": now,
+                "nbf": now,
+                "exp": now + 3600,
+                "iss": "test",
+            }
+            encoded = base64.b64encode(json.dumps(body).encode()).decode()
+            m = json.dumps({
+                # header.body.signature
+                "token": f"fxn.{encoded}.token"
+            })
+            contentType = "application/json"
 
         elif path == "/sso/callback":
             self.server.policy_access_token.value = str(uuid.uuid4())
@@ -521,6 +550,7 @@ def serve(
     policy_extensions=None,
     policy_access_token=None,
     policy_refresh_token=None,
+    policy_access_connector=None,
     policies_fail_request=None,
     signout_count=None,
     # TODO: Behavior is not yet clearly defined
@@ -544,6 +574,8 @@ def serve(
         httpd.policy_extensions = policy_extensions
     if policy_access_token:
         httpd.policy_access_token = policy_access_token
+    if policy_access_connector:
+        httpd.policy_access_connector = policy_access_connector
     if policy_refresh_token:
         httpd.policy_refresh_token = policy_refresh_token
     httpd.policies_fail_request = (
@@ -654,6 +686,7 @@ class FeltTestsBase(ConsoleSSOPortMixin, EnterpriseTestsBase):
         self._console_port = Value("i", 0)
         self._sso_port = Value("i", 0)
         self.policy_block_about_config = Value("b", 1)
+        self.policy_access_connector = Value("b", 0)
         self.policy_extensions = Value("B", 0)
         self.policies_fail_request = Value("B", 0)
         """
@@ -675,6 +708,7 @@ class FeltTestsBase(ConsoleSSOPortMixin, EnterpriseTestsBase):
                 policy_block_about_config=self.policy_block_about_config,
                 policy_extensions=self.policy_extensions,
                 policy_access_token=self.policy_access_token,
+                policy_access_connector=self.policy_access_connector,
                 policy_refresh_token=self.policy_refresh_token,
                 policies_fail_request=self.policies_fail_request,
                 signout_count=self.signout_count,

--- a/testing/enterprise/manifest.toml
+++ b/testing/enterprise/manifest.toml
@@ -4,6 +4,10 @@ subsuite = "enterprise"
 
 ["test_felt_browser_about_config_blocked.py"]
 
+["test_felt_browser_access_connector.py"]
+
+["test_felt_browser_close_warning.py"]
+
 ["test_felt_browser_compulsory_restart.py"]
 
 ["test_felt_browser_console_error.py"]
@@ -43,8 +47,6 @@ run-if = [
 ["test_felt_browser_safe_mode.py"]
 
 ["test_felt_browser_shutdown_crash_exit.py"]
-
-["test_felt_browser_close_warning.py"]
 
 ["test_felt_browser_signout.py"]
 

--- a/testing/enterprise/test_felt_browser_access_connector.py
+++ b/testing/enterprise/test_felt_browser_access_connector.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import os
+import sys
+import time
+
+sys.path.append(os.path.dirname(__file__))
+
+from felt_consts import firefox_config
+from felt_tests import FeltTests
+from marionette_driver.errors import NoSuchElementException, UnknownException
+
+
+class BrowserAccessConnector(FeltTests):
+    def test_browser_access_connector_default_on(self):
+        self._logger.info("Enabling AccessConnector")
+        self.run_change_access_connector_policy(1)
+        self.run_felt_base()
+        self.connect_child_browser()
+
+        self.run_access_connector_enabled_in_browser()
+        self.run_load_page_with_access_connector()
+
+        self.run_disable_access_connector()
+        self.run_enable_access_connector()
+        self.run_disable_access_connector()
+        self.run_enable_access_connector()
+        self.run_disable_access_connector()
+
+    def test_browser_access_connector_default_off(self):
+        self._logger.info("Disabling AccessConnector")
+        self.run_change_access_connector_policy(0)
+        self.run_felt_base()
+        self.connect_child_browser()
+
+        self.run_access_connector_disabled_in_browser()
+        self.run_load_page_without_access_connector()
+
+        self.run_enable_access_connector()
+        self.run_disable_access_connector()
+        self.run_enable_access_connector()
+        self.run_disable_access_connector()
+
+    def run_enable_access_connector(self):
+        self._logger.info("Enabling AccessConnector")
+        self.run_change_access_connector_policy(1)
+        self.run_access_connector_enabled_in_browser()
+        self.run_load_page_with_access_connector()
+
+    def run_disable_access_connector(self):
+        self._logger.info("Disabling AccessConnector")
+        self.run_change_access_connector_policy(0)
+        self.run_access_connector_disabled_in_browser()
+        self.run_load_page_without_access_connector()
+
+    def get_pref_value_and_locked_state(self, pref):
+        with self._child_driver.using_context(self._child_driver.CONTEXT_CHROME):
+            return self._child_driver.execute_script(
+                """
+                const { Preferences } = ChromeUtils.importESModule(
+                  "resource://gre/modules/Preferences.sys.mjs"
+                );
+
+                const pref = arguments[0];
+                const defaultBranch = arguments[1];
+                const valueType = arguments[2];
+
+                const prefs = new Preferences({defaultBranch: defaultBranch});
+                const value = prefs.get(pref, null, Components.interfaces[valueType]);
+                console.debug(`Felt: Test: prefs.get(${pref}) => ${value}`);
+                const isLocked = prefs.locked(pref);
+
+                return { [pref]: { "value": value, "isLocked": isLocked } };
+                """,
+                script_args=(pref, False, "unspecified"),
+            )
+
+    def get_access_connector_prefs_states(self):
+        rv = {}
+        rv.update(
+            self.get_pref_value_and_locked_state(
+                "browser.ipProtection.features.autoStart"
+            )
+        )
+        rv.update(
+            self.get_pref_value_and_locked_state(
+                "browser.ipProtection.autoStartEnabled"
+            )
+        )
+        rv.update(self.get_pref_value_and_locked_state("browser.ipProtection.mode"))
+        rv.update(
+            self.get_pref_value_and_locked_state(
+                "browser.ipProtection.override.serverlist"
+            )
+        )
+        rv.update(
+            self.get_pref_value_and_locked_state(
+                "browser.ipProtection.inclusion.match_patterns"
+            )
+        )
+        rv.update(
+            self.get_pref_value_and_locked_state(
+                "browser.ipProtection.openedPanelWithLocation"
+            )
+        )
+        rv.update(self.get_pref_value_and_locked_state("browser.ipProtection.enabled"))
+        return rv
+
+    def get_access_connector_icon_is_displayed(self):
+        with self._child_driver.using_context(self._child_driver.CONTEXT_CHROME):
+            try:
+                ipprotection = self.find_elem_child("#ipprotection-button")
+                return ipprotection.is_displayed()
+            except NoSuchElementException:
+                return False
+
+    def get_access_connector_icon_is_green(self):
+        with self._child_driver.using_context(self._child_driver.CONTEXT_CHROME):
+            try:
+                ipprotection = self.find_elem_child("#ipprotection-button")
+                classes = ipprotection.get_attribute("class")
+                return "ipprotection-on" in classes
+            except NoSuchElementException:
+                return False
+
+    def run_access_connector_enabled_in_browser(self):
+        self._logger.info("Checking access connectors state is on")
+        state = self.get_access_connector_prefs_states()
+        assert state["browser.ipProtection.features.autoStart"]["value"]
+        assert state["browser.ipProtection.features.autoStart"]["isLocked"]
+        assert state["browser.ipProtection.autoStartEnabled"]["value"]
+        assert state["browser.ipProtection.autoStartEnabled"]["isLocked"]
+        assert state["browser.ipProtection.mode"]["value"] == 3
+        assert state["browser.ipProtection.mode"]["isLocked"]
+        assert (
+            state["browser.ipProtection.override.serverlist"]["value"]
+            == '[{"code":"US","cities":[{"servers":[{"host":"proxy","port":"18443","protocols":[{"name":"connect","port":"18443","host":"proxy","scheme":"https"}]}]}]}]'
+        )
+        assert state["browser.ipProtection.override.serverlist"]["isLocked"]
+        assert (
+            state["browser.ipProtection.inclusion.match_patterns"]["value"]
+            == '["https://*.mozilla.org"]'
+        )
+        assert state["browser.ipProtection.inclusion.match_patterns"]["isLocked"]
+        assert state["browser.ipProtection.openedPanelWithLocation"]["value"]
+        assert state["browser.ipProtection.openedPanelWithLocation"]["isLocked"]
+        assert state["browser.ipProtection.enabled"]["value"]
+        assert state["browser.ipProtection.enabled"]["isLocked"]
+
+    def run_access_connector_disabled_in_browser(self):
+        self._logger.info("Checking access connectors state is off")
+        state = self.get_access_connector_prefs_states()
+        assert not state["browser.ipProtection.features.autoStart"]["value"]
+        assert not state["browser.ipProtection.features.autoStart"]["isLocked"]
+        assert not state["browser.ipProtection.autoStartEnabled"]["value"]
+        assert not state["browser.ipProtection.autoStartEnabled"]["isLocked"]
+        # Bug 2036744: This is likely not correct? Value is still == 3
+        # assert state["browser.ipProtection.mode"]["value"] == 3
+        assert not state["browser.ipProtection.mode"]["isLocked"]
+        # Bug 2036744: This is likely not correct? value is not ""
+        # assert state["browser.ipProtection.override.serverlist"]["value"] == ""
+        assert not state["browser.ipProtection.override.serverlist"]["isLocked"]
+        # Bug 2036744: This is likely not correct? value is not ""
+        # assert state["browser.ipProtection.inclusion.match_patterns"]["value"] == ""
+        assert not state["browser.ipProtection.inclusion.match_patterns"]["isLocked"]
+        assert not state["browser.ipProtection.openedPanelWithLocation"]["value"]
+        assert not state["browser.ipProtection.openedPanelWithLocation"]["isLocked"]
+        assert not state["browser.ipProtection.enabled"]["value"]
+        assert not state["browser.ipProtection.enabled"]["isLocked"]
+
+    def run_change_access_connector_policy(self, new_value):
+        self._logger.info("Changing Access Connectors policy")
+        self.policy_access_connector.value = new_value
+
+        # Polling frequency + 1s
+        waiting_time = (firefox_config["polling_frequency"]["pref_value"] / 1000) + 1
+        # Give time to make sure Policy got applied
+        time.sleep(waiting_time)
+        self._logger.info(
+            f"Policy should have been applied after waiting {waiting_time}s, continue tests"
+        )
+
+    def run_load_page_ok(self, url, expected_title):
+        self.open_tab_child(url)
+        found_title = self._child_driver.title
+        assert found_title == expected_title, (
+            f"No access connector used, expected '{expected_title}', found '{found_title}'"
+        )
+
+    def run_load_page_with_access_connector(self):
+        with self.assertRaisesRegex(
+            UnknownException,
+            r"Reached error page: about:neterror\?e=proxyResolveFailure&u=https%3A//support\.mozilla\.org",
+        ):
+            self.open_tab_child("https://support.mozilla.org/en-US/")
+            assert self.get_access_connector_icon_is_displayed(), (
+                "Access Connector icon is displayed"
+            )
+            assert self.get_access_connector_icon_is_green(), (
+                "Access Connector icon is reporting active"
+            )
+        self.run_load_page_ok(f"http://localhost:{self.console_port}/ping", "Pong!")
+
+    def run_load_page_without_access_connector(self):
+        self.run_load_page_ok("https://support.mozilla.org/en-US/", "Mozilla Support")
+        assert not self.get_access_connector_icon_is_displayed(), (
+            "Access Connector icon is not displayed"
+        )
+        assert not self.get_access_connector_icon_is_green(), (
+            "Access Connector icon is reporting inactive"
+        )
+        self.run_load_page_ok(f"http://localhost:{self.console_port}/ping", "Pong!")


### PR DESCRIPTION
Provide basic testing of access connector from policies pushed by the console, either being set enabled by default (from console) or disabled by default (from console). Coverage ensures prefs and set at expected values, and locked when applied and correctly unlocked and reset after.

Also try to load data with the policy applied and verify there is a proxy error because no proxy is really setup to handle the connections.

Bugzilla: Bug-2036167

### Testing <!-- OPTIONAL -->

* [x] Added tests
* [ ] Manual testing performed