### PR TITLE
Bug 2040381 - Register security event for Access Connector connection error

### DIFF
--- a/browser/components/enterprise/AccessConnectorButton.sys.mjs
+++ b/browser/components/enterprise/AccessConnectorButton.sys.mjs
@@ -31,6 +31,7 @@ export class AccessConnectorButton {
   #window = null;
   #progressListener = null;
   #onClick = null;
+  #lastErrorDomain = null;
 
   /**
    * @param {Window} window - The chrome window that owns the button.
@@ -149,19 +150,23 @@ export class AccessConnectorButton {
       const params = new URLSearchParams(principalURI.query);
       const errorCode = params.get("e");
       if (PROXY_ERROR_CODES.has(errorCode)) {
-        return { isProtected: true, isError: true };
+        let domain = "";
+        try {
+          domain = new URL(params.get("u") ?? "").hostname;
+        } catch {}
+        return { isProtected: true, isError: true, domain };
       }
     }
-    return { isProtected: false, isError: false };
+    return { isProtected: false, isError: false, domain: "" };
   }
 
   /**
    * Shows the button when the page is protected by the access connector, and
    * applies error styling when the proxy is unavailable.
    *
-   * @param {{ isProtected: boolean, isError: boolean }} status
+   * @param {{ isProtected: boolean, isError: boolean, domain: string }} status
    */
-  #applyStatus({ isProtected, isError }) {
+  #applyStatus({ isProtected, isError, domain }) {
     const button = this.#button;
     if (!button) {
       return;
@@ -199,6 +204,21 @@ export class AccessConnectorButton {
         );
       }
     }
+
+    if (isError && domain !== this.#lastErrorDomain) {
+      this.#recordProxyError(domain);
+    }
+    this.#lastErrorDomain = isError ? domain : null;
+  }
+
+  /**
+   * Submits a security event for a proxy error incident.
+   *
+   * @param {string} domain - The hostname that failed to load through the proxy.
+   */
+  #recordProxyError(domain) {
+    Glean.accessConnector.proxyError.record({ domain });
+    GleanPings.enterprise.submit();
   }
 
   /**

--- a/browser/components/enterprise/metrics.yaml
+++ b/browser/components/enterprise/metrics.yaml
@@ -1,0 +1,39 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Adding a new metric? We have docs for that!
+# https://firefox-source-docs.mozilla.org/toolkit/components/glean/user/new_definitions_file.html
+
+---
+$schema: moz://mozilla.org/schemas/glean/metrics/2-0-0
+$tags:
+  - 'Enterprise Products :: Firefox'
+
+#ifdef MOZ_ENTERPRISE
+access_connector:
+  proxy_error:
+    type: event
+    description: >
+      Recorded when the Access Connector proxy error state is shown to the
+      user (urlbar button enters error state due to a proxy connection failure).
+      Only collected when MOZ_ENTERPRISE is defined and enabled.
+    bugs:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=TBD
+    data_reviews:
+      - https://bugzilla.mozilla.org/show_bug.cgi?id=TBD
+    data_sensitivity:
+      - highly_sensitive
+    notification_emails:
+      - security-telemetry@mozilla.org
+      - enterprise-telemetry@mozilla.org
+    expires: never
+    send_in_pings:
+      - enterprise
+    extra_keys:
+      domain:
+        description: >
+          The hostname of the site that failed to load through the Access
+          Connector proxy.
+        type: string
+#endif

--- a/toolkit/components/glean/metrics_index.py
+++ b/toolkit/components/glean/metrics_index.py
@@ -124,6 +124,7 @@ firefox_desktop_metrics = [
     "browser/components/controlcenter/metrics.yaml",
     "browser/components/customkeys/metrics.yaml",
     "browser/components/downloads/metrics.yaml",
+    "browser/components/enterprise/metrics.yaml",
     "browser/components/enterprisepolicies/metrics.yaml",
     "browser/components/extensions/metrics.yaml",
     "browser/components/firefoxview/metrics.yaml",

--- a/toolkit/components/glean/tags.yaml
+++ b/toolkit/components/glean/tags.yaml
@@ -311,6 +311,8 @@ $schema: moz://mozilla.org/schemas/glean/tags/1-0-0
   description: The Bugzilla component which applies to this object.
 'Developer Infrastructure :: Try':
   description: The Bugzilla component which applies to this object.
+'Enterprise Products :: Firefox':
+  description: The Bugzilla component which applies to this object.
 'Firefox :: Address Bar':
   description: The Bugzilla component which applies to this object.
 'Firefox :: Bookmarks & History':


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2040381

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

Part 3 of 3. Adds a security event that records when the Access Connector enters an error state because a site failed to load due to a proxy connection error. 

- Registers a new `access_connector.proxy_error` event metric with the domain as additional metadata, sent in the `enterprise` ping.
- Since Access Connector is an Enterprise-only feature, the new metric is added in `enterprise/metrics.yaml` using the `Enterprise Products :: Firefox` tag.
- Metric is uses `data_sensitivity: highly_sensitive` since it sends the browsed domain as an extra key.
- Records the event once per error transition. Adds a guard to prevent re-firing on subsequent `update` calls for the same domain while the page remains in the error state.

> Note: this is stacked on top of #1048. Relevant commit is `Bug 2040381 - Register telemetry metric for Access Connector proxy error`.

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on: #1048 
* Part 3 of: #1033 

---

### Testing <!-- OPTIONAL -->

* [x] Manual testing performed


**Steps to verify changes:**

Follow steps outlined in #1048 

**Expected result:**

`access_connector.proxy_error` event is submitted to console. Verifiable in either the Browser Toolbox network tab or in the console itself. 