### PR TITLE
Bug 2044296 - Disable Sync/FxA related tests for firefox enterprise

### DIFF
--- a/browser/base/content/test/sync/browser.toml
+++ b/browser/base/content/test/sync/browser.toml
@@ -2,8 +2,10 @@
 support-files = ["head.js"]
 
 ["browser_appmenu_signin_cta_variants.js"]
+skip-if = ["enterprise"] # FxA sign-in CTA is not enabled in enterprise builds
 
 ["browser_avatar_menu_signin_cta_variants.js"]
+skip-if = ["enterprise"] # FxA sign-in CTA is not enabled in enterprise builds
 
 ["browser_contextmenu_sendpage.js"]
 skip-if = [
@@ -15,12 +17,15 @@ skip-if = [
 ["browser_contextmenu_sendtab.js"]
 
 ["browser_fxa_badge.js"]
+skip-if = ["enterprise"] # FxA badge notifications are not enabled in enterprise builds
 
 ["browser_fxa_web_channel.js"]
 https_first_disabled = true
 support-files = ["browser_fxa_web_channel.html"]
+skip-if = ["enterprise"] # FxA web channel messaging is not enabled in enterprise builds
 
 ["browser_sendtab_telemetry.js"]
+skip-if = ["enterprise"] # Send tab telemetry relies on FxA panel and devices
 
 ["browser_sendtab_toolbarbutton.js"]
 
@@ -28,5 +33,6 @@ support-files = ["browser_fxa_web_channel.html"]
 
 ["browser_sync.js"]
 support-files = ["!/browser/components/profiles/tests/browser/head.js"]
+skip-if = ["enterprise"] # Tests FxA/Sync panel UI states which are disabled in enterprise
 
 ["browser_synced_tabs_view.js"]

--- a/browser/base/content/test/sync/browser_contextmenu_sendtab.js
+++ b/browser/base/content/test/sync/browser_contextmenu_sendtab.js
@@ -52,6 +52,10 @@ function updateTabContextMenu(tab = gBrowser.selectedTab) {
   menu.hidePopup();
 }
 
+function add_task_skip(fn) {
+  add_task({ skip_if: () => AppConstants.MOZ_ENTERPRISE }, fn);
+}
+
 add_setup(async function () {
   await SpecialPowers.pushPrefEnv({
     set: [["test.wait300msAfterTabSwitch", true]],
@@ -104,7 +108,8 @@ async function checkForConfirmationHint(targetId) {
   sandbox.restore();
 }
 
-add_task(async function test_sendTabToDevice_showsConfirmationHint_fxa() {
+// Test relies on fxa-toolbar-menu-button which is hidden in enterprise.
+add_task_skip(async function test_sendTabToDevice_showsConfirmationHint_fxa() {
   // We need to change the fxastatus from "not_configured" to show the FxA button.
   is(
     document.documentElement.getAttribute("fxastatus"),
@@ -116,7 +121,8 @@ add_task(async function test_sendTabToDevice_showsConfirmationHint_fxa() {
   document.documentElement.setAttribute("fxastatus", "not_configured");
 });
 
-add_task(
+// Test relies on fxa-toolbar-menu-button which is hidden in enterprise.
+add_task_skip(
   async function test_sendTabToDevice_showsConfirmationHint_onOverflowMenu() {
     // We need to change the fxastatus from "not_configured" to show the FxA button.
     is(
@@ -203,7 +209,8 @@ add_task(async function test_tab_contextmenu() {
   sandbox.restore();
 });
 
-add_task(async function test_tab_contextmenu_send_to_mobile() {
+// Test mocks FxA mobile devices; enterprise backend does not serve them.
+add_task_skip(async function test_tab_contextmenu_send_to_mobile() {
   let mobileFxaDevices = [
     {
       id: 1,

--- a/browser/components/asrouter/tests/browser/browser.toml
+++ b/browser/components/asrouter/tests/browser/browser.toml
@@ -38,6 +38,7 @@ skip-if = [
 https_first_disabled = true
 
 ["browser_asrouter_menu_messages.js"]
+skip-if = ["enterprise"] # Tests messages in the PanelUI-fxa panel, which is not available in enterprise builds.
 
 ["browser_asrouter_milestone_message_cfr.js"]
 


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2044296

- Skip FxA-related tests (sync, asrouter menu messages) since enterprise builds do not include Firefox Accounts UI functionality

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on:

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

---

### Testing <!-- OPTIONAL -->

* [ ] Added tests
* [ ] Manual testing performed

<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
