### PR TITLE
Bug 2049553 - Add missing routes for MSIX

### DIFF
--- a/taskcluster/gecko_taskgraph/transforms/repackage_signing.py
+++ b/taskcluster/gecko_taskgraph/transforms/repackage_signing.py
@@ -98,6 +98,8 @@ def make_repackage_signing_description(config, jobs):
                 )
                 group_symbol = "MSIXs"
             treeherder["symbol"] = f"{group_symbol}({dep_symbol})"
+            repack_label = dep_symbol.replace("/", "_")
+            attributes["repackage_type"] = f"{config.kind}-{repack_label}"
 
         if "enterprise-repack" in dep_job.label:
             repack_id = (

--- a/taskcluster/kinds/repackage-signing-msix/kind.yml
+++ b/taskcluster/kinds/repackage-signing-msix/kind.yml
@@ -8,6 +8,7 @@ transforms:
     - taskgraph.transforms.from_deps
     - gecko_taskgraph.transforms.name_sanity
     - gecko_taskgraph.transforms.repackage_signing
+    - gecko_taskgraph.transforms.repackage_routes
     - gecko_taskgraph.transforms.task
 
 kind-dependencies:


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2049553

Adds the missing index for https://github.com/mozilla/enterprise-console/pull/311

### Dependencies

-  #351 