### PR TITLE
NO BUG - Enterprise: allow shippable on enterprise-firefox-try

### DIFF
--- a/taskcluster/gecko_taskgraph/util/verify.py
+++ b/taskcluster/gecko_taskgraph/util/verify.py
@@ -187,6 +187,9 @@ def verify_task_graph_no_shippable_enterprise_level_not_1(
     if task is None:
         return
 
+    if parameters["project"] == "enterprise-firefox-try":
+        return
+
     level = int(parameters["level"])
     if level < 3 and "enterprise" in task.label and "shippable" in task.label:
         raise Exception(


### PR DESCRIPTION
Mechanical change that does not fail the decision task when pushing to try with shippable packages to perform tests.