### PR TITLE
Bug 2038631 - Enterprise: make access connector test wait for the title

### DIFF
--- a/testing/enterprise/test_felt_browser_access_connector.py
+++ b/testing/enterprise/test_felt_browser_access_connector.py
@@ -185,6 +185,7 @@ class BrowserAccessConnector(FeltTests):
 
     def run_load_page_ok(self, url, expected_title):
         self.open_tab_child(url)
+        self._child_longwait.until(lambda d: len(d.title) > 0)
         found_title = self._child_driver.title
         assert found_title == expected_title, (
             f"No access connector used, expected '{expected_title}', found '{found_title}'"


### PR DESCRIPTION
We have a network dependency that is hard to avoid since Access Connector's match pattern depends on having a hostname, hence testing wildcard is complicated with only localhost, no port can be added in the matching part. Thus testing is done against support.mozilla.org hence hitting the network which can be slow. Waiting loinger for the title to be read correctly to avoid intermittence.

<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2038631

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on: #825 