### PR TITLE
Bug 2044899 - Extract enterprise panel css into enterprise-panel.css

### DIFF
--- a/browser/components/customizableui/content/panelUI.inc.xhtml
+++ b/browser/components/customizableui/content/panelUI.inc.xhtml
@@ -338,6 +338,10 @@
 </html:template>
 
 #ifdef MOZ_ENTERPRISE
+<!-- Loading enterprise-panel.css here, because the enterprise panel's markup lives in the appMenu-viewCache template,
+ which is inert and cannot load its own stylesheet -->
+<html:link rel="stylesheet" href="chrome://browser/content/enterprise/enterprise-panel.css" />
+
 <!-- Urlbar panels must live at the navbar DOM level to position correctly
      relative to their anchor. Do not move into appMenu-viewCache. -->
 #include ../../enterprise/content/enterprise-urlbar-panels.inc.xhtml

--- a/browser/components/enterprise/content/enterprise-panel.css
+++ b/browser/components/enterprise/content/enterprise-panel.css
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+.panelUI-enterprise__main-frame {
+  gap: var(--space-small);
+}
+
+.panelUI-enterprise__email {
+  padding: var(--space-small) 0 0 var(--space-large);
+}
+
+.panelUI-enterprise__info-frame {
+  padding: var(--space-small) var(--space-small) var(--space-small) var(--space-large);
+  gap: var(--space-small);
+  /* stylelint-disable-next-line stylelint-plugin-mozilla/use-design-tokens */
+  width: 270px;
+}
+
+.panelUI-enterprise__alert {
+  gap: var(--space-small);
+}
+
+.panelUI-enterprise__alert__icon {
+  width: var(--icon-size);
+  height: var(--icon-size);
+  -moz-context-properties: fill;
+  fill: currentColor;
+
+  #panelUI-enterprise[visible] & {
+    list-style-image: url(chrome://browser/content/enterprise/alert.svg);
+  }
+}
+
+.panelUI-enterprise__alert__message {
+  font-weight: var(--font-weight-semibold);
+}

--- a/browser/components/enterprise/jar.mn
+++ b/browser/components/enterprise/jar.mn
@@ -6,6 +6,7 @@ browser.jar:
 # Override the toolkit enterprise.properties with the browser version (loaded by nsDocShell.cpp).
 % override chrome://global/locale/enterprise.properties chrome://browser/locale/enterprise.properties
   content/browser/enterprise/enterprise-badge.css           (content/enterprise-badge.css)
+  content/browser/enterprise/enterprise-panel.css           (content/enterprise-panel.css)
   content/browser/enterprise/alert.svg                      (content/icons/alert.svg)
   content/browser/enterprise/enterprise-urlbar-actions.css  (content/enterprise-urlbar-actions.css)
   content/browser/enterprise/site-restrictions.svg          (content/icons/site-restrictions.svg)

--- a/browser/themes/shared/customizableui/panelUI-shared.css
+++ b/browser/themes/shared/customizableui/panelUI-shared.css
@@ -2521,37 +2521,3 @@ radiogroup:focus-visible > .subviewradio[focused="true"] {
 #PanelUI-ipprotection-locations {
   max-height: 400px;
 }
-
-/* ----- Enterprise panel ----- */
-.panelUI-enterprise__main-frame {
-  gap: 8px;
-}
-
-.panelUI-enterprise__email {
-  padding: 8px 0 0 16px;
-}
-
-.panelUI-enterprise__info-frame {
-  padding: 8px 8px 8px 16px;
-  gap: 8px;
-  width: 270px;
-}
-
-.panelUI-enterprise__alert {
-  gap: 8px;
-}
-
-.panelUI-enterprise__alert__icon {
-  width: var(--icon-size);
-  height: var(--icon-size);
-  -moz-context-properties: fill;
-  fill: currentColor;
-
-  #panelUI-enterprise[visible] & {
-    list-style-image: url(chrome://browser/content/enterprise/alert.svg);
-  }
-}
-
-.panelUI-enterprise__alert__message {
-  font-weight: var(--font-weight-semibold);
-}


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2044899

- Extracts enterprise panel css into self-contained `enterprise-panel.css` to avoid further merge conflicts.