### PR TITLE
Bug 2044008 - Use WebAuthnPromptHelper from toolkit in Felt

### DIFF
--- a/browser/extensions/felt/api.js
+++ b/browser/extensions/felt/api.js
@@ -16,10 +16,13 @@ ChromeUtils.defineESModuleGetters(lazy, {
   PrivateBrowsingUtils: "resource://gre/modules/PrivateBrowsingUtils.sys.mjs",
   ConsoleClient: "resource:///modules/enterprise/ConsoleClient.sys.mjs",
   isBlockingShutdown: "resource:///modules/enterprise/EnterpriseCommon.sys.mjs",
+  isBuildAppBrowser: "resource:///modules/enterprise/EnterpriseCommon.sys.mjs",
   shouldNotCloseWindow:
     "resource:///modules/enterprise/EnterpriseCommon.sys.mjs",
   createEnterpriseLogger:
     "resource:///modules/enterprise/EnterpriseCommon.sys.mjs",
+  WebAuthnPromptHelper:
+    "moz-src:///toolkit/modules/WebAuthnPromptHelper.sys.mjs",
 });
 
 ChromeUtils.defineLazyGetter(lazy, "log", () => {
@@ -199,6 +202,14 @@ this.felt = class extends ExtensionAPI {
     },
   };
 
+  webauthnObserver = {
+    observe(aSubject, aTopic, aData) {
+      if (aTopic === "webauthn-prompt") {
+        lazy.WebAuthnPromptHelper.observe(aSubject, aTopic, aData);
+      }
+    },
+  };
+
   _feltMessageListeners = [
     "FeltParent:FirefoxNormalExit",
     "FeltParent:FirefoxRestartUpdateExit",
@@ -232,6 +243,9 @@ this.felt = class extends ExtensionAPI {
       await lazy.FeltStorage.init();
       this.showWindow();
       this.addFeltMessageListeners();
+      if (!lazy.isBuildAppBrowser()) {
+        Services.obs.addObserver(this.webauthnObserver, "webauthn-prompt");
+      }
     } else if (Services.felt.isFeltBrowser()) {
       // In the real Firefox, register observer to handle URLs
       Services.obs.addObserver(this.urlObserver, "felt-open-url");
@@ -408,6 +422,9 @@ this.felt = class extends ExtensionAPI {
 
     if (Services.felt.isFeltUI()) {
       this.removeFeltMessageListeners();
+      if (!lazy.isBuildAppBrowser()) {
+        Services.obs.removeObserver(this.webauthnObserver, "webauthn-prompt");
+      }
     }
 
     if (this.chromeHandle) {

--- a/browser/extensions/felt/content/felt.xhtml
+++ b/browser/extensions/felt/content/felt.xhtml
@@ -107,7 +107,7 @@
         id="webauthn-notification-icon"
         class="notification-anchor-icon"
         role="button"
-        data-l10n-id="urlbar-web-authn-anchor"
+        data-l10n-id="felt-urlbar-web-authn-anchor"
       />
     </xul:box>
 

--- a/browser/locales/en-US/browser/enterprise/felt.ftl
+++ b/browser/locales/en-US/browser/enterprise/felt.ftl
@@ -28,6 +28,9 @@ felt-version-nightly = { $version } ({ $isodate })
 #   $version (String): version of Firefox for beta and release builds
 felt-version = { $version }
 
+felt-urlbar-web-authn-anchor =
+    .tooltiptext = Open Web Authentication panel
+
 ## Error details when launching the browser crashes
 
 felt-browser-error-sso-timeout2 =


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2044008

Let's make sure we load the WebAuthn helper when the app is not a browser (that loads it for us)

### Dependencies

#982 for `isBuildAppBrowser()`