### PR TITLE
Revert "Bug 2040350 - Add missing strings for signout modal"

### DIFF
--- a/browser/locales/en-US/browser/enterprise/enterprise.ftl
+++ b/browser/locales/en-US/browser/enterprise/enterprise.ftl
@@ -54,16 +54,6 @@ enterprise-quit-shortcut-prompt-title = Close window and quit { -brand-short-nam
 enterprise-quit-shortcut-prompt-message = Quitting will sign you out of your session. You’ll need to reauthenticate through your organization’s SSO provider.
 enterprise-quit-shortcut-prompt-primary-btn-label = Quit and sign out
 
-# $tabCount (Number) - the number of open tabs
-enterprise-signout-prompt-title2 =
-    { $tabCount ->
-        [one] Sign out of { -brand-short-name }?
-       *[other] Sign out and close { $tabCount } tabs?
-    }
-enterprise-signout-prompt-message = You’re signing out of your { -brand-short-name } browser. To use it again, you’ll need to re-authenticate through your company’s SSO provider.
-enterprise-signout-prompt-checkbox-label = Show this message when signing out.
-enterprise-signout-prompt-primary-btn-label = Sign out
-
 restart-forced-title = Restart { -brand-short-name }
 restart-forced-heading = Restart to continue using { -brand-short-name }.
 restart-forced-intro = Company policy requires that { -brand-short-name } be restarted.


### PR DESCRIPTION
Reverts #972. Keeping these strings in `enterprise-main` is no longer needed since l10n [added support](https://github.com/mozilla-l10n/enterprise-firefox-l10n/pull/17) for `enterprise-beta` and `enterprise-release`.