### PR TITLE
Bug 2008554 - Add a linter for current policy JSON schema

### DIFF
--- a/browser/components/enterprisepolicies/schemas/policies-schema.json
+++ b/browser/components/enterprisepolicies/schemas/policies-schema.json
@@ -866,6 +866,9 @@
     },
     "DefaultSerialGuardSetting": {
       "type": "number",
+      "x-category": "Content settings",
+      "description": "Set the default permission for sites requesting serial port access.",
+      "examples": [2, 3],
       "enum": [2, 3]
     },
     "DisableAccounts": {
@@ -1719,7 +1722,7 @@
     },
     "IPProtectionAvailable": {
       "type": "boolean",
-      "description": "",
+      "description": "Control whether the IP Protection feature is available to users.",
       "x-category": "Network security",
       "examples": [true, false]
     },

--- a/browser/components/enterprisepolicies/schemas/policies-schema.json
+++ b/browser/components/enterprisepolicies/schemas/policies-schema.json
@@ -867,7 +867,7 @@
     "DefaultSerialGuardSetting": {
       "type": "number",
       "x-category": "Content settings",
-      "description": "Set the default permission for sites requesting serial port access.",
+      "description": "Control use of the Serial API.",
       "examples": [2, 3],
       "enum": [2, 3]
     },
@@ -1722,7 +1722,7 @@
     },
     "IPProtectionAvailable": {
       "type": "boolean",
-      "description": "Control whether the IP Protection feature is available to users.",
+      "description": "Prevent the built-in VPN from being available to users.",
       "x-category": "Network security",
       "examples": [true, false]
     },

--- a/browser/components/enterprisepolicies/schemas/policies-schema.meta.json
+++ b/browser/components/enterprisepolicies/schemas/policies-schema.meta.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Firefox enterprise policies schema.",
+  "description": "Validates the structure of policies-schema.json. Each entry under `properties` must adhere to this schema so downstream tooling has data it relies on.",
+  "type": "object",
+  "required": ["$schema", "type", "properties"],
+  "properties": {
+    "$schema": {
+      "type": "string"
+    },
+    "type": {
+      "const": "object"
+    },
+    "properties": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "$ref": "#/definitions/policyEntry"
+      }
+    }
+  },
+  "definitions": {
+    "typeName": {
+      "type": "string",
+      "enum": [
+        "string",
+        "number",
+        "integer",
+        "boolean",
+        "array",
+        "object",
+        "URL",
+        "URLorEmpty",
+        "origin",
+        "JSON"
+      ]
+    },
+    "policyEntry": {
+      "type": "object",
+      "required": ["x-category", "description", "type", "examples"],
+      "properties": {
+        "x-category": {
+          "type": "string",
+          "minLength": 1
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "type": {
+          "oneOf": [
+            { "$ref": "#/definitions/typeName" },
+            {
+              "type": "array",
+              "items": { "$ref": "#/definitions/typeName" },
+              "minItems": 1
+            }
+          ]
+        },
+        "examples": {
+          "type": "array"
+        }
+      }
+    }
+  }
+}

--- a/taskcluster/kinds/source-test/mozlint.yml
+++ b/taskcluster/kinds/source-test/mozlint.yml
@@ -322,6 +322,19 @@ lintpref:
             - 'browser/app/profile/channel-prefs.js'
             - 'tools/lint/lintpref.yml'
 
+policies-json:
+    description: Validate enterprise policy JSON artifact against a schema.
+    treeherder:
+        symbol: misc(policy-json)
+    run:
+        mach: lint -v -l policies-json -f treeherder -f json:/builds/worker/mozlint.json .
+    when:
+        files-changed:
+            - 'browser/components/enterprisepolicies/schemas/policies-schema.json'
+            - 'browser/components/enterprisepolicies/schemas/policies-schema.meta.json'
+            - 'tools/lint/policies-json.yml'
+            - 'tools/lint/policies_json/**'
+
 node-licenses:
     description: Lint for node licenses issues
     treeherder:

--- a/tools/lint/policies-json.yml
+++ b/tools/lint/policies-json.yml
@@ -1,0 +1,11 @@
+---
+policies-json:
+    description: Validate enterprise policy JSON artifact against its schema.
+    include:
+        - browser/components/enterprisepolicies/schemas/policies-schema.json
+    extensions: ['json']
+    type: external
+    payload: policies_json:lint
+    support-files:
+        - 'tools/lint/policies_json/**'
+        - 'browser/components/enterprisepolicies/schemas/policies-schema.meta.json'

