### PR TITLE
Bug 2031249 - Set FullScreenPrimary at window creation to prevent crash in NSViewUpdateVibrancyForSubtree

### DIFF
--- a/browser/extensions/felt/content/felt.xhtml
+++ b/browser/extensions/felt/content/felt.xhtml
@@ -10,6 +10,7 @@
   class="system-font-size"
   id="felt-window"
   windowtype="navigator:browser"
+  macnativefullscreen="true"
 >
   <head>
     <meta charset="utf-8" />

--- a/widget/cocoa/nsCocoaWindow.mm
+++ b/widget/cocoa/nsCocoaWindow.mm
@@ -5071,11 +5071,18 @@ nsresult nsCocoaWindow::CreateNativeWindow(const NSRect& aRect,
     // particular space, override the "Assign To" space and display popups on
     // the active space. Does not work with multiple displays. See
     // NeedsRecreateToReshow() for multi-display with multi-space workaround.
-    mWindow.collectionBehavior = mWindow.collectionBehavior |
-                                 NSWindowCollectionBehaviorMoveToActiveSpace;
+    mWindow.collectionBehavior =
+        mWindow.collectionBehavior |
+        NSWindowCollectionBehaviorMoveToActiveSpace |
+        NSWindowCollectionBehaviorFullScreenAuxiliary |
+        NSWindowCollectionBehaviorFullScreenDisallowsTiling;
   } else {
     // Non-popup windows are always opaque.
     mWindow.opaque = YES;
+    mWindow.collectionBehavior =
+        mWindow.collectionBehavior |
+        NSWindowCollectionBehaviorFullScreenPrimary |
+        NSWindowCollectionBehaviorFullScreenAllowsTiling;
   }
 
   if (mAlwaysOnTop || mIsAlert) {
@@ -7023,9 +7030,15 @@ void nsCocoaWindow::SetSupportsNativeFullscreen(
     // being called with aSupportsNativeFullscreen set to `true` here.
     NSWindowCollectionBehavior newBehavior = [mWindow collectionBehavior];
     if (aSupportsNativeFullscreen) {
-      newBehavior |= NSWindowCollectionBehaviorFullScreenPrimary;
+      newBehavior |= NSWindowCollectionBehaviorFullScreenPrimary |
+                     NSWindowCollectionBehaviorFullScreenAllowsTiling;
+      newBehavior &= ~(NSWindowCollectionBehaviorFullScreenAuxiliary |
+                       NSWindowCollectionBehaviorFullScreenDisallowsTiling);
     } else {
-      newBehavior &= ~NSWindowCollectionBehaviorFullScreenPrimary;
+      newBehavior |= NSWindowCollectionBehaviorFullScreenAuxiliary |
+                     NSWindowCollectionBehaviorFullScreenDisallowsTiling;
+      newBehavior &= ~(NSWindowCollectionBehaviorFullScreenPrimary |
+                       NSWindowCollectionBehaviorFullScreenAllowsTiling);
     }
     [mWindow setCollectionBehavior:newBehavior];
   }


### PR DESCRIPTION


<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2031249

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

We are preventing _implicitlyAllowsFullScreenPrimary from changing its value internally, which avoids creating extra views mid-enumeration. This is done by setting NSWindowCollectionBehaviorFullScreenPrimary explicitly at window creation time and via macnativefullscreen="true" in felt.xhtml, so AppKit's _effectiveCollectionBehavior never enters the implicit heuristic path.


On creating a window we have this scenario, we set the flag on step 1, and we make sure on 3 the flag does not change its value
1. Create window with some flags
2. Appkit calls displayIfNeeded
3. XUL Parsing, sets some attributes

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on:

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

---

### Testing <!-- OPTIONAL -->

* [ ] Added tests
* [x] Manual testing performed

500 runs, 0 crashes ( 3 test failures unrelated, unrelated testing/enterprise/test_felt_browser_crash_restart.py)
https://firefox-ci-tc.services.mozilla.com/tasks/groups/eaN8CSlEQpmU1ZTNQ6c1xg#marionette

500 runs, 0 crashes ( 5 tests failures unrelated, testing/enterprise/test_felt_browser_crash_restart.py)
https://firefox-ci-tc.services.mozilla.com/tasks/groups/daETusbpT12MtRorgcBVvA#marionette
<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
