### PR TITLE
[beta uplift] Bug 2041830 - Use ternary operator instead of incorrect use of object spread syntax to pass parameter

### DIFF
--- a/services/fxaccounts/FxAccountsClient.sys.mjs
+++ b/services/fxaccounts/FxAccountsClient.sys.mjs
@@ -797,9 +797,11 @@ FxAccountsClient.prototype = {
         method,
         credentials,
         jsonPayload,
-        ...(AppConstants.MOZ_ENTERPRISE && {
-          Authorization: `Bearer ${await lazy.ConsoleClient.getAccessToken()}`,
-        })
+        AppConstants.MOZ_ENTERPRISE
+          ? {
+              Authorization: `Bearer ${await lazy.ConsoleClient.getAccessToken()}`,
+            }
+          : {}
       );
     } catch (error) {
       log.error(`error ${method}ing ${path}`, error);


### PR DESCRIPTION
(cherry picked from commit 238e1bc03c0e7bb1d6697afff0e5d3fbcb04e747)

<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2041830

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Uplift of: #950 

<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
