### PR TITLE
Ensure `./mach try ` displays enterprise specific tasks by default

### DIFF
--- a/python/mach/mach/settings.py
+++ b/python/mach/mach/settings.py
@@ -121,6 +121,12 @@ class MachSettings:
                     "Remote name or url to push to.",
                     "git@github.com:mozilla/enterprise-firefox-try.git",
                 ),
+                (
+                    "try.params",
+                    "string",
+                    "Default set of parameters to generate tasks with.",
+                    "taskcluster/test/params/em-onpush.yml",
+                ),
             ]
 
         def taskgraph_config_settings():

--- a/taskcluster/test/params/em-onpush.yml
+++ b/taskcluster/test/params/em-onpush.yml
@@ -1,0 +1,203 @@
+android_perftest_backstop: false
+app_version: 153.0a1
+backstop: false
+base_ref: ''
+base_repository: https://github.com/mozilla/enterprise-firefox
+base_rev: 1647002c9c52a131713913111dc30cd296d2d573
+build_date: 1779807116
+build_number: 1
+do_not_optimize: []
+dontbuild: false
+enable_always_target:
+  - docker-image
+existing_tasks: {}
+files_changed:
+  - testing/enterprise/test_felt_browser_access_connector.py
+filters:
+  - target_tasks_method
+head_ref: refs/heads/enterprise-main
+head_repository: https://github.com/mozilla/enterprise-firefox
+head_rev: 8e57364545b4b31f9dd82dd6c5a5e6106032a315
+head_tag: ''
+hg_branch: null
+level: '3'
+message: ''
+moz_build_date: '20260526145156'
+next_version: null
+optimize_strategies: null
+optimize_target_tasks: true
+owner: user@example.com
+phabricator_diff: null
+project: enterprise-firefox
+pushdate: 0
+pushlog_id: '0'
+release_enable_emefree: false
+release_enable_partner_attribution: false
+release_enable_partner_repack: false
+release_eta: ''
+release_history: {}
+release_partner_build_number: 1
+release_partner_config:
+  enterprise-repack-mac-notarization:
+    hosted:
+      pilotProd:
+        locales:
+          - en-US
+          - fr
+        platforms:
+          - macosx64-enterprise-shippable
+      pilotStage:
+        locales:
+          - en-US
+          - fr
+        platforms:
+          - macosx64-enterprise-shippable
+    moz:
+      prodGCP:
+        locales:
+          - en-US
+          - fr
+        platforms:
+          - macosx64-enterprise-shippable
+      stageGCP:
+        locales:
+          - en-US
+          - fr
+        platforms:
+          - macosx64-enterprise-shippable
+  enterprise-repack-mac-signing:
+    hosted:
+      pilotProd:
+        locales:
+          - en-US
+          - fr
+        platforms:
+          - macosx64-enterprise-shippable
+      pilotStage:
+        locales:
+          - en-US
+          - fr
+        platforms:
+          - macosx64-enterprise-shippable
+    moz:
+      prodGCP:
+        locales:
+          - en-US
+          - fr
+        platforms:
+          - macosx64-enterprise-shippable
+      stageGCP:
+        locales:
+          - en-US
+          - fr
+        platforms:
+          - macosx64-enterprise-shippable
+  enterprise-repack-repackage:
+    hosted:
+      pilotProd:
+        locales:
+          - en-US
+          - fr
+        platforms:
+          - linux64-enterprise-shippable
+          - linux64-aarch64-enterprise-shippable
+          - macosx64-enterprise-shippable
+          - win64-enterprise-shippable
+      pilotStage:
+        locales:
+          - en-US
+          - fr
+        platforms:
+          - linux64-enterprise-shippable
+          - linux64-aarch64-enterprise-shippable
+          - macosx64-enterprise-shippable
+          - win64-enterprise-shippable
+    moz:
+      prodGCP:
+        locales:
+          - en-US
+          - fr
+        platforms:
+          - linux64-enterprise-shippable
+          - linux64-aarch64-enterprise-shippable
+          - macosx64-enterprise-shippable
+          - win64-enterprise-shippable
+      stageGCP:
+        locales:
+          - en-US
+          - fr
+        platforms:
+          - linux64-enterprise-shippable
+          - linux64-aarch64-enterprise-shippable
+          - macosx64-enterprise-shippable
+          - win64-enterprise-shippable
+  repackage-deb:
+    hosted:
+      pilotProd:
+        locales:
+          - en-US
+          - fr
+        platforms:
+          - linux64-enterprise-shippable
+          - linux64-aarch64-enterprise-shippable
+      pilotStage:
+        locales:
+          - en-US
+          - fr
+        platforms:
+          - linux64-enterprise-shippable
+          - linux64-aarch64-enterprise-shippable
+    moz:
+      prodGCP:
+        locales:
+          - en-US
+          - fr
+        platforms:
+          - linux64-enterprise-shippable
+          - linux64-aarch64-enterprise-shippable
+      stageGCP:
+        locales:
+          - en-US
+          - fr
+        platforms:
+          - linux64-enterprise-shippable
+          - linux64-aarch64-enterprise-shippable
+  repackage-msi:
+    hosted:
+      pilotProd:
+        locales:
+          - en-US
+          - fr
+        platforms:
+          - win64-enterprise-shippable
+      pilotStage:
+        locales:
+          - en-US
+          - fr
+        platforms:
+          - win64-enterprise-shippable
+    moz:
+      prodGCP:
+        locales:
+          - en-US
+          - fr
+        platforms:
+          - win64-enterprise-shippable
+      stageGCP:
+        locales:
+          - en-US
+          - fr
+        platforms:
+          - win64-enterprise-shippable
+release_partners:
+  - moz
+  - hosted
+release_product: firefox-enterprise
+release_type: nightly-enterprise
+repository_type: git
+target_tasks_method: enterprise_firefox_with_tests_tasks
+tasks_for: github-push
+test_manifest_loader: default
+try_mode: null
+try_task_config: {}
+version: 153.0a1

