### PR TITLE
Bug 2043206 - Add label for access connector toolbar button

### DIFF
--- a/browser/locales/en-US/browser/enterprise/enterprise.ftl
+++ b/browser/locales/en-US/browser/enterprise/enterprise.ftl
@@ -80,6 +80,7 @@ neterror-blocked-by-policy-contact-admin = If you believe this is an error or ne
 enterprise-access-connector-heading = Access Connector
 enterprise-access-connector-info-active = This site is being accessed through a secure company connection.
 enterprise-access-connector-button =
+  .label = Access Connector
   .tooltiptext = Access Connector
 enterprise-access-connector-status-label-active = active
 enterprise-access-connector-status-label-inactive = inactive


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2043206

Adds missing label to the access connector toolbar button.

---

### Screenshots <!-- REQUIRED (if applicable) -->

Access connector toolbar button in toolbar customization panel **without label**
<img width="4224" height="600" alt="access-connector-button-without-label" src="https://github.com/user-attachments/assets/894109eb-6533-4b4c-a55c-f8b7af2de019" />

Access connector toolbar button in toolbar customization panel **with label**
<img width="4224" height="600" alt="access-connector-button-with-label" src="https://github.com/user-attachments/assets/8bd3a3ae-f7a5-42ff-8fca-73cc813cf680" />