### PR TITLE
Bug 2046242 - Look up enterprise-policies-descriptions.ftl in test_policy_descriptions_present

### DIFF
--- a/browser/components/enterprisepolicies/tests/xpcshell/test_policy_descriptions.js
+++ b/browser/components/enterprisepolicies/tests/xpcshell/test_policy_descriptions.js
@@ -3,6 +3,9 @@
 
 "use strict";
 
+const { AppConstants } = ChromeUtils.importESModule(
+  "resource://gre/modules/AppConstants.sys.mjs"
+);
 async function fetchText(url) {
   let response = await fetch(url);
   return response.text();
@@ -40,6 +43,16 @@ add_task(async function test_policy_descriptions_present() {
   let messageIds = new Set();
   for (let item of resource.textElements()) {
     messageIds.add(item.id);
+  }
+
+  if (AppConstants.MOZ_ENTERPRISE) {
+    const enterpriseFtlText = await fetchText(
+      "resource://app/localization/en-US/browser/enterprise/enterprise-policies-descriptions.ftl"
+    );
+    const enterpriseResource = new FluentResource(enterpriseFtlText);
+    for (const item of enterpriseResource.textElements()) {
+      messageIds.add(item.id);
+    }
   }
 
   let aboutPoliciesSource = await fetchText(


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2046242

Look up `enterprise-policies-descriptions.ftl` in enterprise builds when checking whether for all policies from the policies-schema.json is a description present.