### PR TITLE
Bug 2035781 - Register enterprise.prompt_on_signout pref default and add fresh-profile test

### DIFF
--- a/browser/branding/enterprise/pref/firefox-enterprise.js
+++ b/browser/branding/enterprise/pref/firefox-enterprise.js
@@ -8,6 +8,7 @@ pref("browser.profiles.enabled", false);
 pref("extensions.activeThemeID", "firefox-enterprise-light@mozilla.org");
 
 pref("enterprise.log_level", "Error");
+pref("enterprise.prompt_on_signout", true);
 
 pref("browser.newtabpage.activity-stream.feeds.section.topstories", false);
 

--- a/testing/enterprise/test_felt_browser_close_warning.py
+++ b/testing/enterprise/test_felt_browser_close_warning.py
@@ -178,7 +178,7 @@ class BrowserCloseWarning(FeltTests):
 
     def test_prompt_on_signout_default_is_true(self):
         """enterprise.prompt_on_signout must have a registered default of true."""
-        super().run_felt_base()
+        self.run_felt_base()
         self.connect_child_browser()
 
         self._child_driver.set_context("chrome")
@@ -199,7 +199,7 @@ class BrowserCloseWarning(FeltTests):
 
     def test_browser_window_close_signout_warning_only(self):
         """Sign-out warn on, tabs warn off, single tab - enterprise signout dialog shows."""
-        super().run_felt_base()
+        self.run_felt_base()
         self.connect_child_browser()
         self.assert_user_signed_in(env=Environment.FIREFOX)
 
@@ -219,7 +219,7 @@ class BrowserCloseWarning(FeltTests):
 
     def test_browser_window_close_with_both_warnings(self):
         """Sign-out warn on, tabs warn on, multiple tabs open - enterprise dialog with tabs count shown."""
-        super().run_felt_base()
+        self.run_felt_base()
         self.connect_child_browser()
         self.assert_user_signed_in(env=Environment.FIREFOX)
 
@@ -240,7 +240,7 @@ class BrowserCloseWarning(FeltTests):
 
     def test_browser_window_close_tabs_warning_only(self):
         """Sign-out warn off, tabs warn on, multiple tabs - dialog shows tabs-only variant."""
-        super().run_felt_base()
+        self.run_felt_base()
         self.connect_child_browser()
         self.assert_user_signed_in(env=Environment.FIREFOX)
 
@@ -260,7 +260,7 @@ class BrowserCloseWarning(FeltTests):
 
     def test_browser_window_close_no_warnings(self):
         """Sign-out warn off, tabs warn off - no dialog, quit proceeds directly."""
-        super().run_felt_base()
+        self.run_felt_base()
         self.connect_child_browser()
         self.assert_user_signed_in(env=Environment.FIREFOX)
 
@@ -274,7 +274,7 @@ class BrowserCloseWarning(FeltTests):
 
     def test_browser_window_close_no_warnings_multiple_tabs(self):
         """Sign-out warn off, tabs warn off, multiple tabs - no dialog, quit proceeds."""
-        super().run_felt_base()
+        self.run_felt_base()
         self.connect_child_browser()
         self.assert_user_signed_in(env=Environment.FIREFOX)
 
@@ -290,7 +290,7 @@ class BrowserCloseWarning(FeltTests):
     def test_browser_close_no_windows_shows_standalone_dialog(self):
         """macOS no-window: quitting with no browser windows shows a standalone
         enterprise dialog instead of crashing."""
-        super().run_felt_base()
+        self.run_felt_base()
         self.connect_child_browser()
         self.assert_user_signed_in(env=Environment.FIREFOX)
 

--- a/testing/enterprise/test_felt_browser_close_warning.py
+++ b/testing/enterprise/test_felt_browser_close_warning.py
@@ -193,7 +193,7 @@ class BrowserCloseWarning(FeltTests):
         assert is_registered, (
             f"{PREF_PROMPT_ON_SIGNOUT} has no registered default value"
         )
-        assert default_value is True, (
+        assert default_value, (
             f"Expected {PREF_PROMPT_ON_SIGNOUT} default to be True, got {default_value!r}"
         )
 

--- a/testing/enterprise/test_felt_browser_close_warning.py
+++ b/testing/enterprise/test_felt_browser_close_warning.py
@@ -176,6 +176,27 @@ class BrowserCloseWarning(FeltTests):
 
         self._child_wait.until(is_closed)
 
+    def test_prompt_on_signout_default_is_true(self):
+        """enterprise.prompt_on_signout must have a registered default of true."""
+        super().run_felt_base()
+        self.connect_child_browser()
+
+        self._child_driver.set_context("chrome")
+        is_registered = self._child_driver.execute_script(
+            f"return Services.prefs.getDefaultBranch('').getPrefType('{PREF_PROMPT_ON_SIGNOUT}') === Services.prefs.PREF_BOOL;"
+        )
+        default_value = self._child_driver.execute_script(
+            f"return Services.prefs.getDefaultBranch('').getBoolPref('{PREF_PROMPT_ON_SIGNOUT}', false);"
+        )
+        self._child_driver.set_context("content")
+
+        assert is_registered, (
+            f"{PREF_PROMPT_ON_SIGNOUT} has no registered default value"
+        )
+        assert default_value is True, (
+            f"Expected {PREF_PROMPT_ON_SIGNOUT} default to be True, got {default_value!r}"
+        )
+
     def test_browser_window_close_signout_warning_only(self):
         """Sign-out warn on, tabs warn off, single tab - enterprise signout dialog shows."""
         super().run_felt_base()


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

This PR adds a default value for `enterprise.prompt_on_signout`. The functionality was working as expected in a fresh profile, but the pref did not have an explicit default.

Bugzilla: Bug-2035781

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Testing <!-- OPTIONAL -->

* [x] Added tests
* [x] Manual testing performed

**Steps to verify changes:**

1. Start with a fresh profile
2. Open a new browser
3. Open `about:config` and see the pref `enterprise.prompt_on_signout` set to `true` by default
4. Trigger a quit of the browser
5. Observe the Enterprise signout dialog

**Expected result:**

User is presented with the Enterprise signout dialog when the browser exits.
