### PR TITLE
Bug 2028392 - Use brand strings for Access Connector feature name

### DIFF
--- a/browser/base/content/appmenu-viewcache.inc.xhtml
+++ b/browser/base/content/appmenu-viewcache.inc.xhtml
@@ -878,7 +878,7 @@
          class="panel-header">
         <html:h1>
           <html:span id="ipprotection-header-content"
-                     data-l10n-id="enterprise-access-connector-heading"></html:span>
+                     data-l10n-id="enterprise-access-connector-heading2"></html:span>
         </html:h1>
         <html:moz-button
           id="ipprotection-header-button"

--- a/browser/branding/enterprise/locales/en-US/brand.ftl
+++ b/browser/branding/enterprise/locales/en-US/brand.ftl
@@ -25,9 +25,3 @@
 -brand-product-name = Firefox
 -vendor-short-name = Mozilla
 trademarkInfo = Firefox and the Firefox logos are trademarks of the Mozilla Foundation.
-
-## Enterprise Brand Features
-##
-## These feature names are enterprise product names and must not be translated.
-
--brand-feature-access-connector = Access Connector

--- a/browser/branding/enterprise/locales/en-US/brand.ftl
+++ b/browser/branding/enterprise/locales/en-US/brand.ftl
@@ -25,3 +25,9 @@
 -brand-product-name = Firefox
 -vendor-short-name = Mozilla
 trademarkInfo = Firefox and the Firefox logos are trademarks of the Mozilla Foundation.
+
+## Enterprise Brand Features
+##
+## These feature names are enterprise product names and must not be translated.
+
+-brand-feature-access-connector = Access Connector

--- a/browser/components/enterprisepolicies/content/aboutPolicies.html
+++ b/browser/components/enterprisepolicies/content/aboutPolicies.html
@@ -24,6 +24,7 @@
       rel="localization"
       href="browser/policies/policies-descriptions.ftl"
     />
+    <link rel="localization" href="browser/enterprise/enterprise.ftl" />
     <link
       rel="localization"
       href="browser/enterprise/enterprise-policies-descriptions.ftl"

--- a/browser/components/enterprisepolicies/content/aboutPolicies.js
+++ b/browser/components/enterprisepolicies/content/aboutPolicies.js
@@ -297,6 +297,7 @@ function generateDocumentation() {
     SkipTermsOfUse: "SkipTermsOfUse2",
     WindowsSSO: "Windows10SSO",
     BrowserDataBackup: "Backup",
+    AccessConnector: "AccessConnector2",
   };
   let deprecated_policies = ["DisablePocket"];
 

