### PR TITLE
Bug 2049772 - Fix test_IPPFxaActivateAuthProvider.js for enterprise builds

### DIFF
--- a/toolkit/components/ipprotection/tests/xpcshell/test_IPPFxaActivateAuthProvider.js
+++ b/toolkit/components/ipprotection/tests/xpcshell/test_IPPFxaActivateAuthProvider.js
@@ -12,6 +12,9 @@ const { IPPSignInWatcher } = ChromeUtils.importESModule(
   "moz-src:///toolkit/components/ipprotection/fxa/IPPSignInWatcher.sys.mjs"
 );
 
+const { AppConstants } = ChromeUtils.importESModule(
+  "resource://gre/modules/AppConstants.sys.mjs"
+);
 const { AddonTestUtils } = ChromeUtils.importESModule(
   "resource://testing-common/AddonTestUtils.sys.mjs"
 );
@@ -431,9 +434,15 @@ add_task(async function test_isEnrolling_during_enroll() {
 add_task(async function test_guardian_endpoint_updates_on_reinit() {
   await IPProtectionService.init();
 
+  // Enterprise builds ship an empty default endpoint, whereas
+  // upstream defaults to the production Guardian endpoint.
+  const defaultEndpoint = AppConstants.MOZ_ENTERPRISE
+    ? ""
+    : "https://vpn.mozilla.org/";
+
   Assert.equal(
     IPPFxaActivateAuthProvider.guardian.guardianEndpoint,
-    "https://vpn.mozilla.org/",
+    defaultEndpoint,
     "Guardian should have default endpoint"
   );
 


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2049772

`test_IPPFxaActivateAuthProvider.js` fails on enterprise builds in the `test_guardian_endpoint_updates_on_reinit` task. The task asserts the default value of `browser.ipProtection.guardian.endpoint`, but enterprise builds ship an empty default for that pref (see the `MOZ_ENTERPRISE` branch in `firefox.js`), whereas upstream defaults to `https://vpn.mozilla.org/`.

This PR updates the assertion for both configurations:

- On enterprise builds the default endpoint is `""`.
- On non-enterprise builds it remains `"https://vpn.mozilla.org/"`.

### Testing <!-- OPTIONAL -->

* [ ] Added tests
* [x] Manual testing performed

Try run: https://treeherder.mozilla.org/jobs?repo=enterprise-firefox-try&searchStr=xpcshell&revision=e10c53bff660689305b615171872c3caaec83bc8