### PR TITLE
Bug 2040374 - Fix enterprise transparent primary password after refactor

### DIFF
--- a/browser/components/BrowserGlue.sys.mjs
+++ b/browser/components/BrowserGlue.sys.mjs
@@ -1142,16 +1142,7 @@ BrowserGlue.prototype = {
           }
 
           // Check if the PK11 token needs initialization
-          if (pk11token.needsUserInit) {
-            try {
-              pk11token.initPassword(primarySecret);
-            } catch (e) {
-              console.error(
-                "EnterpriseStorageEncryption.load: Failed to initialize PK11 token password: " +
-                  e
-              );
-            }
-          } else if (!pk11token.hasPassword) {
+          if (!pk11token.hasPassword) {
             // Token doesn't need login (empty password), set it to primarySecret
             try {
               pk11token.changePassword("", primarySecret);
@@ -1171,7 +1162,7 @@ BrowserGlue.prototype = {
               isPasswordValid = sdr.login(primarySecret);
             } catch (e) {
               console.error(
-                "EnterpriseStorageEncryption.load: Error checking password against PK11 token: " +
+                "EnterpriseStorageEncryption.load: Error logging into the Secret Decoder Ring with the primary secret: " +
                   e
               );
               return;

--- a/browser/components/BrowserGlue.sys.mjs
+++ b/browser/components/BrowserGlue.sys.mjs
@@ -1129,13 +1129,11 @@ BrowserGlue.prototype = {
           }
 
           // Load the PK11 token
-          const tokenDB = Cc["@mozilla.org/security/pk11tokendb;1"].getService(
-            Ci.nsIPK11TokenDB
-          );
-
           let pk11token;
           try {
-            pk11token = tokenDB.getInternalKeyToken();
+            pk11token = Cc[
+              "@mozilla.org/security/internalkeytoken;1"
+            ].createInstance(Ci.nsIPKCS11Token);
           } catch (e) {
             console.error(
               "EnterpriseStorageEncryption.load: Error getting PK11 token: " + e
@@ -1153,7 +1151,7 @@ BrowserGlue.prototype = {
                   e
               );
             }
-          } else if (!pk11token.needsLogin()) {
+          } else if (!pk11token.hasPassword) {
             // Token doesn't need login (empty password), set it to primarySecret
             try {
               pk11token.changePassword("", primarySecret);
@@ -1167,7 +1165,10 @@ BrowserGlue.prototype = {
             // Token needs login - verify the password matches primarySecret
             let isPasswordValid;
             try {
-              isPasswordValid = pk11token.checkPassword(primarySecret);
+              let sdr = Cc["@mozilla.org/security/sdr;1"].getService(
+                Ci.nsISecretDecoderRing
+              );
+              isPasswordValid = sdr.login(primarySecret);
             } catch (e) {
               console.error(
                 "EnterpriseStorageEncryption.load: Error checking password against PK11 token: " +


### PR DESCRIPTION
### Description <!-- REQUIRED -->

Bugzilla: Bug-2040374

Fixes primary password support issues introduced in [2037682](https://bugzilla.mozilla.org/show_bug.cgi?id=2037682) and [2043434](https://bugzilla.mozilla.org/show_bug.cgi?id=2043434).

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on: https://phabricator.services.mozilla.com/D307107?id=1301597

---

### Testing <!-- OPTIONAL -->

* [ ] Added tests
* [x] Manual testing performed


**Steps to verify changes:**
1. Run and old build of Firefox Enterprise and make sure EnterpriseStorageEncryption is enabled
2. Add a password to about:logins
3. Update to a build before this patch and verify that the password is not there (and a prompt pops up)
4. Update to this patch and verify the password is there and no prompt pops up.

