### PR TITLE
Bug 2042349 - Fix test_sync_auth_manager.js for enterprise builds

### DIFF
--- a/services/fxaccounts/FxAccountsClient.sys.mjs
+++ b/services/fxaccounts/FxAccountsClient.sys.mjs
@@ -797,7 +797,7 @@ FxAccountsClient.prototype = {
         method,
         credentials,
         jsonPayload,
-        AppConstants.MOZ_ENTERPRISE
+        AppConstants.MOZ_ENTERPRISE && Services.felt?.isFeltBrowser()
           ? {
               Authorization: `Bearer ${await lazy.ConsoleClient.getAccessToken()}`,
             }

--- a/services/sync/tests/unit/test_sync_auth_manager.js
+++ b/services/sync/tests/unit/test_sync_auth_manager.js
@@ -36,6 +36,28 @@ const { TokenServerClient, TokenServerClientServerError } =
 const { AccountState, ERROR_INVALID_ACCOUNT_STATE } =
   ChromeUtils.importESModule("resource://gre/modules/FxAccounts.sys.mjs");
 
+add_setup(function () {
+  const { AppConstants } = ChromeUtils.importESModule(
+    "resource://gre/modules/AppConstants.sys.mjs"
+  );
+  if (AppConstants.MOZ_ENTERPRISE) {
+    // Enterprise builds need a default tokenserver URI, otherwise
+    // TokenServerClient rejects the empty/missing URL.
+    const defaultBranch = Services.prefs.getDefaultBranch("");
+    const originalUri = defaultBranch.getStringPref(
+      "identity.sync.tokenserver.uri",
+      ""
+    );
+    defaultBranch.setStringPref(
+      "identity.sync.tokenserver.uri",
+      "https://token.services.mozilla.com/1.0/sync/1.5"
+    );
+    registerCleanupFunction(() => {
+      defaultBranch.setStringPref("identity.sync.tokenserver.uri", originalUri);
+    });
+  }
+});
+
 const SECOND_MS = 1000;
 const MINUTE_MS = SECOND_MS * 60;
 const HOUR_MS = MINUTE_MS * 60;


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2042349

test_sync_auth_manager.js fails because the consoleClient throws when it attempts to call felt.getAccessTokenIfValid()

This patch adds an add_setup block that, only on enterprise builds:

- Sets a default identity.sync.tokenserver.uri pref so the token server client has a valid endpoint to work with. (i.e it just expect a url)
- Prevents the call to happen when it is not felt managed

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on: https://github.com/mozilla/enterprise-firefox/pull/950

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

---

### Testing <!-- OPTIONAL -->

* [ ] Added tests
* [x] Manual testing performed

[See test failing](https://treeherder.mozilla.org/logviewer?job_id=568748340&repo=enterprise-firefox-pr&task=IPwSNZK_SMWqGDP4qIq2gQ.0&lineNumber=5535)
[See test pass](https://treeherder.mozilla.org/logviewer?job_id=568764996&repo=enterprise-firefox-pr&task=dhxXZJu6QyyF96_s-DZIjg.0&lineNumber=4742)
<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
