### PR TITLE
Bug 2037196 - Enterprise: report launch failure to the user

### DIFF
--- a/browser/extensions/felt/api.js
+++ b/browser/extensions/felt/api.js
@@ -230,6 +230,7 @@ this.felt = class extends ExtensionAPI {
       );
       Services.ppmm.addMessageListener("FeltParent:FirefoxLogoutExit", this);
       Services.ppmm.addMessageListener("FeltParent:FirefoxAbnormalExit", this);
+      Services.ppmm.addMessageListener("FeltParent:FirefoxLaunchFailure", this);
       Services.ppmm.addMessageListener(
         "FeltParent:TransitionFeltToBackground",
         this
@@ -296,6 +297,12 @@ this.felt = class extends ExtensionAPI {
         const success = Services.felt.makeBackgroundProcess(false);
         lazy.log.debug(`FeltExtension: makeBackgroundProcess? ${success}`);
         this.showWindow("felt-browser-error-multiple-crashes");
+        break;
+      }
+
+      case "FeltParent:FirefoxLaunchFailure": {
+        Services.felt.makeBackgroundProcess(false);
+        this.showWindow("felt-browser-error-launch-failure");
         break;
       }
 
@@ -388,6 +395,10 @@ this.felt = class extends ExtensionAPI {
     }
 
     Services.ppmm.removeMessageListener("FeltChild:Loaded", this);
+    Services.ppmm.removeMessageListener(
+      "FeltParent:FirefoxLaunchFailure",
+      this
+    );
 
     if (this.chromeHandle) {
       this.chromeHandle.destruct();

--- a/browser/extensions/felt/content/FeltProcessParent.sys.mjs
+++ b/browser/extensions/felt/content/FeltProcessParent.sys.mjs
@@ -455,8 +455,11 @@ export class FeltProcessParent extends JSProcessActorParent {
           });
       })
       .catch(err => {
+        lazy.log.error(
+          `Firefox launch failure (${err.result} / ${err.name}): ${err.message}`
+        );
         lazy.ConsoleClient.isSessionRefreshBlocked = false;
-        throw err;
+        Services.cpmm.sendAsyncMessage("FeltParent:FirefoxLaunchFailure");
       });
   }
 

--- a/browser/extensions/felt/content/felt.xhtml
+++ b/browser/extensions/felt/content/felt.xhtml
@@ -187,6 +187,12 @@
             dismissable="true"
           ></moz-message-bar>
           <moz-message-bar
+            class="felt-browser-error-launch-failure is-hidden"
+            data-l10n-id="felt-browser-error-launch-failure"
+            type="error"
+            dismissable="true"
+          ></moz-message-bar>
+          <moz-message-bar
             class="felt-browser-error-no-network is-hidden"
             data-l10n-id="felt-browser-error-no-network"
             type="error"

--- a/browser/locales/en-US/browser/enterprise/felt.ftl
+++ b/browser/locales/en-US/browser/enterprise/felt.ftl
@@ -35,6 +35,9 @@ felt-browser-error-sso-timeout2 =
     .message = Please try again, or contact your administrator if the problem persists.
 felt-browser-error-multiple-crashes2 =
     .heading = { -brand-short-name } crashed multiple times
+felt-browser-error-launch-failure =
+    .heading = { -brand-short-name } cannot start
+    .message = Please contact your administrator if the problem persists.
 
 ## Logout messages
 

--- a/testing/enterprise/manifest.toml
+++ b/testing/enterprise/manifest.toml
@@ -52,6 +52,8 @@ run-if = [
 
 ["test_felt_browser_starts.py"]
 
+["test_felt_browser_starts_missing_bin.py"]
+
 ["test_felt_browser_token_refresh.py"]
 
 ["test_felt_browser_updater_errors.py"]

--- a/testing/enterprise/test_felt_browser_starts_missing_bin.py
+++ b/testing/enterprise/test_felt_browser_starts_missing_bin.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import os
+import sys
+
+sys.path.append(os.path.dirname(__file__))
+
+from base_test import Environment
+from felt_tests import FeltTests
+
+
+class FeltStartsBrowserMissingBin(FeltTests):
+    def mock_services_felt_binPath(self):
+        self._driver.set_context("chrome")
+        self._driver.execute_script(
+            """
+            const originalServiceFelt = Services.felt;
+            const MockServiceFelt = {
+                binPath() {
+                    const originalBinPath = originalServiceFelt.binPath();
+                    console.debug(`Felt: Tests: mocked binPath() => ${originalBinPath}`);
+                    return `${originalBinPath}.nonExistent`;
+                },
+
+              // Forward all other known methods explicitly
+              ...Object.fromEntries(
+                Object.keys(originalServiceFelt)
+                    .filter(e => e !== "binPath")
+                    .filter(e => e !== "QueryInterface")
+                    .filter(e => typeof(Services.felt[e]) === "function")
+                    .map(name => [
+                  name,
+                  originalServiceFelt[name].bind(originalServiceFelt),
+                ])
+              ),
+            };
+            Services.felt = MockServiceFelt;
+            """
+        )
+
+    def test_felt_browser_start_missing_binary(self):
+        # Browser is not being executed at all
+        self._manually_closed_child = True
+        self.mock_services_felt_binPath()
+        self.run_felt_base()
+        self.run_felt_check_error_message()
+
+    def run_felt_check_error_message(self):
+        self.await_felt_auth_window()
+        self.force_window()
+        self._driver.set_context("chrome")
+        error_msg = self.get_elem(".felt-browser-error-launch-failure")
+        assert "cannot start" in error_msg.text, (
+            f"Error message about launch failure: {error_msg.text}"
+        )
+        self.maybe_save_screenshot(Environment.FELT, "launch_failure")
+        self._logger.info("Launch failure properly reported")


### PR DESCRIPTION
Ensure that early launch failure of the browser gets reported to the user: Felt window shown again, error message with call to action

<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2037196

Release uplift

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on: #843 