### PR TITLE
Bug 2037872 - Fix access connector toolbar icon width after token rename

### DIFF
--- a/browser/themes/shared/toolbarbutton-icons.css
+++ b/browser/themes/shared/toolbarbutton-icons.css
@@ -389,7 +389,7 @@
   }
   > .toolbarbutton-icon {
     list-style-image: url("chrome://browser/content/ipprotection/assets/ac-icon.svg");
-    width: calc(2 * var(--toolbarbutton-inner-padding) + 16px);
+    width: calc(2 * var(--toolbarbutton-padding-inner) + 16px);
   }
   &.ipprotection-on {
     > .toolbarbutton-icon {


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2037872

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

This PR updates a design token used for setting the Access Connector toolbar button icon that was regressed by Bug-2034495.

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Regressed by: Bug-2034495

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->
<img width="332" height="217" alt="access-connect-r-before" src="https://github.com/user-attachments/assets/2d7afcd4-e526-4d3b-920d-dc00ea8542f7" />

_Before_

<img width="332" height="217" alt="access-connector-after" src="https://github.com/user-attachments/assets/04ae2162-fbbd-4e92-ad94-beae61689246" />

_After_