### PR TITLE
Bug 2046504 - Use app name to compute branding name

### DIFF
--- a/testing/enterprise/felt_console_error.py
+++ b/testing/enterprise/felt_console_error.py
@@ -95,3 +95,14 @@ class FeltConsoleErrorBase(FeltTests):
         self.maybe_save_screenshot(Environment.FELT, screenshot_name)
 
         self._driver.set_context("content")
+
+    def get_brand_name(self):
+        app_name = self._driver.session_capabilities.get("browserName")
+        brand = None
+        if app_name == "firefox":
+            brand = "Firefox Enterprise"
+        elif app_name == "thunderbird":
+            brand = "Thunderbird Enterprise"
+        else:
+            assert False, f"Unsupported app {app_name}"
+        return brand

--- a/testing/enterprise/test_felt_console_error.py
+++ b/testing/enterprise/test_felt_console_error.py
@@ -137,38 +137,29 @@ class FeltConsoleError(FeltConsoleErrorBase):
         # connectionFailure with host substitution so the console address appears in details.
         refused_port = find_free_port()
 
-        app_name = self._driver.session_capabilities.get("browserName")
-        expected_str = None
-        if app_name == "firefox":
-            expected_str = f"Firefox Enterprise can’t connect to the server at localhost:{refused_port}"
-        elif app_name == "thunderbird":
-            expected_str = f"The connection was refused when attempting to contact localhost:{refused_port}."
-        else:
-            assert False, f"Unsupported app {app_name}"
-
         self.assert_neterror(
             login_location=f"http://localhost:{refused_port}",
             expected_heading="Unable to connect",
-            error_msg=expected_str,
+            error_msg=f"{self.get_brand_name()} can’t connect to the server at localhost:{refused_port}",
         )
 
         self.assert_xhrerror(
             login_location=f"http://localhost:{refused_port}",
             selector=".felt-browser-error-connection",
             expected_heading="Unable to connect",
-            error_msg=expected_str,
+            error_msg=f"{self.get_brand_name()} can’t connect to the server at localhost:{refused_port}",
         )
 
     def test_felt_error_insecure_certs(self):
         self.assert_neterror(
             login_location="https://wrong.host.badssl.com/sso_url",
             expected_heading="Unable to connect",
-            error_msg="Firefox Enterprise spotted a potentially serious security issue with wrong.host.badssl.com. Someone pretending to be the site could try to steal things like credit card info, passwords, or emails.",
+            error_msg=f"{self.get_brand_name()} spotted a potentially serious security issue with wrong.host.badssl.com. Someone pretending to be the site could try to steal things like credit card info, passwords, or emails.",
         )
 
         self.assert_xhrerror(
             login_location="https://wrong.host.badssl.com/sso_url",
             selector=".felt-browser-error-connection",
             expected_heading="Unable to connect",
-            error_msg="Firefox Enterprise spotted a potentially serious security issue with wrong.host.badssl.com. Someone pretending to be the site could try to steal things like credit card info, passwords, or emails.",
+            error_msg=f"{self.get_brand_name()} spotted a potentially serious security issue with wrong.host.badssl.com. Someone pretending to be the site could try to steal things like credit card info, passwords, or emails.",
         )

--- a/testing/enterprise/test_felt_verify_neterror.py
+++ b/testing/enterprise/test_felt_verify_neterror.py
@@ -88,7 +88,7 @@ class FeltVerifyNetError(FeltConsoleErrorBase):
         self.assert_error_bar_message(
             selector=".felt-browser-error-connection",
             expected_heading="Unable to connect. Please contact your administrator.",
-            error_msg="Firefox Enterprise spotted a potentially serious security issue with www.mozilla.org. Someone pretending to be the site could try to steal things like credit card info, passwords, or emails.",
+            error_msg=f"{self.get_brand_name()} spotted a potentially serious security issue with www.mozilla.org. Someone pretending to be the site could try to steal things like credit card info, passwords, or emails.",
             screenshot_name=f"{self._testMethodName}_MOZILLA_PKIX_ERROR_MITM_DETECTED",
         )
 


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2046504

Assertions needs to match the app name.