### PR TITLE
Bug 2052919 - Collect MAC address on network interfaces reporting as Ethernet

### DIFF
--- a/netwerk/system/netlink/NetlinkService.cpp
+++ b/netwerk/system/netlink/NetlinkService.cpp
@@ -275,6 +275,9 @@ class NetlinkLink {
     len = aNlh->nlmsg_len - NLMSG_LENGTH(sizeof(*iface));
 
     bool hasName = false;
+#if defined(MOZ_ENTERPRISE)
+    bool hasMAC = false;
+#endif
     for (attr = IFLA_RTA(iface); RTA_OK(attr, len);
          attr = RTA_NEXT(attr, len)) {
       if (attr->rta_type == IFLA_IFNAME) {
@@ -284,15 +287,24 @@ class NetlinkLink {
 #if defined(MOZ_ENTERPRISE)
       if (attr->rta_type == IFLA_ADDRESS) {
         memcpy(mMAC, RTA_DATA(attr), ETH_ALEN);
+        hasMAC = true;
       }
 #endif
 
-      if (hasName) {
+      if (hasName
+#if defined(MOZ_ENTERPRISE)
+          && (IsTypeEther() && hasMAC)
+#endif
+      ) {
         break;
       }
     }
 
-    if (!hasName) {
+    if (!hasName
+#if defined(MOZ_ENTERPRISE)
+        || (IsTypeEther() && !hasMAC)
+#endif
+    ) {
       return false;
     }
 

--- a/testing/enterprise/test_felt_device_posture.py
+++ b/testing/enterprise/test_felt_device_posture.py
@@ -259,7 +259,12 @@ class FeltDevicePosture(FeltTests):
                     "Device posture should not report loopback"
                 )
 
-            assert len(interface["mac"]) == 17, "Device posture reports MAC address"
+            assert len(interface["mac"]) == 17, (
+                "Device posture reports some MAC address"
+            )
+            assert interface["mac"] != "00:00:00:00:00:00", (
+                f"Device posture missing MAC address for interface '{interface['name']}'"
+            )
 
             """
             Not all interfaces are expected to have IPv4 and/or IPv6 but we


### PR DESCRIPTION

<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2052919

Bug 2013652 removed the requirement for MAC address when receiving NetLink messages because WWAN interface do not have one. However a WiFI network interface have, and because NetLink sends multiple messages, it may be missing at first and it is thus required to continue receiving messages to get the MAC address.

### Testing <!-- OPTIONAL -->

* [x] Added tests