### PR TITLE
Bug 2038902 - Fix browser_pip_ui.js test for enterprise badge button

### DIFF
--- a/browser/base/content/appmenu-viewcache.inc.xhtml
+++ b/browser/base/content/appmenu-viewcache.inc.xhtml
@@ -966,4 +966,8 @@
 
 #include ../../components/reportbrokensite/content/reportBrokenSitePanel.inc.xhtml
 
+#ifdef MOZ_ENTERPRISE
+#include ../../components/enterprise/content/enterprise-panel.inc.xhtml
+#endif
+
 </html:template>

--- a/browser/components/customizableui/content/panelUI.inc.xhtml
+++ b/browser/components/customizableui/content/panelUI.inc.xhtml
@@ -338,6 +338,7 @@
 </html:template>
 
 #ifdef MOZ_ENTERPRISE
-#include ../../enterprise/content/enterprise-panel.inc.xhtml
+<!-- Urlbar panels must live at the navbar DOM level to position correctly
+     relative to their anchor. Do not move into appMenu-viewCache. -->
 #include ../../enterprise/content/enterprise-urlbar-panels.inc.xhtml
 #endif

--- a/browser/components/enterprise/EnterpriseHandler.sys.mjs
+++ b/browser/components/enterprise/EnterpriseHandler.sys.mjs
@@ -267,7 +267,11 @@ export const EnterpriseHandler = {
       parseUrl("https://support.mozilla.org/kb/managed-browser-firefox");
 
     const document = win.document;
-    const learnMoreLink = document.getElementById("enterprise-learn-more-link");
+    const viewNode = win.PanelMultiView.getViewNode(
+      document,
+      "panelUI-enterprise"
+    );
+    const learnMoreLink = viewNode.querySelector("#enterprise-learn-more-link");
     lazy.log.debug(`Setting learn more uri to ${validLearnMoreUrl.href}`);
     learnMoreLink.setAttribute("href", validLearnMoreUrl.href);
 
@@ -279,9 +283,7 @@ export const EnterpriseHandler = {
       win.openTrustedLinkIn(validLearnMoreUrl.href, where);
       e.preventDefault();
 
-      const panel = document
-        .getElementById("panelUI-enterprise")
-        .closest("panel");
+      const panel = viewNode.closest("panel");
       win.PanelMultiView.hidePopup(panel);
     });
   },