--- a/tools/lint/policies_json/__init__.py
+++ b/tools/lint/policies_json/__init__.py
@@ -1,0 +1,85 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import json
+import pathlib
+
+import jsonschema
+from mozlint import result
+
+META_SCHEMA_REL = (
+    "browser/components/enterprisepolicies/schemas/policies-schema.meta.json"
+)
+# Resolve relative to this file rather than lintargs["root"], so the linter
+# and its tests share a single source-of-truth meta-schema.
+META_SCHEMA_PATH = pathlib.Path(__file__).resolve().parents[3] / META_SCHEMA_REL
+
+
+def _load_json(path):
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _locate_lineno(text, json_path):
+    """Locate the source line for a jsonschema validation error.
+
+    Returns the line of the top-level policy entry under `properties` that
+    the error is about, or 1 for root-level errors.
+    """
+    parts = list(json_path)
+    if len(parts) >= 2 and parts[0] == "properties":
+        needle = f'"{parts[1]}":'
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if needle in line:
+                return lineno
+    return 1
+
+
+def _error(config, path, lineno, message):
+    return result.from_config(
+        config,
+        path=str(path),
+        lineno=lineno,
+        message=message,
+        level="error",
+    )
+
+
+def lint(paths, config, **lintargs):
+    try:
+        meta_schema = _load_json(META_SCHEMA_PATH)
+    except (OSError, json.JSONDecodeError) as e:
+        return [
+            _error(
+                config,
+                META_SCHEMA_PATH,
+                1,
+                f"Could not load meta-schema: {e}",
+            )
+        ]
+
+    validator = jsonschema.Draft7Validator(meta_schema)
+    results = []
+
+    for path in paths:
+        path = pathlib.Path(path)
+        try:
+            with open(path, encoding="utf-8") as f:
+                text = f.read()
+            data = json.loads(text)
+        except json.JSONDecodeError as e:
+            results.append(_error(config, path, e.lineno, f"Invalid JSON: {e.msg}"))
+            continue
+        except OSError as e:
+            results.append(_error(config, path, 1, f"Could not read file: {e}"))
+            continue
+
+        for err in sorted(validator.iter_errors(data), key=lambda e: list(e.path)):
+            location = "/".join(str(p) for p in err.absolute_path) or "<root>"
+            message = f"{location}: {err.message}"
+            results.append(
+                _error(config, path, _locate_lineno(text, err.absolute_path), message)
+            )
+
+    return results

--- a/tools/lint/test/files/policies-json/bad.json
+++ b/tools/lint/test/files/policies-json/bad.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "MissingCategory": {
+      "type": "boolean",
+      "description": "Has description but no x-category.",
+      "examples": [true]
+    },
+    "EmptyDescription": {
+      "type": "string",
+      "x-category": "Security",
+      "description": "",
+      "examples": ["example"]
+    }
+  }
+}

--- a/tools/lint/test/files/policies-json/good.json
+++ b/tools/lint/test/files/policies-json/good.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "AlphaPolicy": {
+      "type": "boolean",
+      "x-category": "Security",
+      "description": "An example policy.",
+      "examples": [true]
+    },
+    "BetaPolicy": {
+      "type": "string",
+      "x-category": "Network",
+      "description": "Another example policy.",
+      "examples": ["example"]
+    }
+  }
+}

--- a/tools/lint/test/python.toml
+++ b/tools/lint/test/python.toml
@@ -54,6 +54,8 @@ skip-if = ["os == 'win'"]
 
 ["test_node_package_names.py"]
 
+["test_policies_json.py"]
+
 ["test_python_sites.py"]
 
 ["test_rst.py"]

--- a/tools/lint/test/test_policies_json.py
+++ b/tools/lint/test/test_policies_json.py
@@ -1,0 +1,27 @@
+import mozunit
+
+LINTER = "policies-json"
+
+
+def test_clean(lint, paths):
+    results = lint(paths("good.json"))
+    assert results == []
+
+
+def test_violations(lint, paths):
+    results = lint(paths("bad.json"))
+    messages = [r.message for r in results]
+    assert len(messages) == 2
+
+    missing_category = [m for m in messages if "MissingCategory" in m]
+    assert len(missing_category) == 1
+    assert "'x-category' is a required property" in missing_category[0]
+
+    empty_description = [m for m in messages if "EmptyDescription" in m]
+    assert len(empty_description) == 1
+    assert "description" in empty_description[0]
+    assert "too short" in empty_description[0]
+
+
+if __name__ == "__main__":
+    mozunit.main()


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [x] Ensure the linked Bugzilla item is up to date
- [x] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description

Bugzilla: Bug-2008554

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

Supporting work in 2008554. This PR is a lint step that should help with incoming changes on the policies JSON. As we are working on extending the JSON artifact with additional members, we should validate it against a schema so that required fields are provided (compatibility, defaults, examples).

This already catches the following:

- Empty description (`""`)
- Missing `examples`

__Additions:__

- `browser/components/enterprisepolicies/schemas/policies-schema.meta.json`: Described the shape of the current JSON file.
- The linter: `tools/lint/policies_json/__init__.py`
- Taskcluster changes in `taskcluster/kinds/source-test/mozlint.yml`


- Testing the linter: `tools/lint/test/test_policies_json.py`

__changes:__
- Updating the `policies-schema.json` based on linter failures.

### Testing <!-- OPTIONAL -->

* [x] Added tests
* [x] Manual testing performed

**Steps to verify changes:**
1. run `./mach lint --linter policies-json`
2. edit `browser/components/enterprisepolicies/schemas/policies-schema.json` to make the JSON non-compliant (i.e., remove `x-category` for a given policy)
3. run `./mach lint --linter policies-json`

**Expected result:**

There are lint failures detected.