--- a/taskcluster/test/params/update.sh
+++ b/taskcluster/test/params/update.sh
@@ -19,53 +19,62 @@ else
 fi
 for f in $files; do
     base=$(basename "$f" .yml)
-    repo=${base%%-*}
+    prefix=${base%%-*}
     action=${base#*-}
+    trust_domain=gecko
     # remove people's email addresses
     filter='.owner="user@example.com"'
 
-    case $repo in
+    case $prefix in
         mc)
-            repo=mozilla-central
+            path=mozilla-central
             ;;
         mb)
-            repo=mozilla-beta
+            path=mozilla-beta
             ;;
         mr)
-            repo=mozilla-release
+            path=mozilla-release
             ;;
         me)
             version=$(curl -s https://product-details.mozilla.org/1.0/firefox_versions.json | jq -r  .FIREFOX_ESR)
             version=${version%%.*}
-            repo=mozilla-esr${version}
+            path=mozilla-esr${version}
             # unset enable_always_target to fall back to the default, to avoid
             # generating a broken graph with esr115 params
             filter="$filter | del(.enable_always_target)"
             ;;
         autoland)
+            path=autoland
+            ;;
+        em)
+            trust_domain=enterprise
+            path=enterprise-firefox.branch.enterprise-main
+            ;;
+        github)
+            continue
             ;;
         try)
             continue
             ;;
         *)
-            echo unknown repo $repo >&2
+            echo unknown prefix $prefix >&2
             exit 1
             ;;
     esac
 
     case $action in
         onpush)
-            task=gecko.v2.${repo}.latest.taskgraph.decision
+            task=${trust_domain}.v2.${path}.latest.taskgraph.decision
             service=index
             # find a non-DONTBUILD push
             while :; do
                 params=$(curl -f -L ${TASKCLUSTER_ROOT_URL}/api/${service}/v1/task/${task}/artifacts/public%2Fparameters.yml)
                 method=$(echo "$params" | yq -r .target_tasks_method)
-                if [ $method != nothing ]; then
+                pushlog_id=$(echo "$params" | yq -r .pushlog_id)
+                if [ "$method" != nothing ] || [ "$pushlog_id" -eq 0 ]; then
                     break
                 fi
