### PR TITLE
Bug 2044899 - Restore enterprise panel styling lost in beta merge ef77ddb55809

### DIFF
--- a/browser/components/enterprise/content/enterprise-panel.css
+++ b/browser/components/enterprise/content/enterprise-panel.css
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+.panelUI-enterprise__main-frame {
+  gap: var(--space-small);
+}
+
+.panelUI-enterprise__email {
+  padding: var(--space-small) 0 0 var(--space-large);
+}
+
+.panelUI-enterprise__info-frame {
+  padding: var(--space-small) var(--space-small) var(--space-small) var(--space-large);
+  gap: var(--space-small);
+  /* stylelint-disable-next-line stylelint-plugin-mozilla/use-design-tokens */
+  width: 270px;
+}
+
+.panelUI-enterprise__alert {
+  gap: var(--space-small);
+}
+
+.panelUI-enterprise__alert__icon {
+  width: var(--icon-size);
+  height: var(--icon-size);
+  -moz-context-properties: fill;
+  fill: currentColor;
+
+  #panelUI-enterprise[visible] & {
+    list-style-image: url(chrome://browser/content/enterprise/alert.svg);
+  }
+}
+
+.panelUI-enterprise__alert__message {
+  font-weight: var(--font-weight-semibold);
+}

--- a/browser/components/enterprise/content/enterprise-panel.inc.xhtml
+++ b/browser/components/enterprise/content/enterprise-panel.inc.xhtml
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+<html:link rel="stylesheet" href="chrome://browser/content/enterprise/enterprise-panel.css" />
 <html:link rel="localization" href="browser/enterprise/enterprise.ftl" />
 
 <panelview id="panelUI-enterprise" class="PanelUI-subView">

--- a/browser/components/enterprise/jar.mn
+++ b/browser/components/enterprise/jar.mn
@@ -7,6 +7,7 @@ browser.jar:
   content/browser/enterprise/enterprise-badge.inc.xhtml     (content/enterprise-badge.inc.xhtml)
   content/browser/enterprise/alert.svg                      (content/icons/alert.svg)
   content/browser/enterprise/enterprise-panel.inc.xhtml     (content/enterprise-panel.inc.xhtml)
+  content/browser/enterprise/enterprise-panel.css           (content/enterprise-panel.css)
   content/browser/enterprise/enterprise-urlbar-actions.inc.xhtml (content/enterprise-urlbar-actions.inc.xhtml)
   content/browser/enterprise/enterprise-urlbar-actions.css  (content/enterprise-urlbar-actions.css)
   content/browser/enterprise/enterprise-urlbar-panels.inc.xhtml (content/enterprise-urlbar-panels.inc.xhtml)


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2044899

- Regressed by upstream/beta to enterprise-beta merge (7ddb55809), which removed the css in [panelUI-shared.css](https://searchfox.org/enterprise-main/source/browser/themes/shared/customizableui/panelUI-shared.css).
- Adds back css for the enterprise panel and moved it to `browser/components/enterprise/content/enterprise-panel.css` to avoid further merge conflicts.