### PR TITLE
Bug 2038609 -  Enable by default "browser.newtabpage.activity-stream.feeds.section.topstories" as it will be set disabled/enabled by policy

### DIFF
--- a/browser/branding/enterprise/pref/firefox-enterprise.js
+++ b/browser/branding/enterprise/pref/firefox-enterprise.js
@@ -9,8 +9,6 @@ pref("extensions.activeThemeID", "firefox-enterprise-light@mozilla.org");
 
 pref("enterprise.log_level", "Error");
 
-pref("browser.newtabpage.activity-stream.feeds.section.topstories", false);
-
 // On Enterprise we want to enforce updates so we force it
 // Bug 2020768: Should those value be set/locked at runtime by FELT only
 //              or is it fine to apply it to any enterprise build?


### PR DESCRIPTION


<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2038609

edit: Enabling again the original pref, as we support the feature and will just be disabled with policy


<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on:

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

---

### Testing <!-- OPTIONAL -->

* [ ] Added tests
* [ ] Manual testing performed
[See test pass](https://treeherder.mozilla.org/logviewer?job_id=565781665&repo=enterprise-firefox-pr&task=NbOnbR2ZTwevUTLrspA-TA.0&lineNumber=15503) filter for `browser/components/preferences/tests/home/`

<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