-                pushlog_id=$(echo "$params" | yq -r .pushlog_id)
-                task=gecko.v2.${repo}.pushlog-id.$((pushlog_id - 1)).decision
+                task=${trust_domain}.v2.${path}.pushlog-id.$((pushlog_id - 1)).decision
             done
             ;;
         onpush-geckoview)
@@ -74,19 +83,19 @@ for f in $files; do
             ;;
         cron-*)
             task=${action#cron-}
-            task=gecko.v2.${repo}.latest.taskgraph.decision-${task}
+            task=${trust_domain}.v2.${path}.latest.taskgraph.decision-${task}
             service=index
             ;;
         nightly-all)
-            task=gecko.v2.${repo}.latest.taskgraph.decision-nightly-all
+            task=${trust_domain}.v2.${path}.latest.taskgraph.decision-nightly-all
             service=index
             ;;
         android-nightly)
-            task=gecko.v2.${repo}.latest.taskgraph.decision-nightly-android
+            task=${trust_domain}.v2.${path}.latest.taskgraph.decision-nightly-android
             service=index
             ;;
         desktop-nightly)
-            task=gecko.v2.${repo}.latest.taskgraph.decision-nightly-desktop
+            task=${trust_domain}.v2.${path}.latest.taskgraph.decision-nightly-desktop
             service=index
             ;;
         push*|promote*|ship*)
@@ -126,7 +135,7 @@ for f in $files; do
                     ;;
             esac
             # grab the action task id from the latest release where this phase wasn't skipped
-            task=$(curl -s "https://shipitapi-public.services.mozilla.com/releases?product=${product}&branch=releases/${repo}&status=shipped" | \
+            task=$(curl -s "https://shipitapi-public.services.mozilla.com/releases?product=${product}&branch=releases/${path}&status=shipped" | \
                 jq -r "map(.phases[] | select(.name == "'"'"$phase"'"'" and (.skipped | not)))[-1].actionTaskId")
             service=queue
             ;;

--- a/tools/tryselect/mach_commands.py
+++ b/tools/tryselect/mach_commands.py
@@ -42,13 +42,14 @@ def generic_parser():
 
 
 def init(command_context):
-    from tryselect import lando, push, task_config
+    from tryselect import lando, push, task_config, tasks
 
     mach_context = command_context._mach_context
     lando.LAUNCH_BROWSER = not mach_context.settings["try"]["nobrowser"]
     push.MAX_HISTORY = mach_context.settings["try"]["maxhistory"]
     push.MACH_TRY_REMOTE = mach_context.settings["try"]["pushremote"]
     task_config.SKIP_ARTIFACT_BUILD_CHECK = mach_context.settings["try"]["noartifact"]
+    tasks.DEFAULT_PARAMS = mach_context.settings["try"]["params"] or None
 
 
 @functools.cache

--- a/tools/tryselect/tasks.py
+++ b/tools/tryselect/tasks.py
@@ -22,6 +22,7 @@ from taskgraph.util import json
 here = os.path.abspath(os.path.dirname(__file__))
 build = MozbuildObject.from_environment(cwd=here)
 
+DEFAULT_PARAMS: str | None = None
 PARAMETER_MISMATCH = """
 ERROR - The parameters being used to generate tasks differ from those expected
 by your working copy:
@@ -113,6 +114,9 @@ def generate_tasks(
     if target_tasks_method:
         overrides["target_tasks_method"] = target_tasks_method
         overrides["filters"].insert(0, "target_tasks_method")
+
+    if not param_spec and DEFAULT_PARAMS:
+        param_spec = os.path.join(build.topsrcdir, DEFAULT_PARAMS)
 
     params = parameters_loader(param_spec, strict=False, overrides=overrides)
     root = os.path.join(build.topsrcdir, "taskcluster")


### PR DESCRIPTION
Currently `mach try` is using the default gecko-specific parameters to generate tasks locally. This means many enterprise specific tasks are being filtered out at the target phase. Instead make `mach try` on enterprise point to a parameter set pulled from a push to `enterprise-main`. This way all enterprise specific tasks will appear.