@@ -290,16 +292,20 @@ export const EnterpriseHandler = {
     const win = element.documentGlobal;
     win.PanelUI.showSubView("panelUI-enterprise", element, event);
     const document = element.ownerDocument;
+    const viewNode = win.PanelMultiView.getViewNode(
+      document,
+      "panelUI-enterprise"
+    );
 
     if (!element._isEnterpriseLearnMoreLinkConfigured) {
       this._setupLearnMoreLink(win);
       element._isEnterpriseLearnMoreLinkConfigured = true;
     }
 
-    const email = document.querySelector(".panelUI-enterprise__email");
+    const email = viewNode.querySelector(".panelUI-enterprise__email");
     if (!this._signedInUser) {
       email.hidden = true;
-      document.querySelector("#PanelUI-enterprise-email-separator").hidden =
+      viewNode.querySelector("#PanelUI-enterprise-email-separator").hidden =
         true;
       lazy.log.warn(
         "Unable to update email in enterprise panel without user information"

--- a/browser/components/enterprise/content/enterprise-badge.inc.xhtml
+++ b/browser/components/enterprise/content/enterprise-badge.inc.xhtml
@@ -5,7 +5,7 @@
 <html:link rel="stylesheet" href="chrome://browser/content/enterprise/enterprise-badge.css" overflows="false"/>
 <html:link rel="localization" href="browser/enterprise/enterprise.ftl" overflows="false"/>
 
-<toolbarbutton id="enterprise-badge-toolbar-button" class="toolbarbutton-1" delegatesanchor="true" data-l10n-id="enterprise-toolbar-button" removable="false" cui-areatype="toolbar">
+<toolbarbutton id="enterprise-badge-toolbar-button" class="toolbarbutton-1 chromeclass-toolbar-additional" delegatesanchor="true" data-l10n-id="enterprise-toolbar-button" removable="false" cui-areatype="toolbar">
   <hbox>
     <div class="enterprise-badge">
       <div id="enterprise-company-logo__wrapper" class="is-hidden">

--- a/browser/components/enterprise/content/enterprise-panel.inc.xhtml
+++ b/browser/components/enterprise/content/enterprise-panel.inc.xhtml
@@ -2,8 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-<html:link rel="localization" href="browser/enterprise/enterprise.ftl" />
-
 <panelview id="panelUI-enterprise" class="PanelUI-subView">
   <vbox class="panel-subview-body panelUI-enterprise__main-frame">
     <html:div class="panelUI-enterprise__email"></html:div>


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2038902

The test [browser_pip_ui.js](https://searchfox.org/enterprise-main/rev/a22c3e7f4dcb4a11456e72129b53d2580ef56d12/dom/documentpip/tests/browser/browser_pip_ui.js#56) fails with 
```
1. [task 2026-05-11T11:33:54.364+00:00] 11:33:54     INFO - TEST-UNEXPECTED-FAIL | dom/documentpip/tests/browser/browser_pip_ui.js | pip_ui_buttons - Expected '' to be not be visible for PiP - -1 > -1
2. [task 2026-05-11T11:33:54.367+00:00] 11:33:54     INFO - TEST-UNEXPECTED-FAIL | dom/documentpip/tests/browser/browser_pip_ui.js | pip_ui_buttons - Expected 'enterprise-badge-toolbar-button' to be not be visible for PiP - -1 > -1
3. [task 2026-05-11T11:33:54.370+00:00] 11:33:54     INFO - TEST-UNEXPECTED-FAIL | dom/documentpip/tests/browser/browser_pip_ui.js | pip_ui_buttons - Expected 'document-pip-return-to-opener-button' to be not be visible for PiP - -1 > -1
```

1. is coming from the subview panel we have being in the dom, the [test](https://searchfox.org/enterprise-main/rev/a22c3e7f4dcb4a11456e72129b53d2580ef56d12/dom/documentpip/tests/browser/browser_pip_ui.js#56) [finds this button](https://searchfox.org/enterprise-main/rev/a22c3e7f4dcb4a11456e72129b53d2580ef56d12/browser/components/enterprise/content/enterprise-panel.inc.xhtml#24)
 - solution here is to put the subview in the [appview-cache](https://searchfox.org/firefox-main/rev/22adc0417a3dbf478c7af00d45daa311e2efdf8b/browser/base/content/appmenu-viewcache.inc.xhtml#17)
2. this happens because we have the badge in the toolbar, this is expected, the reason is we have the flag `removable="false"`, this affects customizableUI as well as this, I asked @mcroud and he said it is supposed to be like this.
 - solution is just to add it in the expected buttons
3. is a side effect of the test failing, that goes away with fixing the test  


Let me know if 1 is incorrect, I had to adapt the code to use ```win.PanelMultiView.getViewNode(document```

I also tried to move ```#include ../../enterprise/content/enterprise-urlbar-panels.inc.xhtml``` which has the lockdown mode ui, but after testing it then it was not rendered correctly (i.e it was looking like the icon was behind)

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on:

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

---

### Testing <!-- OPTIONAL -->

* [ ] Added tests
* [x] Manual testing performed
I tested the UI by clicking the badge, clicking the "more link", also on a new window.
[See test pass](https://treeherder.mozilla.org/logviewer?job_id=566006627&repo=enterprise-firefox-pr&task=TzpDOqQwQmai3r3_aTBHgA.0&lineNumber=14266)
<!--
**Steps to verify changes:**
1.
5.
6.

**Expected result:**
-->
