### PR TITLE
Bug 2035426 - Enterprise: add missing mozconfig

### DIFF
--- a/browser/config/mozconfigs/linux64/beta-enterprise
+++ b/browser/config/mozconfigs/linux64/beta-enterprise
@@ -1,0 +1,5 @@
+. "$topsrcdir/browser/config/mozconfigs/linux64/common-opt"
+
+ac_add_options --enable-enterprise
+
+. "$topsrcdir/build/mozconfig.common.override"

--- a/browser/config/mozconfigs/macosx64-aarch64/beta-enterprise
+++ b/browser/config/mozconfigs/macosx64-aarch64/beta-enterprise
@@ -1,0 +1,5 @@
+. "$topsrcdir/browser/config/mozconfigs/macosx64-aarch64/common-opt"
+
+ac_add_options --enable-enterprise
+
+. "$topsrcdir/build/mozconfig.common.override"

--- a/browser/config/mozconfigs/macosx64/beta-enterprise
+++ b/browser/config/mozconfigs/macosx64/beta-enterprise
@@ -1,0 +1,5 @@
+. "$topsrcdir/browser/config/mozconfigs/macosx64/common-opt"
+
+ac_add_options --enable-enterprise
+
+. "$topsrcdir/build/mozconfig.common.override"

--- a/browser/config/mozconfigs/win64/beta-enterprise
+++ b/browser/config/mozconfigs/win64/beta-enterprise
@@ -1,0 +1,7 @@
+. "$topsrcdir/build/mozconfig.win-common"
+. "$topsrcdir/browser/config/mozconfigs/win64/common-win64"
+. "$topsrcdir/browser/config/mozconfigs/win64/common-opt"
+
+ac_add_options --enable-enterprise
+
+. "$topsrcdir/build/mozconfig.common.override"


### PR DESCRIPTION
The beta builds were missing their mozconfig file for opt builds failing everywhere. Not caught earlier because of broken treeherder display.

<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2035426

This is a "downlift" (via cherry-pick) of the original change that went straight into `enterprise-beta` in #798 . Although these configs are only used in the `enterprise-beta` branch, we want to ensure all source is present in `enterprise-main` first then uplifted as necessary. By limiting this kind of difference between branches, it makes promotion merges easier.

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->


<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
