### PR TITLE
Bug 2036826: Allow update processing for non-Felt standalone firefox launches

### DIFF
--- a/toolkit/xre/nsAppRunner.cpp
+++ b/toolkit/xre/nsAppRunner.cpp
@@ -4801,8 +4801,16 @@ Maybe<ShouldNotProcessUpdatesReason> ShouldNotProcessUpdates(
   }
 
 #  if defined(MOZ_ENTERPRISE)
+
+  // The "test-process-updates" argument (bug 2036826) allows
+  // tests like marAppApplyUpdateSuccess.js and
+  // marAppApplyUpdateStageSuccess.js to bypass this check and force update
+  // processing.
+  if(CheckArgExists("test-process-updates")){
+    return Nothing();
+  }
   // Don't process updates when launching a Browser from FELT, only Felt should
-  // perform that step
+  // perform that step.
   if (!is_felt_ui()) {
     return Some(ShouldNotProcessUpdatesReason::FeltOnlyUpdates);
   }


### PR DESCRIPTION


<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2036826

When Firefox is launched standalone (not through Felt), the !is_felt_ui() check alone is too broad and makes test "marAppApplyUpdateStageSuccess.js" fail, using the flag "test-process-updates" solves the issue

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on:

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

---

### Testing <!-- OPTIONAL -->

* [ ] Added tests
* [x] Manual testing performed

[See test failing](https://treeherder.mozilla.org/logviewer?job_id=564255947&repo=enterprise-firefox-pr&task=NbTjC3A0Qe-UQq2ng4gHdw.0&lineNumber=23788)
[See test passing](https://treeherder.mozilla.org/logviewer?job_id=567140725&repo=enterprise-firefox-pr&task=WOc_6DnZTd6K0soR2yNwYw.0&lineNumber=6730)

<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
