### PR TITLE
Bug 2044013 - Limit URL forwarding from Felt to browser app only

### DIFF
--- a/browser/components/enterprise/EnterpriseCommon.sys.mjs
+++ b/browser/components/enterprise/EnterpriseCommon.sys.mjs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { AppConstants } from "resource://gre/modules/AppConstants.sys.mjs";
+
 const IS_TESTING_ENVIRONMENT = "enterprise.is_testing";
 const IS_BLOCKING_SHUTDOWN = "enterprise.felt_tests.is_blocking_shutdown";
 const IS_UPDATES_TESTING = "enterprise.felt_tests.is_updates_testing";
@@ -21,6 +23,10 @@ export const isBlockingShutdown = () => {
 
 export const shouldNotCloseWindow = () => {
   return Services.prefs.getBoolPref(SHOULD_NOT_CLOSE_WINDOW, false);
+};
+
+export const isBuildAppBrowser = () => {
+  return AppConstants.MOZ_BUILD_APP == "browser";
 };
 
 const ENTERPRISE_LOG_LEVEL_PREF = "enterprise.log_level";

--- a/browser/extensions/felt/content/FeltProcessParent.sys.mjs
+++ b/browser/extensions/felt/content/FeltProcessParent.sys.mjs
@@ -8,6 +8,7 @@ ChromeUtils.defineESModuleGetters(lazy, {
   Subprocess: "resource://gre/modules/Subprocess.sys.mjs",
   ConsoleClient: "resource:///modules/enterprise/ConsoleClient.sys.mjs",
   CONSOLE_ADDRESS_PREF: "resource:///modules/enterprise/ConsoleClient.sys.mjs",
+  isBuildAppBrowser: "resource:///modules/enterprise/EnterpriseCommon.sys.mjs",
   isTesting: "resource:///modules/enterprise/EnterpriseCommon.sys.mjs",
   createEnterpriseLogger:
     "resource:///modules/enterprise/EnterpriseCommon.sys.mjs",
@@ -240,9 +241,11 @@ export class FeltProcessParent extends JSProcessActorParent {
           case "felt-extension-ready": {
             if (gFeltProcessParentInstance) {
               gFeltProcessParentInstance.extensionReady = true;
-              gFeltProcessParentInstance.forwardPendingURLs().catch(err => {
-                lazy.log.error("Failed to forward pending URLs", err);
-              });
+              if (lazy.isBuildAppBrowser()) {
+                gFeltProcessParentInstance.forwardPendingURLs().catch(err => {
+                  lazy.log.error("Failed to forward pending URLs", err);
+                });
+              }
               notifyFirefoxReady();
             }
             break;
@@ -447,7 +450,11 @@ export class FeltProcessParent extends JSProcessActorParent {
     this.exitReported = false;
     this.firefoxReady = false;
     this.extensionReady = false;
-    resetFeltFirefoxWindowReady();
+    if (lazy.isBuildAppBrowser()) {
+      // This also part of FeltURLHandler that cannot be loaded in non browser
+      // applications.
+      resetFeltFirefoxWindowReady();
+    }
     gFeltFirefoxReadyNotified = false;
 
     // There is no message being sent to the message listener on restart phases
@@ -482,7 +489,9 @@ export class FeltProcessParent extends JSProcessActorParent {
         this.firefoxReady = true;
 
         // Try to forward pending URLs now (will only forward if extension is also ready)
-        await this.forwardPendingURLs();
+        if (lazy.isBuildAppBrowser()) {
+          await this.forwardPendingURLs();
+        }
         notifyFirefoxReady();
       })
       .then(() => {


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2044013

Forwarding handling of URLs only makes sense for browser app.
