### PR TITLE
Bug 2040606 - Unlock FxA prefs in moreFromMozilla test head.js for enterprise builds

### DIFF
--- a/browser/components/preferences/tests/moreFromMozilla/head.js
+++ b/browser/components/preferences/tests/moreFromMozilla/head.js
@@ -59,6 +59,19 @@ async function mockDefaultFxAInstance() {
    *                             the illusion of a custom FxA instance.
    */
 
+  // On enterprise builds these prefs are locked, temporarily unlock them
+  // so the test can swap default/user values for FxA mocking.
+  let lockedPrefs = [];
+  if (AppConstants.MOZ_ENTERPRISE) {
+    lockedPrefs = [
+      "identity.fxaccounts.auth.uri",
+      "identity.fxaccounts.remote.root",
+    ].filter(pref => Services.prefs.prefIsLocked(pref));
+    for (const pref of lockedPrefs) {
+      Services.prefs.unlockPref(pref);
+    }
+  }
+
   const defaultPrefs = Services.prefs.getDefaultBranch("");
   const userPrefs = Services.prefs.getBranch("");
   const realAuth = defaultPrefs.getCharPref("identity.fxaccounts.auth.uri");
@@ -76,6 +89,11 @@ async function mockDefaultFxAInstance() {
     defaultPrefs.setCharPref("identity.fxaccounts.remote.root", realRoot);
     userPrefs.setCharPref("identity.fxaccounts.auth.uri", mockAuth);
     userPrefs.setCharPref("identity.fxaccounts.remote.root", mockRoot);
+    if (AppConstants.MOZ_ENTERPRISE) {
+      for (const pref of lockedPrefs) {
+        Services.prefs.lockPref(pref);
+      }
+    }
   };
 
   mock();


### PR DESCRIPTION

<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2040606

Both prefs are locked in EnterpriseEndpoints, as far as I understood, we want to support MoreFromMozilla through policy enablement, this bug is about making sure the tests are working properly (i.e functionality is working).
```
      "identity.fxaccounts.auth.uri",
      "identity.fxaccounts.remote.root"
```

[See test fail without changes](https://treeherder.mozilla.org/logviewer?job_id=567149020&repo=enterprise-firefox-pr&task=ePSgjCO8TnqLrC4L2dGY3g.0&lineNumber=8589)
[See test pass](https://treeherder.mozilla.org/logviewer?job_id=567333248&repo=enterprise-firefox-pr&task=TKohEfwdT4ayGkvqXl-UhQ.0&lineNumber=4218)
<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on:

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

---

### Testing <!-- OPTIONAL -->

* [ ] Added tests
* [ ] Manual testing performed

<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
