### PR TITLE
Bug 2047142 - Update bug product and component

### DIFF
--- a/browser/components/enterprise/moz.build
+++ b/browser/components/enterprise/moz.build
@@ -5,7 +5,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 with Files("**"):
-    BUG_COMPONENT = ("Firefox Enterprise", "Client")
+    BUG_COMPONENT = ("Enterprise Products", "Firefox")
 
 EXTRA_JS_MODULES.enterprise += [
     "EnterpriseCommon.sys.mjs",


### PR DESCRIPTION
### Description <!-- REQUIRED -->

Bugzilla: Bug-2047142

Updates `BUG_COMPONENT` in `browser/components/enterprise/moz.build` since Bug-2045685 renamed the Bugzilla product "Firefox Enterprise" to "Enterprise Products" and the component "Client" to "Firefox".