### PR TITLE
Bug 2038706 - Enterprise: add Android not implemented GetNetworkInterfaces

### DIFF
--- a/netwerk/system/android/nsAndroidNetworkLinkService.cpp
+++ b/netwerk/system/android/nsAndroidNetworkLinkService.cpp
@@ -245,3 +245,10 @@ void nsAndroidNetworkLinkService::NotifyObservers(const char* aTopic,
 bool nsINetworkLinkService::HasNonLocalIPv6Address() {
   return mozilla::net::NetlinkService::HasNonLocalIPv6Address();
 }
+
+// There is no MOZ_ENTERPRISE build for Android at all
+NS_IMETHODIMP
+nsAndroidNetworkLinkService::GetNetworkInterfaces(
+    nsTArray<RefPtr<nsINetworkInterface>>& aNetworkInterfaces) {
+  return NS_ERROR_NOT_IMPLEMENTED;
+}


### PR DESCRIPTION
Implement the method but return an error since there is no Android build of Firefox Enterprise.

<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2038706

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->
