### PR TITLE
Bug 2043206 - Add label for access connector toolbar button

### DIFF
--- a/browser/locales/en-US/browser/enterprise/enterprise.ftl
+++ b/browser/locales/en-US/browser/enterprise/enterprise.ftl
@@ -80,6 +80,7 @@ neterror-blocked-by-policy-contact-admin = If you believe this is an error or ne
 enterprise-access-connector-heading = Access Connector
 enterprise-access-connector-info-active = This site is being accessed through a secure company connection.
 enterprise-access-connector-button =
+  .label = Access Connector
   .tooltiptext = Access Connector
 enterprise-access-connector-status-label-active = active
 enterprise-access-connector-status-label-inactive = inactive


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2043206

Adds missing label to the access connector toolbar button. Uplifts #969.