### PR TITLE
Bug 2036854:  unlock identity.fxaccounts.remote.root for test browser_synced_tabs_menu.js

### DIFF
--- a/browser/components/customizableui/test/browser_synced_tabs_menu.js
+++ b/browser/components/customizableui/test/browser_synced_tabs_menu.js
@@ -56,6 +56,18 @@ let mockedInternal = {
 };
 
 add_setup(async function () {
+  // In enterprise builds, EnterpriseEndpoints.sys.mjs locks this pref at startup.
+  // Unlock it so the test can override it, and re-lock in cleanup.
+  if (
+    AppConstants.MOZ_ENTERPRISE &&
+    Services.prefs.prefIsLocked("identity.fxaccounts.remote.root")
+  ) {
+    Services.prefs.unlockPref("identity.fxaccounts.remote.root");
+    registerCleanupFunction(() => {
+      Services.prefs.lockPref("identity.fxaccounts.remote.root");
+    });
+  }
+
   const getSignedInUser = FxAccounts.config.getSignedInUser;
 
   FxAccounts.config.getSignedInUser = async () =>


### PR DESCRIPTION


<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2036854

The pref "identity.fxaccounts.remote.root" is used in the test, and currently it is lock.

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on:

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

---

### Testing <!-- OPTIONAL -->

* [ ] Added tests
* [x] Manual testing performed
[See test pass with changes](https://treeherder.mozilla.org/logviewer?job_id=564290704&repo=enterprise-firefox-pr&task=DnIs5PsqQfOHzOLHAfblYg.0&lineNumber=5948)
[See test crash without changes](https://treeherder.mozilla.org/logviewer?job_id=564292894&repo=enterprise-firefox-pr&task=RgCFGGqNTXiai5f4jKVsIg.0&lineNumber=15918)

<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
