### PR TITLE
Bug 2040434 - Use full subsuite for enterprise marionette tests as expected

### DIFF
--- a/taskcluster/kinds/test/marionette.yml
+++ b/taskcluster/kinds/test/marionette.yml
@@ -147,5 +147,5 @@ marionette-enterprise:
                     - marionette/enterprise_config.py
                     - remove_executables.py
         extra-options:
-            - --subsuite=enterprise
+            - --subsuite=marionette-enterprise
             - --test-manifest=enterprise-tests.toml


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2040434

The subsuite for enterprise marionette tests doesn't match the pattern for the unit or integration subsuites. This updates enterprise to match the pattern of the others.
<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

Note: no uplift to release since the change had already been correctly updated there.

---

### Testing <!-- OPTIONAL -->

* [ ] Will ensure enterprise marionette tests still run correctly in the PR.

<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
