### PR TITLE
Bug 2049389 - Remove :shutdown to close console/SSO server and use terminate()

### DIFF
--- a/testing/enterprise/felt_tests.py
+++ b/testing/enterprise/felt_tests.py
@@ -93,18 +93,6 @@ class LocalHttpRequestHandler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(bytes(payload, "utf8"))
 
-    def do_POST(self):
-        print("POST", self.path)
-
-        if self.path == "/:shutdown":
-            print("Shutting down as requested")
-            self.reply("OK")
-            setattr(self.server, "_BaseServer__shutdown_request", True)
-            self.server.server_close()
-            return json.dumps({})
-
-        return None
-
     def not_found(self, path=None):
         self.send_response(404, "Not Found")
         self.send_header("Content-Length", "0")
@@ -444,7 +432,7 @@ class ConsoleHttpHandler(LocalHttpRequestHandler):
 
     def do_POST(self):
         print("POST", self.path)
-        m = super().do_POST()
+        m = None
 
         parsed = urllib.parse.urlparse(self.path)
         path = parsed.path
@@ -810,13 +798,23 @@ class FeltTestsBase(ConsoleSSOPortMixin, EnterpriseTestsBase):
             self._logger.info("Browser was already manually closed.")
 
         self._logger.info("Shutting down console")
-        requests.post(f"http://localhost:{self.console_port}/:shutdown", timeout=2)
+        self.console_httpd.terminate()
+        self.console_httpd.join(timeout=5)
+        if self.console_httpd.is_alive():
+            self._logger.warning(
+                "Console process did not exit after terminate; sending SIGKILL"
+            )
+            self.console_httpd.kill()
+            self.console_httpd.join(timeout=2)
         self._logger.info("Shutting down SSO")
-        requests.post(f"http://localhost:{self.sso_port}/:shutdown", timeout=2)
-        self._logger.info("Stopping process console")
-        self.console_httpd.join()
-        self._logger.info("Stopping process SSO")
-        self.sso_httpd.join()
+        self.sso_httpd.terminate()
+        self.sso_httpd.join(timeout=5)
+        if self.sso_httpd.is_alive():
+            self._logger.warning(
+                "SSO process did not exit after terminate; sending SIGKILL"
+            )
+            self.sso_httpd.kill()
+            self.sso_httpd.join(timeout=2)
         self._logger.info("All stopped")
 
         # If the test never started a child browser, this would not exists

--- a/testing/enterprise/test_felt_starts_utf8.py
+++ b/testing/enterprise/test_felt_starts_utf8.py
@@ -49,7 +49,13 @@ class FeltStartsUtf8(FeltTests):
         super().teardown()
         self._driver.instance.binary = self._original_binary
         if os.path.isdir(self._root_dir.name):
-            self._root_dir.cleanup()
+            if sys.platform == "win32":
+                shutil.rmtree(
+                    "\\\\?\\" + os.path.abspath(self._root_dir.name), ignore_errors=True
+                )
+                self._root_dir._finalizer.detach()
+            else:
+                self._root_dir.cleanup()
 
     def test_felt_browser_start_from_utf8_path(self):
         super().run_felt_base()


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2049389

On Windows it looks like there can be a ReadTimeout exception raised when we `POST` to `/:shutdown`. Handling this over an http request is prone to risks, just `terminate()`.

This also tackle some issues that arised with UTF-8 path handling