### PR TITLE
Bug 2044298 - Skip telemetry tests on enterprise builds

### DIFF
--- a/toolkit/components/telemetry/app/TelemetrySend.sys.mjs
+++ b/toolkit/components/telemetry/app/TelemetrySend.sys.mjs
@@ -1602,6 +1602,11 @@ export var TelemetrySendImpl = {
    * @return {boolean} True if pings can be send to the servers, false otherwise.
    */
   sendingEnabled(ping = null) {
+    // Legacy telemetry is permanently disabled on enterprise builds. Bug 2042874
+    if (AppConstants.MOZ_ENTERPRISE) {
+      return false;
+    }
+
     // We only send pings when telemetry reporting is enabled, but allow overriding this for tests.
     // For enterprise builds, check MOZ_TELEMETRY_REPORTING; for non-enterprise builds, use isOfficialTelemetry.
     const checkPassed = AppConstants.MOZ_ENTERPRISE

--- a/toolkit/components/telemetry/moz.build
+++ b/toolkit/components/telemetry/moz.build
@@ -27,6 +27,11 @@ TEST_DIRS += ["tests/gtest", "tests"]
 XPCSHELL_TESTS_MANIFESTS += [
     "tests/unit/xpcshell.toml",
 ]
+
+if CONFIG["MOZ_ENTERPRISE"]:
+    XPCSHELL_TESTS_MANIFESTS += [
+        "tests/unit/xpcshell_enterprise.toml",
+    ]
 BROWSER_CHROME_MANIFESTS += ["tests/browser/browser.toml"]
 
 XPIDL_SOURCES += [

--- a/toolkit/components/telemetry/tests/browser/browser.toml
+++ b/toolkit/components/telemetry/tests/browser/browser.toml
@@ -1,4 +1,5 @@
 [DEFAULT]
+skip-if = ["enterprise"] # Enterprise builds do not support legacy telemetry.
 support-files = [
   "file_iframe.html",
   "file_media.html",

--- a/toolkit/components/telemetry/tests/marionette/tests/manifest.toml
+++ b/toolkit/components/telemetry/tests/marionette/tests/manifest.toml
@@ -1,4 +1,5 @@
 [DEFAULT]
+skip-if = ["enterprise"] # Enterprise builds do not support legacy telemetry.
 
 ["include:client/manifest.toml"]
 

--- a/toolkit/components/telemetry/tests/unit/test_TelemetrySend_enterprise.js
+++ b/toolkit/components/telemetry/tests/unit/test_TelemetrySend_enterprise.js
@@ -1,0 +1,76 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/
+*/
+
+const { TelemetryController } = ChromeUtils.importESModule(
+  "resource://gre/modules/TelemetryController.sys.mjs"
+);
+const { TelemetrySend } = ChromeUtils.importESModule(
+  "resource://gre/modules/TelemetrySend.sys.mjs"
+);
+const { TelemetryUtils } = ChromeUtils.importESModule(
+  "resource://gre/modules/TelemetryUtils.sys.mjs"
+);
+const TEST_PING_TYPE = "test-enterprise-ping";
+
+add_setup(async function test_setup() {
+  do_get_profile();
+  await loadAddonManager(
+    "xpcshell@tests.mozilla.org",
+    "XPCShell",
+    "1",
+    "1.9.2"
+  );
+  finishAddonManagerStartup();
+  fakeIntlReady();
+  await setEmptyPrefWatchlist();
+
+  await TelemetryController.testSetup();
+});
+
+add_task(async function test_enterprise_telemetry_server_empty() {
+  let server = Services.prefs.getStringPref(
+    TelemetryUtils.Preferences.Server,
+    ""
+  );
+  Assert.equal(
+    server,
+    "",
+    "Telemetry server should be empty on enterprise builds"
+  );
+
+  Assert.ok(
+    Services.prefs.prefIsLocked(TelemetryUtils.Preferences.Server),
+    "Telemetry server pref should be locked on enterprise builds"
+  );
+});
+
+add_task(async function test_enterprise_no_pings_sent() {
+  Assert.ok(
+    !TelemetrySend.sendingEnabled(),
+    "sendingEnabled() should return false in enterprise builds"
+  );
+
+  PingServer.start();
+
+  let receivedPing = false;
+  PingServer.registerPingHandler(() => {
+    receivedPing = true;
+  });
+
+  await TelemetryController.submitExternalPing(TEST_PING_TYPE, {});
+
+  Assert.ok(
+    !receivedPing,
+    "No pings should reach the server on enterprise builds"
+  );
+
+  Assert.equal(
+    TelemetrySend.pendingPingCount,
+    0,
+    "There should be no pending pings in enterprise builds"
+  );
+
+  PingServer.resetPingHandler();
+  await PingServer.stop();
+});

--- a/toolkit/components/telemetry/tests/unit/xpcshell.toml
+++ b/toolkit/components/telemetry/tests/unit/xpcshell.toml
@@ -1,4 +1,5 @@
 [DEFAULT]
+skip-if = ["enterprise"] # Enterprise builds do not support legacy telemetry.
 head = "head.js"
 firefox-appdir = "browser"
 # The *.xpi files are only needed for test_TelemetryEnvironment.js, but

--- a/toolkit/components/telemetry/tests/unit/xpcshell_enterprise.toml
+++ b/toolkit/components/telemetry/tests/unit/xpcshell_enterprise.toml
@@ -1,0 +1,6 @@
+[DEFAULT]
+head = "head.js"
+firefox-appdir = "browser"
+run-if = ["enterprise"]
+
+["test_TelemetrySend_enterprise.js"]

--- a/toolkit/crashreporter/test/unit/test_crashreporter_crash.js
+++ b/toolkit/crashreporter/test/unit/test_crashreporter_crash.js
@@ -122,15 +122,6 @@ add_task(async function run_test() {
         "datareporting.healthreport.uploadEnabled",
         true
       );
-      const { AppConstants: AC } = ChromeUtils.importESModule(
-        "resource://gre/modules/AppConstants.sys.mjs"
-      );
-      if (
-        AC.MOZ_ENTERPRISE &&
-        Services.prefs.prefIsLocked("toolkit.telemetry.server")
-      ) {
-        Services.prefs.unlockPref("toolkit.telemetry.server");
-      }
       Services.prefs.setCharPref(
         "toolkit.telemetry.server",
         "http://a.telemetry.server"

--- a/toolkit/crashreporter/test/unit/xpcshell.toml
+++ b/toolkit/crashreporter/test/unit/xpcshell.toml
@@ -169,6 +169,7 @@ skip-if = [
 ]
 
 ["test_crashreporter_crash.js"]
+skip-if = ["enterprise"] # crash reporter does not use legacy telemetry in enterprise builds
 
 ["test_crashreporter_omnijar_loading.js"]
 


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2037786

- Skip telemetry test suites (browser, marionette, xpcshell) on enterprise builds since legacy telemetry is disabled

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on:

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

---

### Testing <!-- OPTIONAL -->

* [ ] Added tests
* [ ] Manual testing performed

<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
