### PR TITLE
Bug 2044982 - Hide fxa and sync controls in settings redesign

### DIFF
--- a/browser/components/preferences/config/account-sync.mjs
+++ b/browser/components/preferences/config/account-sync.mjs
@@ -614,9 +614,9 @@ Preferences.addSetting({
   },
   visible: () => {
     return !(
-        AppConstants.MOZ_ENTERPRISE &&
-        !Services.policies.isAllowed("change-sync-state")
-      )
+      AppConstants.MOZ_ENTERPRISE &&
+      !Services.policies.isAllowed("change-sync-state")
+    );
   },
 });
 

--- a/browser/components/preferences/config/account-sync.mjs
+++ b/browser/components/preferences/config/account-sync.mjs
@@ -486,6 +486,10 @@ Preferences.addSetting({
   deps: ["uiStateUpdate"],
   visible() {
     return (
+      !(
+        AppConstants.MOZ_ENTERPRISE &&
+        !Services.policies.isAllowed("change-sync-state")
+      ) &&
       SyncHelpers.uiStateStatus === window.UIState.STATUS_SIGNED_IN &&
       !SyncHelpers.isSyncEnabled
     );
@@ -597,6 +601,12 @@ Preferences.addSetting({
   id: "syncDisconnect",
   onUserClick: () => {
     SyncHelpers.disconnectSync();
+  },
+  visible: () => {
+    return !(
+        AppConstants.MOZ_ENTERPRISE &&
+        !Services.policies.isAllowed("change-sync-state")
+      )
   },
 });
 

--- a/browser/components/preferences/config/account-sync.mjs
+++ b/browser/components/preferences/config/account-sync.mjs
@@ -31,6 +31,9 @@ const lazy = XPCOMUtils.declareLazy({
   SelectableProfileService:
     "resource:///modules/profiles/SelectableProfileService.sys.mjs",
 });
+const { AppConstants } = ChromeUtils.importESModule(
+  "resource://gre/modules/AppConstants.sys.mjs"
+);
 
 Preferences.addAll([
   // sync
@@ -391,6 +394,10 @@ Preferences.addSetting(
         },
       };
     }
+
+    visible() {
+      return !AppConstants.MOZ_ENTERPRISE;
+    }
   }
 );
 
@@ -398,6 +405,9 @@ Preferences.addSetting({
   id: "fxaUnlinkButton",
   onUserClick: () => {
     SyncHelpers.unlinkFirefoxAccount(true);
+  },
+  visible() {
+    return !AppConstants.MOZ_ENTERPRISE;
   },
 });
 
@@ -672,6 +682,9 @@ Preferences.addSetting({
         SyncHelpers.connectAnotherDeviceHref = connectURI;
         emitChange();
       });
+  },
+  visible() {
+    return !AppConstants.MOZ_ENTERPRISE;
   },
 });
 


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2044982

- Hides FxA controls in new about:preferences design
- Hides Sync signout/signin controls in new about:preferences design, when sync state is locked by Sync policy

---

### Screenshots <!-- REQUIRED (if applicable) -->

_`Accounts and Sync` pane on `about:preferences` - No changes_

<img width="491" height="743" alt="Screenshot 2026-06-15 at 22 03 25" src="https://github.com/user-attachments/assets/4002f9f9-3377-4644-b9fa-73c4d0442831" />

_`Accounts and Sync` pane on `about:preferences` - With hidden fxa controls when **sync state unlocked; Sync ON**_

<img width="559" height="729" alt="Screenshot 2026-06-15 at 22 16 50" src="https://github.com/user-attachments/assets/81ddaecf-2158-4fbf-83df-dc865bd652d1" />

_`Accounts and Sync` pane on `about:preferences` - With hidden fxa controls when **sync state unlocked; Sync OFF**_

<img width="633" height="582" alt="Screenshot 2026-06-15 at 21 47 56" src="https://github.com/user-attachments/assets/f5ded8d0-0783-4e67-af16-522216e98351" />

_`Accounts and Sync` pane on `about:preferences` - With hidden sync controls when **sync state locked; Sync ON**_

<img width="625" height="761" alt="Screenshot 2026-06-15 at 22 16 03" src="https://github.com/user-attachments/assets/a1445a2f-c340-43c7-8462-0688ad9ecd46" />

_`Accounts and Sync` pane on `about:preferences` - With hidden sync controls when **sync state locked; Sync OFF**_

<img width="565" height="412" alt="Screenshot 2026-06-15 at 22 17 03" src="https://github.com/user-attachments/assets/97cb1f64-1edc-49fb-8782-cfcc225f6aec" />



---

### Testing <!-- OPTIONAL -->

* [x] Manual testing performed

**Steps to verify changes:**
1. Enable new settings design by setting the preference `browser.settings-redesign.enabled=true`
2. Visit `Accounts and Sync` pane on `about:preferences`

Expected Result: See screenshots and descriptions
