### PR TITLE
Bug 2050550 - Use leaf name without path for remoting.

### DIFF
--- a/toolkit/xre/nsAppRunner.cpp
+++ b/toolkit/xre/nsAppRunner.cpp
@@ -5506,10 +5506,13 @@ int XREMain::XRE_mainStartup(bool* aExitFlag,
     if (NS_SUCCEEDED(rv)) {
 #  if defined(MOZ_ENTERPRISE)
       if (is_felt_ui()) {
-        // Key remoting on the profile's leaf name, not its full path. The FELT
-        // profile lives under %TEMP%, whose prefix varies by launch context
-        // (8.3 vs long form, per-session or relocated temp) and breaks the
-        // remote-window lookup across launchers; the leaf is stable.
+        // Key remoting on the profile's leaf name rather than its full path.
+        // The FELT profile holds no important state (hence it lives under
+        // %TEMP%), but that %TEMP% prefix varies by launch context (8.3 vs long
+        // form, per-session or relocated temp), which breaks the remote-window
+        // lookup across launchers. The leaf name is hardcoded and embeds the
+        // update channel ("felt-<channel>"), so it is stable across launchers
+        // and unlikely to collide with other channels running in parallel.
         nsAutoString profileName;
         if (NS_SUCCEEDED(mProfD->GetLeafName(profileName))) {
           CopyUTF16toUTF8(profileName, profilePath);

--- a/toolkit/xre/nsAppRunner.cpp
+++ b/toolkit/xre/nsAppRunner.cpp
@@ -5504,6 +5504,18 @@ int XREMain::XRE_mainStartup(bool* aExitFlag,
 #  endif
 
     if (NS_SUCCEEDED(rv)) {
+#  if defined(MOZ_ENTERPRISE)
+      if (is_felt_ui()) {
+        // Key remoting on the profile's leaf name, not its full path. The FELT
+        // profile lives under %TEMP%, whose prefix varies by launch context
+        // (8.3 vs long form, per-session or relocated temp) and breaks the
+        // remote-window lookup across launchers; the leaf is stable.
+        nsAutoString profileName;
+        if (NS_SUCCEEDED(mProfD->GetLeafName(profileName))) {
+          CopyUTF16toUTF8(profileName, profilePath);
+        }
+      }
+#  endif
       gRemoteService->SetProfile(profilePath);
 
       if (!mDisableRemoteClient) {


### PR DESCRIPTION
### Description

Bugzilla: Bug-2050550 

Change window remoting name to not use the path (since it can change).