--- a/browser/components/ipprotection/IPProtection.sys.mjs
+++ b/browser/components/ipprotection/IPProtection.sys.mjs
@@ -97,7 +97,7 @@ class IPProtectionWidget {
     const onDestroyed = this.#onDestroyed.bind(this);
     const item = {
       id: IPProtectionWidget.WIDGET_ID,
-      l10nId: "enterprise-access-connector-button",
+      l10nId: "enterprise-access-connector-button2",
       type: "view",
       viewId: IPProtectionWidget.PANEL_ID,
       onViewShowing,

--- a/browser/components/ipprotection/IPProtectionToolbarButton.sys.mjs
+++ b/browser/components/ipprotection/IPProtectionToolbarButton.sys.mjs
@@ -405,7 +405,7 @@ export class IPProtectionToolbarButton {
     let isExcluded = status.isExcluded && this.isExceptionsFeatureEnabled;
     let isIncluded = status.isIncluded;
     let isPaused = status.isPaused;
-    let l10nId = "enterprise-access-connector-button";
+    let l10nId = "enterprise-access-connector-button2";
 
     toolbaritem.classList.remove(
       "ipprotection-on",

--- a/browser/locales/en-US/browser/enterprise/enterprise-policies-descriptions.ftl
+++ b/browser/locales/en-US/browser/enterprise/enterprise-policies-descriptions.ftl
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-policy-AccessConnector = Configure an { -brand-feature-access-connector } for proxying web traffic.
+policy-AccessConnector2 = Configure an { -brand-feature-access-connector } for proxying web traffic.
 policy-AIChatbot = Configure available AI chatbot providers, default provider, and prompt features.
 policy-BlocklistDomainBrowsedTelemetry = Enable and configure security logging/telemetry when { -brand-short-name } blocks a visit to a blocklisted domain.
 policy-DownloadTelemetry = Enable and configure security logging/telemetry when a download is triggered.

--- a/browser/locales/en-US/browser/enterprise/enterprise-policies-descriptions.ftl
+++ b/browser/locales/en-US/browser/enterprise/enterprise-policies-descriptions.ftl
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-policy-AccessConnector = Configure an access connector for proxying web traffic.
+policy-AccessConnector = Configure an { -brand-feature-access-connector } for proxying web traffic.
 policy-AIChatbot = Configure available AI chatbot providers, default provider, and prompt features.
 policy-BlocklistDomainBrowsedTelemetry = Enable and configure security logging/telemetry when { -brand-short-name } blocks a visit to a blocklisted domain.
 policy-DownloadTelemetry = Enable and configure security logging/telemetry when a download is triggered.

--- a/browser/locales/en-US/browser/enterprise/enterprise-policies-descriptions.ftl
+++ b/browser/locales/en-US/browser/enterprise/enterprise-policies-descriptions.ftl
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-policy-AccessConnector2 = Configure an { -enterprise-feature-access-connector } for proxying web traffic.
+policy-AccessConnector2 = Configure the { -enterprise-feature-access-connector } for proxying web traffic.
 policy-AIChatbot = Configure available AI chatbot providers, default provider, and prompt features.
 policy-BlocklistDomainBrowsedTelemetry = Enable and configure security logging/telemetry when { -brand-short-name } blocks a visit to a blocklisted domain.
 policy-DownloadTelemetry = Enable and configure security logging/telemetry when a download is triggered.

--- a/browser/locales/en-US/browser/enterprise/enterprise-policies-descriptions.ftl
+++ b/browser/locales/en-US/browser/enterprise/enterprise-policies-descriptions.ftl
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-policy-AccessConnector2 = Configure an { -brand-feature-access-connector } for proxying web traffic.
+policy-AccessConnector2 = Configure an { -enterprise-feature-access-connector } for proxying web traffic.
 policy-AIChatbot = Configure available AI chatbot providers, default provider, and prompt features.
 policy-BlocklistDomainBrowsedTelemetry = Enable and configure security logging/telemetry when { -brand-short-name } blocks a visit to a blocklisted domain.
 policy-DownloadTelemetry = Enable and configure security logging/telemetry when a download is triggered.

--- a/browser/locales/en-US/browser/enterprise/enterprise.ftl
+++ b/browser/locales/en-US/browser/enterprise/enterprise.ftl
@@ -77,9 +77,9 @@ blocked-by-policy-title-enterprise = Access to this site is restricted
 neterror-blocked-by-policy-page-title-enterprise = Access to this site is restricted
 neterror-blocked-by-policy-contact-admin = If you believe this is an error or need access for work purposes, please contact your IT administrator.
 
-enterprise-access-connector-heading = { -brand-feature-access-connector }
+enterprise-access-connector-heading2 = { -brand-feature-access-connector }
 enterprise-access-connector-info-active = This site is being accessed through a secure company connection.
-enterprise-access-connector-button =
+enterprise-access-connector-button2 =
   .label = { -brand-feature-access-connector }
   .tooltiptext = { -brand-feature-access-connector }
 enterprise-access-connector-status-label-active = active

--- a/browser/locales/en-US/browser/enterprise/enterprise.ftl
+++ b/browser/locales/en-US/browser/enterprise/enterprise.ftl
@@ -77,11 +77,11 @@ blocked-by-policy-title-enterprise = Access to this site is restricted
 neterror-blocked-by-policy-page-title-enterprise = Access to this site is restricted
 neterror-blocked-by-policy-contact-admin = If you believe this is an error or need access for work purposes, please contact your IT administrator.
 
-enterprise-access-connector-heading = Access Connector
+enterprise-access-connector-heading = { -brand-feature-access-connector }
 enterprise-access-connector-info-active = This site is being accessed through a secure company connection.
 enterprise-access-connector-button =
-  .label = Access Connector
-  .tooltiptext = Access Connector
+  .label = { -brand-feature-access-connector }
+  .tooltiptext = { -brand-feature-access-connector }
 enterprise-access-connector-status-label-active = active
 enterprise-access-connector-status-label-inactive = inactive
 

--- a/browser/locales/en-US/browser/enterprise/enterprise.ftl
+++ b/browser/locales/en-US/browser/enterprise/enterprise.ftl
@@ -2,6 +2,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+# Access Connector is an Enterprise feature name and must not be translated.
+-enterprise-feature-access-connector = Access Connector
+
 enterprise-toolbar-button =
     .label = { -brand-short-name }
     .tooltiptext = { -brand-short-name }
@@ -77,11 +80,11 @@ blocked-by-policy-title-enterprise = Access to this site is restricted
 neterror-blocked-by-policy-page-title-enterprise = Access to this site is restricted
 neterror-blocked-by-policy-contact-admin = If you believe this is an error or need access for work purposes, please contact your IT administrator.
 
-enterprise-access-connector-heading2 = { -brand-feature-access-connector }
+enterprise-access-connector-heading2 = { -enterprise-feature-access-connector }
 enterprise-access-connector-info-active = This site is being accessed through a secure company connection.
 enterprise-access-connector-button2 =
-  .label = { -brand-feature-access-connector }
-  .tooltiptext = { -brand-feature-access-connector }
+  .label = { -enterprise-feature-access-connector }
+  .tooltiptext = { -enterprise-feature-access-connector }
 enterprise-access-connector-status-label-active = active
 enterprise-access-connector-status-label-inactive = inactive
 


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2028392

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

Since Access Connector is the name of this enterprise feature, its name should not be included in the l10n strings for translation, and instead should be referenced from our brand.ftl.

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

<img width="543" height="201" alt="image" src="https://github.com/user-attachments/assets/b164a3ad-97a0-47e1-8472-1f3a884da76e" />

_Access Connector button and panel using brand name_

<img width="1142" height="257" alt="image" src="https://github.com/user-attachments/assets/97790719-4e0d-4746-a97a-7b179a1ed9a9" />

_Access Connector policy description using brand name_