### PR TITLE
Bug 2037170 - Enterprise: properly handle UTF8 in browser path

### DIFF
--- a/browser/extensions/felt/rust/nsIFelt.idl
+++ b/browser/extensions/felt/rust/nsIFelt.idl
@@ -12,7 +12,7 @@ interface nsIFelt : nsISupports {
   ACString oneShotIpcServer();
 
   [must_use]
-  ACString binPath();
+  AString binPath();
 
   [must_use]
   boolean makeBackgroundProcess(in boolean background);

--- a/browser/extensions/felt/rust/src/components.rs
+++ b/browser/extensions/felt/rust/src/components.rs
@@ -4,7 +4,7 @@
 use nserror::{
     nsresult, NS_ERROR_CONNECTION_REFUSED, NS_ERROR_FAILURE, NS_ERROR_NOT_CONNECTED, NS_OK,
 };
-use nsstring::{nsACString, nsCString};
+use nsstring::{nsACString, nsAString, nsCString, nsString};
 use std::cell::RefCell;
 use std::env;
 use std::ffi::{c_char, CStr, CString};
@@ -460,20 +460,31 @@ impl FeltXPCOM {
         }
     }
 
-    fn BinPath(&self, bin: *mut nsACString) -> nserror::nsresult {
+    fn BinPath(&self, bin: *mut nsAString) -> nserror::nsresult {
         match env::current_exe() {
-            Ok(exe_path) => match exe_path.to_str() {
-                Some(path) => {
-                    unsafe {
-                        (*bin).assign(path);
+            Ok(exe_path) => {
+                // Use separate code path between Windows and others platforms
+                // here because on Windows it is already encoded as wide strings
+                #[cfg(windows)]
+                let wide: Vec<u16> = {
+                    use std::os::windows::ffi::OsStrExt;
+                    exe_path.as_os_str().encode_wide().collect()
+                };
+
+                #[cfg(not(windows))]
+                let wide: Vec<u16> = match exe_path.to_str() {
+                    Some(path) => path.encode_utf16().collect(),
+                    None => {
+                        trace!("FeltXPCOM: BinPath: to_str() failure");
+                        return NS_ERROR_FAILURE;
                     }
-                    NS_OK
+                };
+
+                unsafe {
+                    (*bin).assign(&nsString::from(&wide[..]));
                 }
-                None => {
-                    trace!("FeltXPCOM: BinPath: to_str() failure");
-                    NS_ERROR_FAILURE
-                }
-            },
+                NS_OK
+            }
             Err(err) => {
                 trace!("FeltXPCOM: BinPath: err={}", err);
                 NS_ERROR_FAILURE

--- a/testing/enterprise/manifest.toml
+++ b/testing/enterprise/manifest.toml
@@ -58,6 +58,8 @@ run-if = [
 
 ["test_felt_browser_starts_missing_bin.py"]
 
+["test_felt_browser_starts_utf8.py"]
+
 ["test_felt_browser_token_refresh.py"]
 
 ["test_felt_browser_updater_errors.py"]

--- a/testing/enterprise/test_felt_browser_starts_utf8.py
+++ b/testing/enterprise/test_felt_browser_starts_utf8.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import os
+import shutil
+import sys
+import tempfile
+
+sys.path.append(os.path.dirname(__file__))
+
+from felt_tests import FeltTests
+
+
+class FeltStartsBrowserUtf8(FeltTests):
+    def setUp(self):
+        super().setUp()
+        self._root_dir = tempfile.TemporaryDirectory(
+            suffix="ééééutf8path", prefix="felt  àààà"
+        )
+        self._logger.info(f"Testing from UTF8 path: {self._root_dir}")
+        self._driver.quit()
+        existing = os.path.dirname(self._driver.instance.binary)
+        # On macOS this gives us:
+        #   obj-*/dist/Firefox EnterpriseDebug.app/Contents/MacOS/firefox => obj-*/dist/Firefox EnterpriseDebug.app/Contents/MacOS
+        # But we want to copy whole .app directory
+        if sys.platform == "darwin":
+            existing = os.path.dirname(os.path.dirname(existing))
+            assert existing.endswith(".app"), "Existing path {existing} should be .app"
+
+        self._logger.info(f"Copying from {existing} to {self._root_dir.name}")
+        shutil.copytree(
+            existing, self._root_dir.name, symlinks=False, dirs_exist_ok=True
+        )
+
+        self._logger.info(f"Executing from {self._root_dir.name}")
+        self._original_binary = self._driver.instance.binary
+        if sys.platform == "darwin":
+            self._driver.instance.binary = os.path.join(
+                self._root_dir.name, "Contents", "MacOS", "firefox"
+            )
+        elif sys.platform == "win":
+            self._driver.instance.binary = os.path.join(
+                self._root_dir.name, "firefox.exe"
+            )
+        else:
+            self._driver.instance.binary = os.path.join(self._root_dir.name, "firefox")
+        self._driver.start_session()
+
+    def teardown(self):
+        super().teardown()
+        self._driver.instance.binary = self._original_binary
+        if os.path.isdir(self._root_dir.name):
+            self._root_dir.cleanup()
+
+    def test_felt_browser_start_from_utf8_path(self):
+        super().run_felt_base()
+        self.connect_child_browser()
+        self.open_tab_child(f"http://localhost:{self.sso_port}/ping")


### PR DESCRIPTION
The browser path is being forwarded from Rust's XPCOM so it needs to ensure it is passing proper UTF-8 at least, and even UTF-16 for Windows, back to Felt to properly handle the case of the installation being in a folder using such characters.



### Description <!-- REQUIRED -->

Bugzilla: Bug-2037170



### Testing <!-- OPTIONAL -->

* [x] Added tests