### PR TITLE
Bug 2039290 - Enterprise: limit tasks scheduling on PRs

### DIFF
--- a/taskcluster/gecko_taskgraph/target_tasks.py
+++ b/taskcluster/gecko_taskgraph/target_tasks.py
@@ -507,15 +507,28 @@ def target_tasks_enterprise_firefox_with_tests(
             return False
 
         build_platform = task.attributes.get("build_platform")
+        test_platform = task.attributes.get("test_platform")
         build_type = task.attributes.get("build_type")
         shippable = task.attributes.get("shippable", False)
 
         level = int(parameters["level"])
-        if ("shippable" in task.label or shippable) and level < 3:
-            return False
+        if level < 3:
+            if "shippable" in task.label or shippable:
+                return False
 
-        if task.kind == "complete" and level < 3:
-            return False
+            if task.kind == "complete":
+                return False
+
+            if build_platform and not "enterprise" in build_platform:
+                if "windows10" in build_platform:
+                    return False
+
+                if "-asan" or "-tsan" in build_platform:
+                    return False
+
+            if test_platform and not "enterprise" in test_platform:
+                if "-asan" or "-tsan" in test_platform:
+                    return False
 
         if not build_platform or not build_type:
             return True


### PR DESCRIPTION
Do not run some tasks on PRs:
 - asan, tsan on all platforms
 - windows10 build and tests

No change for merges

<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2039290

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->
