### PR TITLE
Bug 2044005 - Distinguish FELT UI from Firefox in remote/Marionette

### DIFF
--- a/remote/shared/AppInfo.sys.mjs
+++ b/remote/shared/AppInfo.sys.mjs
@@ -73,6 +73,10 @@ ChromeUtils.defineLazyGetter(AppInfo, "isEnterprise", () => {
   return Services.appinfo.ID == ID_FIREFOX && AppConstants.MOZ_ENTERPRISE;
 });
 
+ChromeUtils.defineLazyGetter(AppInfo, "isFeltUI", () => {
+  return !!(AppConstants.MOZ_ENTERPRISE && Services.felt?.isFeltUI());
+});
+
 ChromeUtils.defineLazyGetter(AppInfo, "name", () => {
   if (Services.appinfo.ID == ID_FIREFOX && AppConstants.MOZ_ENTERPRISE) {
     return "Firefox";

--- a/remote/shared/TabManager.sys.mjs
+++ b/remote/shared/TabManager.sys.mjs
@@ -84,7 +84,7 @@ class TabManagerClass {
 
     if (lazy.AppInfo.isAndroid) {
       return new lazy.MobileTabBrowser(win);
-    } else if (lazy.AppInfo.isFirefox) {
+    } else if (lazy.AppInfo.isFirefox || lazy.AppInfo.isFeltUI) {
       return win.gBrowser;
     }
 


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2044005

This is adding a way to expose the information that we are in the FeltUI case to Marionette, will be useful for non browser app.
