### PR TITLE
Bug 2037872 - Enterprise: Fix access connector toolbar icon size regression (release uplift)

### DIFF
--- a/browser/themes/shared/toolbarbutton-icons.css
+++ b/browser/themes/shared/toolbarbutton-icons.css
@@ -379,7 +379,7 @@
   }
   &:not(:is([overflowedItem="true"], [cui-areatype="panel"])) {
     > .toolbarbutton-icon {
-      width: calc(2 * var(--toolbarbutton-padding-inner) + var(--icon-size-small));
+      width: calc(2 * var(--toolbarbutton-inner-padding) + var(--icon-size-small));
     }
   }
   &.ipprotection-on {

--- a/browser/themes/shared/toolbarbutton-icons.css
+++ b/browser/themes/shared/toolbarbutton-icons.css
@@ -376,7 +376,11 @@
   }
   > .toolbarbutton-icon {
     list-style-image: url("chrome://browser/content/ipprotection/assets/ac-icon.svg");
-    width: calc(2 * var(--toolbarbutton-inner-padding) + 16px);
+  }
+  &:not(:is([overflowedItem="true"], [cui-areatype="panel"])) {
+    > .toolbarbutton-icon {
+      width: calc(2 * var(--toolbarbutton-padding-inner) + var(--icon-size-small));
+    }
   }
   &.ipprotection-on {
     > .toolbarbutton-icon {


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2037872

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

Release uplift of #944. Note that `enterprise-release` did not get the token rename from Bug-2034495, so the token remains as `--toolbarbutton-inner-padding`

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on: #944 