### PR TITLE
Bug 2044982 - Hide fxa and sync controls in settings redesign

### DIFF
--- a/browser/components/preferences/config/account-sync.mjs
+++ b/browser/components/preferences/config/account-sync.mjs
@@ -609,9 +609,9 @@ Preferences.addSetting({
   },
   visible: () => {
     return !(
-        AppConstants.MOZ_ENTERPRISE &&
-        !Services.policies.isAllowed("change-sync-state")
-      )
+      AppConstants.MOZ_ENTERPRISE &&
+      !Services.policies.isAllowed("change-sync-state")
+    );
   },
 });
 

--- a/browser/components/preferences/config/account-sync.mjs
+++ b/browser/components/preferences/config/account-sync.mjs
@@ -31,6 +31,9 @@ const lazy = XPCOMUtils.declareLazy({
   SelectableProfileService:
     "resource:///modules/profiles/SelectableProfileService.sys.mjs",
 });
+const { AppConstants } = ChromeUtils.importESModule(
+  "resource://gre/modules/AppConstants.sys.mjs"
+);
 
 Preferences.addAll([
   // sync
@@ -386,6 +389,10 @@ Preferences.addSetting(
         },
       };
     }
+
+    visible() {
+      return !AppConstants.MOZ_ENTERPRISE;
+    }
   }
 );
 
@@ -393,6 +400,9 @@ Preferences.addSetting({
   id: "fxaUnlinkButton",
   onUserClick: () => {
     SyncHelpers.unlinkFirefoxAccount(true);
+  },
+  visible() {
+    return !AppConstants.MOZ_ENTERPRISE;
   },
 });
 
@@ -657,6 +667,9 @@ Preferences.addSetting({
         SyncHelpers.connectAnotherDeviceHref = connectURI;
         emitChange();
       });
+  },
+  visible() {
+    return !AppConstants.MOZ_ENTERPRISE;
   },
 });
 

--- a/browser/components/preferences/config/account-sync.mjs
+++ b/browser/components/preferences/config/account-sync.mjs
@@ -491,6 +491,10 @@ Preferences.addSetting({
   deps: ["uiStateUpdate"],
   visible() {
     return (
+      !(
+        AppConstants.MOZ_ENTERPRISE &&
+        !Services.policies.isAllowed("change-sync-state")
+      ) &&
       SyncHelpers.uiStateStatus === window.UIState.STATUS_SIGNED_IN &&
       !SyncHelpers.isSyncEnabled
     );
@@ -602,6 +606,12 @@ Preferences.addSetting({
   id: "syncDisconnect",
   onUserClick: () => {
     SyncHelpers.disconnectSync();
+  },
+  visible: () => {
+    return !(
+        AppConstants.MOZ_ENTERPRISE &&
+        !Services.policies.isAllowed("change-sync-state")
+      )
   },
 });
 


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: [Bug-2044982](https://bugzilla.mozilla.org/show_bug.cgi?id=2044982)

Uplifts https://github.com/mozilla/enterprise-firefox/pull/1042.