### PR TITLE
Bug 2044006 - Listen on pref changes for distribution rather than spe…

### DIFF
--- a/browser/components/enterprise/modules/ConsoleClient.sys.mjs
+++ b/browser/components/enterprise/modules/ConsoleClient.sys.mjs
@@ -94,43 +94,31 @@ export const ConsoleClient = {
           const consoleURI = Services.prefs.getStringPref(CONSOLE_ADDRESS_PREF);
           resolve(consoleURI);
         } catch (e) {
-          lazy.log.warn(
-            `Missing console URI. Waiting on distribution customization to complete.`
-          );
-          const kDistributionPreferencesCompleteTopic =
-            "distribution-preferences-complete";
-          const distributionCompleteObserver = {
-            observe(_aSubject, aTopic, _aData) {
-              Services.obs.removeObserver(
-                distributionCompleteObserver,
-                "xpcom-shutdown"
-              );
-              Services.obs.removeObserver(
-                distributionCompleteObserver,
-                kDistributionPreferencesCompleteTopic
-              );
-              if (aTopic === kDistributionPreferencesCompleteTopic) {
-                try {
-                  const consoleURI =
-                    Services.prefs.getStringPref(CONSOLE_ADDRESS_PREF);
-                  resolve(consoleURI);
-                } catch (ex) {
-                  lazy.log.error(
-                    `Critical misconfiguration: Missing console URI`
+          lazy.log.warn(`Missing console URI. Waiting on pref change.`);
+          const consolePrefObserver = {
+            observe(_, topic) {
+              switch (topic) {
+                case "nsPref:changed":
+                  Services.prefs.removeObserver(
+                    CONSOLE_ADDRESS_PREF,
+                    consolePrefObserver
                   );
-                  reject(ex);
-                }
+                  lazy.log.warn(`Missing console URI. Pref changed, checking.`);
+                  try {
+                    const consoleURI =
+                      Services.prefs.getStringPref(CONSOLE_ADDRESS_PREF);
+                    resolve(consoleURI);
+                  } catch (ex) {
+                    lazy.log.error(
+                      `Critical misconfiguration: Missing console URI`
+                    );
+                    reject(ex);
+                  }
+                  break;
               }
             },
           };
-          Services.obs.addObserver(
-            distributionCompleteObserver,
-            kDistributionPreferencesCompleteTopic
-          );
-          Services.obs.addObserver(
-            distributionCompleteObserver,
-            "xpcom-shutdown"
-          );
+          Services.prefs.addObserver(CONSOLE_ADDRESS_PREF, consolePrefObserver);
         }
       });
     }


### PR DESCRIPTION
…cific event

<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2044006

For non browser applications, we cannot rely on this event that is specific to the browser distribution customizer. Use pref changes instead.