### PR TITLE
Bug 2040947 - Enterprise: remove unused IP Protection FxA-path shims

### DIFF
--- a/toolkit/components/ipprotection/fxa/GuardianClient.sys.mjs
+++ b/toolkit/components/ipprotection/fxa/GuardianClient.sys.mjs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { AppConstants } from "resource://gre/modules/AppConstants.sys.mjs";
 import { XPCOMUtils } from "resource://gre/modules/XPCOMUtils.sys.mjs";
 import {
   Entitlement,
@@ -222,14 +221,6 @@ export class GuardianClient {
    * - 401: The auth token was rejected, probably a guardian/auth provider environment mismatch.
    */
   async fetchUserInfo(tokenHandle, abortSignal = null) {
-    if (AppConstants.MOZ_ENTERPRISE) {
-      const entitlement = new Entitlement({
-        subscribed: true,
-        uid: 1,
-        maxBytes: "1000000",
-      });
-      return { status: 200, entitlement };
-    }
     const response = await fetch(this.#statusURL, {
       method: "GET",
       headers: {
@@ -265,15 +256,6 @@ export class GuardianClient {
    * @returns {ProxyUsage | null}
    */
   async fetchProxyUsage(tokenHandle, abortSignal) {
-    if (AppConstants.MOZ_ENTERPRISE) {
-      return new ProxyUsage(
-        "1000000",
-        "1000000",
-        Temporal.Now.zonedDateTimeISO()
-          .add(Temporal.Duration.from({ days: 30 }))
-          .toString()
-      );
-    }
     const response = await fetch(this.#tokenURL, {
       method: "HEAD",
       cache: "no-cache",

--- a/toolkit/components/ipprotection/fxa/IPPFxaAuthProvider.sys.mjs
+++ b/toolkit/components/ipprotection/fxa/IPPFxaAuthProvider.sys.mjs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { AppConstants } from "resource://gre/modules/AppConstants.sys.mjs";
 import { IPPFxaBaseAuthProvider } from "moz-src:///toolkit/components/ipprotection/fxa/IPPFxaBaseAuthProvider.sys.mjs";
 import { GUARDIAN_EXPERIMENT_TYPE } from "moz-src:///toolkit/components/ipprotection/fxa/GuardianClient.sys.mjs";
 
@@ -111,10 +110,6 @@ class IPPFxaAuthProviderSingleton extends IPPFxaBaseAuthProvider {
   }
 
   async #isLinkedToGuardian(useCache = true) {
-    if (AppConstants.MOZ_ENTERPRISE) {
-      return true;
-    }
-
     try {
       const endpoint = Services.prefs.getCharPref(
         GUARDIAN_ENDPOINT_PREF,

--- a/toolkit/components/ipprotection/fxa/IPPFxaBaseAuthProvider.sys.mjs
+++ b/toolkit/components/ipprotection/fxa/IPPFxaBaseAuthProvider.sys.mjs
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { AppConstants } from "resource://gre/modules/AppConstants.sys.mjs";
 import { IPPAuthProvider } from "moz-src:///toolkit/components/ipprotection/IPPAuthProvider.sys.mjs";
 import { GuardianClient } from "moz-src:///toolkit/components/ipprotection/fxa/GuardianClient.sys.mjs";
 
@@ -127,12 +126,6 @@ export class IPPFxaBaseAuthProvider extends IPPAuthProvider {
    * @returns {Promise<{token: string} & Disposable>}
    */
   async getToken(abortSignal = null) {
-    if (AppConstants.MOZ_ENTERPRISE) {
-      return {
-        token: Services.felt.getAccessTokenIfValid(),
-        [Symbol.dispose]: () => {},
-      };
-    }
     let tasks = [
       lazy.fxAccounts.getOAuthToken({
         scope: ["profile", "https://identity.mozilla.com/apps/vpn"],

--- a/toolkit/components/ipprotection/fxa/IPPSignInWatcher.sys.mjs
+++ b/toolkit/components/ipprotection/fxa/IPPSignInWatcher.sys.mjs
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import { AppConstants } from "resource://gre/modules/AppConstants.sys.mjs";
-
 const lazy = {};
 
 ChromeUtils.defineESModuleGetters(lazy, {
@@ -20,9 +18,6 @@ class IPPSignInWatcherSingleton extends EventTarget {
   #signedIn = false;
 
   get isSignedIn() {
-    if (AppConstants.MOZ_ENTERPRISE) {
-      return true;
-    }
     return this.#signedIn;
   }
 


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2040947

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

`IPPEnterpriseAuthProvider` landed upstream so much of our implementation can now be removed. 

- Remove `IPProtectionFxaAuthProvider` enterprise shims which were originally added to force the FxA auth provider to use our Felt tokens
- Remove `GuardianClient` enterprise shims that returned hardcoded entitlement and proxy usage data, bypassing the real Guardian API calls
- Remove `IPPSignInWatcher.isSignedIn` enterprise override that always returned true, bypassing the real FxA sign-in state
  - **Note**: not having this watcher caused a [regression](https://bugzilla.mozilla.org/show_bug.cgi?id=2040983). AccessConnector state on policy activation should not rely on the FxA provider, so this needs fixing in a followup. Currently `test_browser_access_connector_default_off` will be failing.

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on: Bug-2039304
