### PR TITLE
Bug 2036744 - Enterprise: Test that IP Protection prefs with no defaults are cleared on AccessConnector policy removal

### DIFF
--- a/testing/enterprise/test_felt_browser_access_connector.py
+++ b/testing/enterprise/test_felt_browser_access_connector.py
@@ -157,15 +157,12 @@ class BrowserAccessConnector(FeltTests):
         assert not state["browser.ipProtection.features.autoStart"]["isLocked"]
         assert not state["browser.ipProtection.autoStartEnabled"]["value"]
         assert not state["browser.ipProtection.autoStartEnabled"]["isLocked"]
-        # Bug 2036744: This is likely not correct? Value is still == 3
-        # assert state["browser.ipProtection.mode"]["value"] == 3
         assert not state["browser.ipProtection.mode"]["isLocked"]
-        # Bug 2036744: This is likely not correct? value is not ""
-        # assert state["browser.ipProtection.override.serverlist"]["value"] == ""
+        assert not state["browser.ipProtection.mode"]["value"]
         assert not state["browser.ipProtection.override.serverlist"]["isLocked"]
-        # Bug 2036744: This is likely not correct? value is not ""
-        # assert state["browser.ipProtection.inclusion.match_patterns"]["value"] == ""
+        assert not state["browser.ipProtection.override.serverlist"]["value"]
         assert not state["browser.ipProtection.inclusion.match_patterns"]["isLocked"]
+        assert not state["browser.ipProtection.inclusion.match_patterns"]["value"]
         assert not state["browser.ipProtection.openedPanelWithLocation"]["value"]
         assert not state["browser.ipProtection.openedPanelWithLocation"]["isLocked"]
         assert not state["browser.ipProtection.enabled"]["value"]


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [x] Ensure the linked Bugzilla item is up to date
- [x] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2036744

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

- Adds assertions and removes comments in test for AccessConnector policy-locked prefs that were previously not being removed on policy removal


---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on: #925

---

### Testing

- [x] Added tests
- [x] Manual testing performed

> This simply adds the missing assertions for the prefs that were previously broken. Manually tested with the fix from #925 and this works properly.