### PR TITLE
Bug 2052638 - Handle isDomainJoined property throwing r?gcp!

### DIFF
--- a/toolkit/components/enterprise/modules/ConsoleClient.sys.mjs
+++ b/toolkit/components/enterprise/modules/ConsoleClient.sys.mjs
@@ -767,6 +767,13 @@ export const ConsoleClient = {
         getPresentEDRs(),
       ]);
 
+    let isDomainJoined = false;
+    try {
+      isDomainJoined = Services.sysinfo.getPropertyAsBool("isDomainJoined");
+    } catch {
+      // ... ?
+    }
+
     const devicePosturePayload = {
       os,
       security: lazy.TelemetryEnvironment.currentEnvironment.system.sec,
@@ -779,7 +786,7 @@ export const ConsoleClient = {
       machineId,
       secureBootEnabled:
         Services.sysinfo.getPropertyAsBool("secureBootEnabled"),
-      isDomainJoined: Services.sysinfo.getPropertyAsBool("isDomainJoined"),
+      isDomainJoined,
       presentEdrs,
     };
     return devicePosturePayload;


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2052638

Default isDomainJoined to `false` and handle throwing from `getPropertyAsBool`