### PR TITLE
Bug 2045053 - Fix stylelint error for felt-logo background gradient token

### DIFF
--- a/browser/extensions/felt/content/styles/felt.css
+++ b/browser/extensions/felt/content/styles/felt.css
@@ -29,7 +29,7 @@ body {
 
 .felt-logo {
   display: flex;
-  background: var(--felt-logo-background-gradient);
+  background-image: var(--felt-logo-background-gradient);
   overflow: hidden;
   flex-direction: column;
   justify-content: center;


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2045053

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

The `use-design-tokens` lint rule validates `var` token names against design token categories when used with the `background` shorthand. Switch `background` to `background-image` for the felt logo gradient token, which does not validate as it does not expect a color token. This change is an established pattern for handling `linear-gradient` backgrounds, two examples below.

- https://searchfox.org/enterprise-main/source/browser/themes/shared/smartbar.css#14,221
- https://searchfox.org/enterprise-main/source/browser/components/aiwindow/ui/content/firstrun.css#30,66

---

### Screenshots

<img width="1074" height="776" alt="image" src="https://github.com/user-attachments/assets/bc1977ad-562d-415c-8c11-d5929d3f3169" />

_FELT Login with `background-image`_