### PR TITLE
Bug 2045724 - Show correct message when pages are blocked by policy.

### DIFF
--- a/toolkit/content/errors/net-errors.mjs
+++ b/toolkit/content/errors/net-errors.mjs
@@ -408,8 +408,7 @@ export const NET_ERRORS = [
     category: "blocked",
     bodyTitleL10nId: "blocked-by-policy-title-enterprise",
     introContent: {
-      dataL10nId: "fp-neterror-offline-intro",
-      dataL10nArgs: { hostname: null },
+      dataL10nId: "fp-neterror-blocked-by-policy-intro",
     },
     descriptionParts: [
       {


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description

Bugzilla: Bug-2045724

Incorrect error message shown when hitting blocked page or website.

Needed to port bug [2029040](https://bugzilla.mozilla.org/show_bug.cgi?id=2029040) over to the new blockedByPolicyEnterprise message.

---

### Testing

Manual testing - navigate to about:profiles.