### PR TITLE
Bug 2039183 - Enterprise: grant scope for fennec geoloc api key

### DIFF
--- a/taskcluster/gecko_taskgraph/transforms/build.py
+++ b/taskcluster/gecko_taskgraph/transforms/build.py
@@ -329,6 +329,7 @@ def add_enterprise_secret_scopes(config, jobs):
                 f"secrets:get:project/releng/gecko/build/level-{level}/gls-gapi.data",
                 f"secrets:get:project/releng/gecko/build/level-{level}/sb-gapi.data",
                 f"secrets:get:project/releng/gecko/build/level-{level}/mozilla-desktop-geoloc-api.key",
+                f"secrets:get:project/releng/gecko/build/level-{level}/mozilla-fennec-geoloc-api.key",
             ])
 
         yield job


### PR DESCRIPTION
Similar to desktop, grant scope for fetching the Fennec geolocation API key using gecko trust domain.

<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2039183
