### PR TITLE
NO BUG - Update enterprise-main with release-only changes found during promotion

### DIFF
--- a/browser/config/mozconfigs/linux64/release-enterprise
+++ b/browser/config/mozconfigs/linux64/release-enterprise
@@ -1,0 +1,5 @@
+. "$topsrcdir/browser/config/mozconfigs/linux64/common-opt"
+
+ac_add_options --enable-enterprise
+
+. "$topsrcdir/build/mozconfig.common.override"

--- a/browser/config/mozconfigs/macosx64-aarch64/release-enterprise
+++ b/browser/config/mozconfigs/macosx64-aarch64/release-enterprise
@@ -1,0 +1,5 @@
+. "$topsrcdir/browser/config/mozconfigs/macosx64-aarch64/common-opt"
+
+ac_add_options --enable-enterprise
+
+. "$topsrcdir/build/mozconfig.common.override"

--- a/browser/config/mozconfigs/macosx64/release-enterprise
+++ b/browser/config/mozconfigs/macosx64/release-enterprise
@@ -1,0 +1,5 @@
+. "$topsrcdir/browser/config/mozconfigs/macosx64/common-opt"
+
+ac_add_options --enable-enterprise
+
+. "$topsrcdir/build/mozconfig.common.override"

--- a/browser/config/mozconfigs/win64/release-enterprise
+++ b/browser/config/mozconfigs/win64/release-enterprise
@@ -1,0 +1,7 @@
+. "$topsrcdir/build/mozconfig.win-common"
+. "$topsrcdir/browser/config/mozconfigs/win64/common-win64"
+. "$topsrcdir/browser/config/mozconfigs/win64/common-opt"
+
+ac_add_options --enable-enterprise
+
+. "$topsrcdir/build/mozconfig.common.override"

--- a/taskcluster/config.yml
+++ b/taskcluster/config.yml
@@ -889,7 +889,7 @@ workers:
             os: windows
             worker-type: '{alias}'
         win11-a64-25h2:
-            provisioner: 'gecko-t'
+            provisioner: '{trust-domain}-t'
             implementation: generic-worker
             os: windows
             worker-type: '{alias}'


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: NO BUG

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

Since we are new to using the "yolo merge" process for promoting a branch, I attempted to catch changes that might be unique to the release branch (if we committed them directly there instead of into enterprise-main and uplifts). To do this, I locally used `git merge -X theirs enterprise-firefox/enterprise-beta` from a local enterprise-release branch and compared to the results from the yolo merge.

The two items I found were:
- Commit 933b8a5dc65d had been made directly to enterprise-release and would be blapped by the yolo merge
- The enterprise taskcluster config.yml uses `{trust-domain}-t` as a provisioner instead of `gecko-t` but a new entry had been added (thus not encountering merge conflicts). This had been luckily caught and fixed in the enterprise-release merge but not in enterprise-main or enterprise-beta.

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Based on findings from: #1018 - the changes are re-added as follow-up commits in the promotion PR

