### PR TITLE
Bug 2040630 - Enterprise: Add source of profile creation as 'felt'

### DIFF
--- a/browser/extensions/felt/content/FeltProcessParent.sys.mjs
+++ b/browser/extensions/felt/content/FeltProcessParent.sys.mjs
@@ -598,7 +598,11 @@ export class FeltProcessParent extends JSProcessActorParent {
 
       if (!foundProfile) {
         lazy.log.debug(`FeltExtension: creating new ${profileName} profile`);
-        foundProfile = profileService.createProfile(null, profileName);
+        foundProfile = profileService.createProfile(
+          null,
+          profileName,
+          "felt-firstrun"
+        );
 
         await profileService.asyncFlush();
       }

--- a/toolkit/profile/metrics.yaml
+++ b/toolkit/profile/metrics.yaml
@@ -330,6 +330,8 @@ profiles:
           A profile created for a background task
         unknown
           The profile was created without supplying a source
+        felt-firstrun
+          First run of felt creates the profile
     bugs:
       - https://bugzilla.mozilla.org/show_bug.cgi?id=2026972
     data_reviews:


### PR DESCRIPTION
Bug-2026972 introduced a "source" parameter when creating the profile, populating it with "felt".

<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2040630