### PR TITLE
Bug 2038707 - Enterprise: do not schedule complete kind for level < 3

### DIFF
--- a/taskcluster/gecko_taskgraph/target_tasks.py
+++ b/taskcluster/gecko_taskgraph/target_tasks.py
@@ -519,6 +519,9 @@ def target_tasks_enterprise_firefox_with_tests(
         if ("shippable" in task.label or shippable) and level < 3:
             return False
 
+        if task.kind == "complete" and level < 3:
+            return False
+
         if not build_platform or not build_type:
             return True
 

--- a/taskcluster/gecko_taskgraph/util/verify.py
+++ b/taskcluster/gecko_taskgraph/util/verify.py
@@ -178,6 +178,22 @@ def verify_task_graph_symbol(task, taskgraph, scratch_pad, graph_config, paramet
 
 
 @verifications.add("full_task_graph")
+def verify_task_graph_no_shippable_enterprise_level_not_1(
+    task, taskgraph, scratch_pad, graph_config, parameters
+):
+    if task is None:
+        return
+
+    if int(parameters["level"]) < 3:
+        return
+
+    if "enterprise" in task.label and "shippable" in task.label:
+        raise Exception(
+            f"Enterprise shippable job {task.label} should not be scheduled on level {int(parameters['level'])}"
+        )
+
+
+@verifications.add("full_task_graph")
 def verify_task_graph_symbol_enterprise(
     task, taskgraph, scratch_pad, graph_config, parameters
 ):


### PR DESCRIPTION
The 'complete' kind aims at tracking shippable artifact status. It should not be scheduled on tasks of level < 3, otherwise it ends up pulling by the game of dependencies the shippable builds on PRs.

<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2038707

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->
