### PR TITLE
Bug 2040374 - Fix enterprise transparent primary password after nsIPK11TokenDB removal

### DIFF
--- a/browser/components/BrowserGlue.sys.mjs
+++ b/browser/components/BrowserGlue.sys.mjs
@@ -1125,13 +1125,11 @@ BrowserGlue.prototype = {
           }
 
           // Load the PK11 token
-          const tokenDB = Cc["@mozilla.org/security/pk11tokendb;1"].getService(
-            Ci.nsIPK11TokenDB
-          );
-
           let pk11token;
           try {
-            pk11token = tokenDB.getInternalKeyToken();
+            pk11token = Cc[
+              "@mozilla.org/security/internalkeytoken;1"
+            ].createInstance(Ci.nsIPKCS11Token);
           } catch (e) {
             console.error(
               "EnterpriseStorageEncryption.load: Error getting PK11 token: " + e


### PR DESCRIPTION
### Description <!-- REQUIRED -->

Bugzilla: Bug-2040374

`nsIPK11TokenDB` got removed. Fix this for 152.

---


### Testing <!-- OPTIONAL -->

* [ ] Manual testing performed (Running a build now)


**Steps to verify changes:**
1. Run Firefox Enterprise 151 and make sure EnterpriseStorageEncryption is enabled
2. Add a password to about:logins 
3. Update to 152 and make sure the password is there

