### PR TITLE
Bug 2041251 - Enterprise: update NSIS uninstaller removal of profile

### DIFF
--- a/browser/installer/windows/nsis/uninstaller.nsi
+++ b/browser/installer/windows/nsis/uninstaller.nsi
@@ -711,7 +711,7 @@ Section "Uninstall"
   RmDir "$INSTDIR"
 
 !ifdef MOZ_ENTERPRISE
-  RmDir /r "$TEMP\felt\"
+  RmDir /r "$TEMP\felt-${UpdateChannel}\"
 !endif
 
   ; If firefox.exe was successfully deleted yet we still need to restart to


### PR DESCRIPTION
Profile is now keyed by update channel, so the removal needs to be updated.

<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2041251

Beta uplift

### Testing <!-- OPTIONAL -->

**Steps to verify changes:**
1. Pick Windows NSIS installer out of CI
2. Install
3. There should be a `$TEMP\felt-${UpdateChannel}` directory
4. Uninstall

**Expected result:**
Directory `$TEMP\felt-${UpdateChannel}\` should get removed
