### PR TITLE
Bug 2040350 - Add missing strings for signout modal

### DIFF
--- a/browser/locales/en-US/browser/enterprise/enterprise.ftl
+++ b/browser/locales/en-US/browser/enterprise/enterprise.ftl
@@ -54,6 +54,16 @@ enterprise-quit-shortcut-prompt-title = Close window and quit { -brand-short-nam
 enterprise-quit-shortcut-prompt-message = Quitting will sign you out of your session. You’ll need to reauthenticate through your organization’s SSO provider.
 enterprise-quit-shortcut-prompt-primary-btn-label = Quit and sign out
 
+# $tabCount (Number) - the number of open tabs
+enterprise-signout-prompt-title2 =
+    { $tabCount ->
+        [one] Sign out of { -brand-short-name }?
+       *[other] Sign out and close { $tabCount } tabs?
+    }
+enterprise-signout-prompt-message = You’re signing out of your { -brand-short-name } browser. To use it again, you’ll need to re-authenticate through your company’s SSO provider.
+enterprise-signout-prompt-checkbox-label = Show this message when signing out.
+enterprise-signout-prompt-primary-btn-label = Sign out
+
 restart-forced-title = Restart { -brand-short-name }
 restart-forced-heading = Restart to continue using { -brand-short-name }.
 restart-forced-intro = Company policy requires that { -brand-short-name } be restarted.


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2040350

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

Bug-2024613 replaced the previous signout prompt still active in `enterprise-release` with a new custom combination dialog, and in the process the strings in use for the `enterprise-release` prompt were removed. Since our translations are run off of `enterprise-main`, these strings should not have been removed. As a result, the translations were lost for this dialog in `enterprise-release`. 

This PR restores the strings to our `enterprise.ftl`, which should land them back into our main translations for use in `enterprise-release`.

> Uplifting this is not required since the issue is only with `enterprise-main` despite having an effect on `enterprise-release`.

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* #569
---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

<img width="417" height="235" alt="before-translation" src="https://github.com/user-attachments/assets/d12642b7-39cf-4af9-9098-6675ecf62559" />

_Before including the strings_

<img width="431" height="256" alt="after-translation" src="https://github.com/user-attachments/assets/2607c138-8ef4-4f1b-96b5-c42db280ce09" />

_After including the strings_