### PR TITLE
Bug 2047928 - Support macOS aarch64 artifact enterprise builds

### DIFF
--- a/python/mozbuild/mozbuild/artifact_builds.py
+++ b/python/mozbuild/mozbuild/artifact_builds.py
@@ -23,6 +23,8 @@ JOB_CHOICES = {
     "macosx64-enterprise-debug",
     "macosx64-aarch64-opt",
     "macosx64-aarch64-debug",
+    "macosx64-aarch64-enterprise-opt",
+    "macosx64-aarch64-enterprise-debug",
     "win32-opt",
     "win32-debug",
     "win64-opt",


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2047928

Adds `macosx64-aarch64-enterprise-opt` and `macosx64-aarch64-enterprise-debug` artifact `JOB_CHOICES` to support macos aarch64 artifact enterprise builds.
