### PR TITLE
Bug 2050540 - Enterprise: Enable gtest on Enterprise builds

### DIFF
--- a/taskcluster/kinds/test/compiled.yml
+++ b/taskcluster/kinds/test/compiled.yml
@@ -55,6 +55,8 @@ cppunittest:
 
 gtest:
     description: "GTests run"
+    attributes:
+        code-review: true
     suite: gtest
     treeherder-symbol: GTest
     instance-size:

--- a/taskcluster/test_configs/test-sets.yml
+++ b/taskcluster/test_configs/test-sets.yml
@@ -207,6 +207,7 @@ linux-tests:
     - xpcshell
 
 linux-tests-enterprise:
+    - gtest
     - marionette-integration
     - marionette-enterprise
     - mochitest-browser-chrome
@@ -364,6 +365,7 @@ windows11-25h2-tests:
     - xpcshell
 
 windows11-25h2-tests-enterprise:
+    - gtest
     - marionette-integration
     - marionette-enterprise
     - mochitest-browser-chrome
@@ -477,6 +479,7 @@ macosx1500-64-tests:
     - web-platform-tests-eme
 
 macosx1500-64-tests-enterprise:
+    - gtest
     - marionette-integration
     - marionette-enterprise
     - mochitest-browser-chrome

--- a/toolkit/tests/gtest/TestXREAppDir.cpp
+++ b/toolkit/tests/gtest/TestXREAppDir.cpp
@@ -33,14 +33,26 @@ using namespace mozilla;
 
 #include "mozilla/XREAppData.h"
 
-#if defined(MOZ_THUNDERBIRD)
-#  define EXPECTED_APP_NAME_CASED "Thunderbird"
-#  define EXPECTED_APP_NAME_NONCASED "thunderbird"
-#  define EXPECTED_VENDOR_APP_NAME_NONCASED "thunderbird"
+#if defined(MOZ_ENTERPRISE)
+#  if defined(MOZ_THUNDERBIRD)
+#    define EXPECTED_APP_NAME_CASED "ThunderbirdEnterprise"
+#    define EXPECTED_APP_NAME_NONCASED "thunderbirdenterprise"
+#    define EXPECTED_VENDOR_APP_NAME_NONCASED "thunderbirdenterprise"
+#  else
+#    define EXPECTED_APP_NAME_CASED "FirefoxEnterprise"
+#    define EXPECTED_APP_NAME_NONCASED "firefoxenterprise"
+#    define EXPECTED_VENDOR_APP_NAME_NONCASED "mozilla/firefoxenterprise"
+#  endif
 #else
-#  define EXPECTED_APP_NAME_CASED "Firefox"
-#  define EXPECTED_APP_NAME_NONCASED "firefox"
-#  define EXPECTED_VENDOR_APP_NAME_NONCASED "mozilla/firefox"
+#  if defined(MOZ_THUNDERBIRD)
+#    define EXPECTED_APP_NAME_CASED "Thunderbird"
+#    define EXPECTED_APP_NAME_NONCASED "thunderbird"
+#    define EXPECTED_VENDOR_APP_NAME_NONCASED "thunderbird"
+#  else
+#    define EXPECTED_APP_NAME_CASED "Firefox"
+#    define EXPECTED_APP_NAME_NONCASED "firefox"
+#    define EXPECTED_VENDOR_APP_NAME_NONCASED "mozilla/firefox"
+#  endif
 #endif
 
 class BaseXREAppDir : public ::testing::Test {


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2050540

GTest suite was not running, let's enable it and surface to GitHub checks