### PR TITLE
Bug 2043589 - fix browser_all_files_referenced.js for enterprise

### DIFF
--- a/browser/base/content/test/static/browser_all_files_referenced.js
+++ b/browser/base/content/test/static/browser_all_files_referenced.js
@@ -379,6 +379,17 @@ if (AppConstants.platform == "android") {
   });
 }
 
+if (AppConstants.MOZ_ENTERPRISE) {
+  allowlist.push(
+    // toolkit/crashreporter/client/app/src/lang/langpack.rs (string is built programmatically)
+    {
+      file: "resource://gre/localization/en-US/crashreporter/crashreporter-enterprise.ftl",
+    },
+    // Opened programmatically by the felt extension API
+    { file: "chrome://felt/content/felt.xhtml" }
+  );
+}
+
 if (AppConstants.MOZ_UPDATE_AGENT && !AppConstants.MOZ_BACKGROUNDTASKS) {
   // Task scheduling is only used for background updates right now.
   allowlist.push({

--- a/browser/components/enterprise/jar.mn
+++ b/browser/components/enterprise/jar.mn
@@ -3,13 +3,11 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 browser.jar:
+# Override the toolkit enterprise.properties with the browser version (loaded by nsDocShell.cpp).
+% override chrome://global/locale/enterprise.properties chrome://browser/locale/enterprise.properties
   content/browser/enterprise/enterprise-badge.css           (content/enterprise-badge.css)
-  content/browser/enterprise/enterprise-badge.inc.xhtml     (content/enterprise-badge.inc.xhtml)
   content/browser/enterprise/alert.svg                      (content/icons/alert.svg)
-  content/browser/enterprise/enterprise-panel.inc.xhtml     (content/enterprise-panel.inc.xhtml)
-  content/browser/enterprise/enterprise-urlbar-actions.inc.xhtml (content/enterprise-urlbar-actions.inc.xhtml)
   content/browser/enterprise/enterprise-urlbar-actions.css  (content/enterprise-urlbar-actions.css)
-  content/browser/enterprise/enterprise-urlbar-panels.inc.xhtml (content/enterprise-urlbar-panels.inc.xhtml)
   content/browser/enterprise/lockdown-mode.svg              (content/icons/lockdown-mode.svg)
   content/browser/enterprise/user-avatar.svg                (content/icons/user-avatar.svg)
   content/browser/enterprise/enterprise-close-dialog.xhtml  (content/enterprise-close-dialog.xhtml)


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2043589


- Allowlist programmatically-loaded URIs: crashreporter-enterprise.ftl and chrome://felt/content/felt.xhtml are loaded at runtime via code (not static markup), so browser_all_files_referenced.js can't detect them.
- Remove .inc.xhtml files from jar.mn: These fragment files are inlined at build time via #include.
- Add chrome:// override for enterprise.properties: nsDocShell.cpp loads chrome://global/locale/enterprise.properties (the toolkit version). The override directive redirects that URI to chrome://browser/locale/enterprise.properties so the browser-specific version is used instead. Without it, the browser's enterprise.properties would be packaged but never loaded, triggering the unreferenced file test.
<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on:

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

---

### Testing <!-- OPTIONAL -->

* [ ] Added tests
* [ ] Manual testing performed

<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
