### PR TITLE
Bug 2041830 - Fix syntax: Use ternary operator instead of incorrect use of object spread syntax to pass parameter

### DIFF
--- a/services/fxaccounts/FxAccountsClient.sys.mjs
+++ b/services/fxaccounts/FxAccountsClient.sys.mjs
@@ -797,9 +797,11 @@ FxAccountsClient.prototype = {
         method,
         credentials,
         jsonPayload,
-        ...(AppConstants.MOZ_ENTERPRISE && {
-          Authorization: `Bearer ${await lazy.ConsoleClient.getAccessToken()}`,
-        })
+        AppConstants.MOZ_ENTERPRISE
+          ? {
+              Authorization: `Bearer ${await lazy.ConsoleClient.getAccessToken()}`,
+            }
+          : {}
       );
     } catch (error) {
       log.error(`error ${method}ing ${path}`, error);


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2041830

The intent is to pass the single `extraHeaders` parameter as either `{}` (non-Enterprise) or populated with the bearer token (Enterprise). The `...` spread syntax as currently applied in the parameter list attempts to expand the object into the parameter list. It's clearer to instead use a ternary operator to determine what arg to pass.

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Regressed in: #770 

<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
