### PR TITLE
Bug 2040983 - Enterprise: fix IP Protection proxy not activating on dynamic AccessConnector policy

### DIFF
--- a/toolkit/components/ipprotection/IPProtectionServerlist.sys.mjs
+++ b/toolkit/components/ipprotection/IPProtectionServerlist.sys.mjs
@@ -402,6 +402,13 @@ export class PrefServerList extends IPProtectionServerlistBase {
     this.maybeFetchList();
   }
 
+  // Re-read the pref so that a policy activated after module load is picked up before #updateState() runs.
+  init() {
+    this.__list = IPProtectionServerlistBase.dataToList(
+      PrefServerList.prefValue
+    );
+  }
+
   async initOnStartupCompleted() {
     Services.prefs.addObserver(
       IPProtectionServerlist.PREF_NAME,

--- a/toolkit/components/ipprotection/enterprise/IPPEnterpriseAuthProvider.sys.mjs
+++ b/toolkit/components/ipprotection/enterprise/IPPEnterpriseAuthProvider.sys.mjs
@@ -11,6 +11,11 @@ import {
 
 const lazy = {};
 
+ChromeUtils.defineESModuleGetters(lazy, {
+  IPProtectionService:
+    "moz-src:///toolkit/components/ipprotection/IPProtectionService.sys.mjs",
+});
+
 ChromeUtils.defineLazyGetter(lazy, "logConsole", () =>
   console.createInstance({
     prefix: "IPPEnterpriseAuthProvider",
@@ -133,8 +138,25 @@ class IPPEnterpriseAuthProviderSingleton extends IPPAuthProvider {
     return null;
   }
 
+  init() {}
+
+  // eslint-disable-next-line require-await
+  async initOnStartupCompleted() {
+    // The enterprise provider is always ready; notify listeners so the panel
+    // and toolbar button pick up the correct state after policy activation.
+    this.dispatchEvent(
+      new CustomEvent("IPPAuthProvider:StateChanged", {
+        bubbles: true,
+        composed: true,
+      })
+    );
+    lazy.IPProtectionService.updateState();
+  }
+
+  uninit() {}
+
   get helpers() {
-    return [];
+    return [this];
   }
 
   get isReady() {


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2040983

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

- `PrefServerList.init()`: re-reads the serverlist pref so a policy applied after startup is picked up before `#updateState()` runs.
- `IPPEnterpriseAuthProvider`: added to `helpers`, implemented `init()`, `uninit()`, and `initOnStartupCompleted()` so the provider participates in the service lifecycle and notifies UI on activation.                                                                   

### Testing <!-- OPTIONAL -->

* [x] Added tests
  * None added, just made existing pass
* [x] Manual testing performed

<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
