### PR TITLE
Bug 2041388 - Enterprise: correct removeObserver calls

### DIFF
--- a/browser/components/enterprise/modules/ConsoleClient.sys.mjs
+++ b/browser/components/enterprise/modules/ConsoleClient.sys.mjs
@@ -709,7 +709,7 @@ export const ConsoleClient = {
    * Register shutdown observer to clean up the client.
    */
   init() {
-    Services.prefs.addObserver("enterprise.console.address", this);
+    Services.prefs.addObserver(CONSOLE_ADDRESS_PREF, this);
 
     if (Services.felt.isFeltBrowser()) {
       Services.obs.addObserver(this, "xpcom-shutdown");
@@ -723,7 +723,7 @@ export const ConsoleClient = {
     switch (topic) {
       case "xpcom-shutdown": {
         Services.obs.removeObserver(this, "xpcom-shutdown");
-        Services.prefs.removeObserver(this, "enterprise.console.address");
+        Services.prefs.removeObserver(CONSOLE_ADDRESS_PREF, this);
         Services.obs.removeObserver(
           this,
           "felt-firefox-access-token-refreshed"


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Arguments were inverted when performing Services.prefs.removeObserver(), triggering incorrect removal and throwing errors.

Bugzilla: Bug-2041388

Regression from #588

This may warrant an uplift to beta ? And release ?
