### PR TITLE
Bug 2039213 - Fix  customizableui tests for enterprise build

### DIFF
--- a/browser/base/content/browser.xhtml
+++ b/browser/base/content/browser.xhtml
@@ -53,6 +53,10 @@
     rel="stylesheet"
     href="chrome://global/content/resistfingerprinting/letterboxing.css"
   />
+  #ifdef MOZ_ENTERPRISE
+  <html:link rel="stylesheet" href="chrome://browser/content/enterprise/enterprise-badge.css"/>
+  <html:link rel="localization" href="browser/enterprise/enterprise.ftl"/>
+  #endif
 
   <link rel="localization" href="branding/brand.ftl"/>
   <link rel="localization" href="browser/allTabsMenu.ftl"/>

--- a/browser/components/customizableui/test/browser_884402_customize_from_overflow.js
+++ b/browser/components/customizableui/test/browser_884402_customize_from_overflow.js
@@ -18,15 +18,20 @@ registerCleanupFunction(function () {
 // show a context menu with options to move it.
 add_task(async function () {
   overflowPanel.setAttribute("animate", "false");
-  let fxaButton = document.getElementById("fxa-toolbar-menu-button");
-  if (BrowserTestUtils.isHidden(fxaButton)) {
-    // FxA button is likely hidden since the user is logged out.
+
+  const buttonId = AppConstants.MOZ_ENTERPRISE
+    ? "email-link-button"
+    : "fxa-toolbar-menu-button";
+  let button = document.getElementById(buttonId);
+
+  if (BrowserTestUtils.isHidden(button)) {
+    // Button is likely hidden since the user is logged out.
     let initialFxaStatus = document.documentElement.getAttribute("fxastatus");
     document.documentElement.setAttribute("fxastatus", "signed_in");
     registerCleanupFunction(() =>
       document.documentElement.setAttribute("fxastatus", initialFxaStatus)
     );
-    ok(BrowserTestUtils.isVisible(fxaButton), "FxA button is now visible");
+    ok(BrowserTestUtils.isVisible(button), "Button is now visible");
   }
 
   let navbar = document.getElementById(CustomizableUI.AREA_NAVBAR);
@@ -48,13 +53,12 @@ add_task(async function () {
     "customizationPanelItemContextMenu"
   );
   let shownContextPromise = popupShown(contextMenu);
-  ok(fxaButton, "fxa-toolbar-menu-button was found");
-  is(
-    fxaButton.getAttribute("overflowedItem"),
-    "true",
-    "FxA button is overflowing"
+  ok(button, buttonId + " was found");
+  await TestUtils.waitForCondition(
+    () => button.getAttribute("overflowedItem") == "true",
+    buttonId + " should be overflowing"
   );
-  EventUtils.synthesizeMouse(fxaButton, 2, 2, {
+  EventUtils.synthesizeMouse(button, 2, 2, {
     type: "contextmenu",
     button: 2,
   });
@@ -85,37 +89,31 @@ add_task(async function () {
   await hiddenContextPromise;
   await hiddenPromise;
 
-  let fxaButtonPlacement = CustomizableUI.getPlacementOfWidget(
-    "fxa-toolbar-menu-button"
-  );
-  ok(fxaButtonPlacement, "FxA button should still have a placement");
+  let buttonPlacement = CustomizableUI.getPlacementOfWidget(buttonId);
+  ok(buttonPlacement, "Button should still have a placement");
   is(
-    fxaButtonPlacement && fxaButtonPlacement.area,
+    buttonPlacement && buttonPlacement.area,
     CustomizableUI.AREA_FIXED_OVERFLOW_PANEL,
-    "FxA button should be pinned now"
+    "Button should be pinned now"
   );
   CustomizableUI.reset();
   ensureToolbarOverflow(window, false);
 
   // In some cases, it can take a tick for the navbar to overflow again. Wait for it:
-  await TestUtils.waitForCondition(() =>
-    fxaButton.hasAttribute("overflowedItem")
-  );
+  await TestUtils.waitForCondition(() => button.hasAttribute("overflowedItem"));
   ok(navbar.hasAttribute("overflowing"), "Should have an overflowing toolbar.");
 
-  fxaButtonPlacement = CustomizableUI.getPlacementOfWidget(
-    "fxa-toolbar-menu-button"
-  );
-  ok(fxaButtonPlacement, "FxA button should still have a placement");
+  buttonPlacement = CustomizableUI.getPlacementOfWidget(buttonId);
+  ok(buttonPlacement, "Button should still have a placement");
   is(
-    fxaButtonPlacement && fxaButtonPlacement.area,
+    buttonPlacement && buttonPlacement.area,
     "nav-bar",
-    "FxA button should be back in the navbar now"
+    "Button should be back in the navbar now"
   );
 
   is(
-    fxaButton.getAttribute("overflowedItem"),
+    button.getAttribute("overflowedItem"),
     "true",
-    "FxA button should still be overflowed"
+    "Button should still be overflowed"
   );
 });

--- a/browser/components/customizableui/test/browser_923857_customize_mode_event_wrapping_during_reset.js
+++ b/browser/components/customizableui/test/browser_923857_customize_mode_event_wrapping_during_reset.js
@@ -8,14 +8,14 @@
 add_task(async function () {
   await startCustomizing();
   let devButton = document.getElementById("developer-button");
-  let fxaButton = document.getElementById("fxa-toolbar-menu-button");
+  let buttonId = AppConstants.MOZ_ENTERPRISE
+    ? "enterprise-badge-toolbar-button"
+    : "fxa-toolbar-menu-button";
+  let button = document.getElementById(buttonId);
   let stopReloadButton = document.getElementById("stop-reload-button");
   let palette = document.getElementById("customization-palette");
-  ok(
-    devButton && fxaButton && stopReloadButton && palette,
-    "Stuff should exist"
-  );
-  simulateItemDrag(devButton, fxaButton);
+  ok(devButton && button && stopReloadButton && palette, "Stuff should exist");
+  simulateItemDrag(devButton, button);
   simulateItemDrag(stopReloadButton, palette);
   await gCustomizeMode.reset();
   ok(CustomizableUI.inDefaultState, "Should be back in default state");

--- a/browser/components/customizableui/test/browser_editcontrols_update.js
+++ b/browser/components/customizableui/test/browser_editcontrols_update.js
@@ -3,6 +3,30 @@
 // It also verifies that the performance optimiation implemented by
 // updateEditUIVisibility in browser.js is applied.
 
+// The enterprise badge button sits in the navbar. Without a logo it can have
+// zero width, which throws off the kForceOverflowWidthPx resize threshold used
+// in test_panelui_customize_to_toolbar to force toolbar overflow.
+if (AppConstants.MOZ_ENTERPRISE) {
+  add_setup(async function () {
+    await SpecialPowers.pushPrefEnv({
+      set: [
+        [
+          "enterprise.configs.company_logo_url",
+          "data:image/svg+xml;base64," +
+            btoa(
+              '<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32"><rect width="32" height="32" fill="#ccc"/></svg>'
+            ),
+        ],
+      ],
+    });
+    const { EnterpriseHandler } = ChromeUtils.importESModule(
+      "resource:///modules/enterprise/EnterpriseHandler.sys.mjs"
+    );
+    // Re-trigger badge update since the logo pref was set after initial init.
+    EnterpriseHandler.updateBadge(window);
+  });
+}
+
 let isMac = navigator.platform.indexOf("Mac") == 0;
 
 function checkState(allowCut, desc, testWindow = window) {

--- a/browser/components/enterprise/content/enterprise-badge.inc.xhtml
+++ b/browser/components/enterprise/content/enterprise-badge.inc.xhtml
@@ -2,9 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-<html:link rel="stylesheet" href="chrome://browser/content/enterprise/enterprise-badge.css" overflows="false"/>
-<html:link rel="localization" href="browser/enterprise/enterprise.ftl" overflows="false"/>
-
 <toolbarbutton id="enterprise-badge-toolbar-button" class="toolbarbutton-1 chromeclass-toolbar-additional" delegatesanchor="true" data-l10n-id="enterprise-toolbar-button" removable="false" cui-areatype="toolbar">
   <hbox>
     <div class="enterprise-badge">


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2039213

fixes:

In general tests fail with `uncaught rejection: DocumentFragment.querySelector: '#' is not a valid selector`, this is because the we have two html link elements in the pannel, and the CustomizableUI uses id's programatically. I moved those ones in browser.xhtml as other items are doing.
- browser_884402_customize_from_overflow.js uses the FxA button from the "overflowable" menu and tries to customize it, because our badge is not customizable (i.e non removable) and we do not have FxA button, I used another button
- browser_923857_customize_mode_event_wrapping_during_reset.js same as above, I just used email button
- browser_editcontrols_update.js the test does different things, the problem in here is the expectation that we reach the "overflow" state, our "enterprise badge" has usually no size on this tests, as such I gave it a fake logo, to have a "organic size" (instead of just setting some random width)
- The test `browser_976792_insertNodeInWindow.js` is fixed upstream (see dependencies)

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on: https://bugzilla.mozilla.org/show_bug.cgi?id=2041653
* https://phabricator.services.mozilla.com/D302990

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

---

### Testing <!-- OPTIONAL -->

* [ ] Added tests
* [ ] Manual testing performed
[See test pass](https://treeherder.mozilla.org/logviewer?job_id=569225516&repo=enterprise-firefox-pr&task=XQJFeFQkTeSnfKAgAWpPzw.0&lineNumber=6026)

<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
