### PR TITLE
Bug 2040016, Bug 2040017 - Fix test race conditions waiting for felt window by specifically looking for a new window

### DIFF
--- a/testing/enterprise/felt_tests.py
+++ b/testing/enterprise/felt_tests.py
@@ -15,7 +15,7 @@ import tempfile
 import time
 import urllib.parse
 import uuid
-from contextlib import closing
+from contextlib import closing, contextmanager
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from multiprocessing import Array, Process, Value
 
@@ -1074,3 +1074,27 @@ class FeltTests(FeltTestsBase):
 
     def await_felt_auth_window(self):
         self._wait.until(lambda mn: len(self._driver.chrome_window_handles) == 1)
+
+    @contextmanager
+    def expect_new_felt_auth_window(self):
+        """Context manager: assert FELT's auth window is replaced by a new one.
+
+        Captures the current FELT chrome window handle on entry. On normal
+        exit, waits for that window to be replaced by a new single chrome
+        window and switches to it via force_window(). Use to wrap actions
+        whose effect is that FELT closes its auth window and then re-opens
+        a new one (e.g. login completion that spawns a child Firefox which
+        then fails, causing FELT to re-open its auth window). Ensures the
+        test awaits the new FELT window and not the original one prior to
+        closing.
+        """
+        handles = self._driver.chrome_window_handles
+        previous_handle = handles[0] if len(handles) == 1 else None
+        yield
+
+        def replaced(_):
+            handles = self._driver.chrome_window_handles
+            return previous_handle not in handles and len(handles) == 1
+
+        self._wait.until(replaced)
+        self.force_window()

--- a/testing/enterprise/test_felt_browser_init_failures.py
+++ b/testing/enterprise/test_felt_browser_init_failures.py
@@ -15,10 +15,11 @@ from felt_tests import FeltTests
 class BrowserInitFailures(FeltTests):
     def test_browser_init_policy_fetch_fail(self):
         self.policies_fail_request.value = 1
-        super().run_felt_base()
-        self._manually_closed_child = True
-
-        self.await_felt_auth_window()
+        # After SSO completion, FELT closes its auth window and spawns the
+        # child Firefox. The child fails its policy fetch and exits, which
+        # causes FELT to re-open a new auth window.
+        with self.expect_new_felt_auth_window():
+            self.run_felt_base()
+            self._manually_closed_child = True
         self.policies_fail_request.value = 0
-        self.force_window()
         self.assert_user_signed_out(env=Environment.FELT)

--- a/testing/enterprise/test_felt_browser_starts_missing_bin.py
+++ b/testing/enterprise/test_felt_browser_starts_missing_bin.py
@@ -45,12 +45,15 @@ class FeltStartsBrowserMissingBin(FeltTests):
         # Browser is not being executed at all
         self._manually_closed_child = True
         self.mock_services_felt_binPath()
-        self.run_felt_base()
+        # After SSO completion, FELT closes its auth window and tries to
+        # spawn the child Firefox. The spawn fails because binPath is mocked
+        # to a non-existent path, so FELT re-opens a new auth window with the
+        # error element visible.
+        with self.expect_new_felt_auth_window():
+            self.run_felt_base()
         self.run_felt_check_error_message()
 
     def run_felt_check_error_message(self):
-        self.await_felt_auth_window()
-        self.force_window()
         self._driver.set_context("chrome")
         error_msg = self.get_elem(".felt-browser-error-launch-failure")
         assert "cannot start" in error_msg.text, (


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2040016, Bug-2040017

These two tests logically want to trigger a condition that returns the user to the felt auth window. The tests ran through the login workflow then immediately began a wait for the felt window to be present. However, in the race condition, the original felt window used for the login has not yet disappeared, and the test begins assertions before the actual condition-under-test has occurred. This change adds the ability to wait specifically for a new felt window to appear.

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Testing <!-- OPTIONAL -->

* [x] Manual testing performed (failed consistently locally without the change, succeeded after the change)

<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
