### PR TITLE
Bug 2043622 - Add preprocessor for firefox-branding.js enterprise

### DIFF
--- a/browser/branding/branding-common.mozbuild
+++ b/browser/branding/branding-common.mozbuild
@@ -5,7 +5,10 @@
 
 @template
 def FirefoxBranding():
-    if CONFIG["MOZ_BRANDING_DIRECTORY"] == "browser/branding/official":
+    if CONFIG["MOZ_BRANDING_DIRECTORY"] in (
+        "browser/branding/official",
+        "browser/branding/enterprise",
+    ):
         JS_PREFERENCE_PP_FILES += [
             "pref/firefox-branding.js",
         ]


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2043622

The file `firefox-branding.js` has preprocessor but it is not being processed due to the .build

The test basically errors with 

```
browser_parsable_script.js | checkAllTheJS - Script error reading jar:file:///opt/worker/tasks/cltbld/build/application/Firefox%20Enterprise.app/Contents/Resources/browser/omni.ja!/defaults/preferences/firefox-branding.js: SyntaxError: private names aren't valid in this context
```


<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on:

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

---

### Testing <!-- OPTIONAL -->

* [ ] Added tests
* [x] Manual testing performed
[See test pass](https://treeherder.mozilla.org/logviewer?job_id=569532575&repo=enterprise-firefox-pr&task=azBngEq6QrKVf5BaMYvSxA.0&lineNumber=3869)

<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
