### PR TITLE
Bug 2037872 - Enterprise: Fix access connector toolbar icon size regression

### DIFF
--- a/browser/themes/shared/toolbarbutton-icons.css
+++ b/browser/themes/shared/toolbarbutton-icons.css
@@ -387,7 +387,7 @@
   }
   &:not(:is([overflowedItem="true"], [cui-areatype="panel"])) {
     > .toolbarbutton-icon {
-      width: calc(2 * var(--toolbarbutton-padding-inner) + var(--icon-width));
+      width: calc(2 * var(--toolbarbutton-padding-inner) + var(--icon-size-small));
     }
   }
   &.ipprotection-on {

--- a/browser/themes/shared/toolbarbutton-icons.css
+++ b/browser/themes/shared/toolbarbutton-icons.css
@@ -384,7 +384,11 @@
   }
   > .toolbarbutton-icon {
     list-style-image: url("chrome://browser/content/ipprotection/assets/ac-icon.svg");
-    width: calc(2 * var(--toolbarbutton-padding-inner) + 16px);
+  }
+  &:not(:is([overflowedItem="true"], [cui-areatype="panel"])) {
+    > .toolbarbutton-icon {
+      width: calc(2 * var(--toolbarbutton-padding-inner) + var(--icon-width));
+    }
   }
   &.ipprotection-on {
     > .toolbarbutton-icon {


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2037872

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

- Updates the Access Connector icon CSS rule to match upstream change to target only non-overflow panel icon

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on: #885 