### PR TITLE
Bug 2046862 - Disable noWindowAutoRestart on Enterprise

### DIFF
--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -200,7 +200,14 @@ pref("app.update.langpack.enabled", true);
 #ifdef XP_MACOSX
   // If set to true, Firefox will automatically restart if it is left running
   // with no browser windows open.
-  pref("app.update.noWindowAutoRestart.enabled", true);
+  #if defined(MOZ_ENTERPRISE)
+    // Bug 2046862 : For Enterprise, FELT is running without a window, so it is
+    // required to disable this feature.
+    pref("app.update.noWindowAutoRestart.enabled", false);
+  #else
+    pref("app.update.noWindowAutoRestart.enabled", true);
+  #endif
+
   // How long to wait after all browser windows are closed before restarting,
   // in milliseconds. 5 min = 300000 ms
   pref("app.update.noWindowAutoRestart.delayMs", 300000);


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2046862

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

When running FELT after launching the browser, it is effectively a window-less instance of Firefox. On macOS it means there is a risk that background updates gets applied **and** that FELT restarts, without user action, creating troubles. Disable this feature.