### PR TITLE
Bug 2049771 - Populate PrefServerList in ipprotection xpcshell tests on enterprise builds

### DIFF
--- a/toolkit/components/ipprotection/tests/xpcshell/head.js
+++ b/toolkit/components/ipprotection/tests/xpcshell/head.js
@@ -19,6 +19,9 @@ const { ProxyPass, ProxyUsage, Entitlement } = ChromeUtils.importESModule(
 const { RemoteSettings } = ChromeUtils.importESModule(
   "resource://services-settings/remote-settings.sys.mjs"
 );
+const { AppConstants } = ChromeUtils.importESModule(
+  "resource://gre/modules/AppConstants.sys.mjs"
+);
 const { IPProtectionActivator } = ChromeUtils.importESModule(
   "moz-src:///toolkit/components/ipprotection/IPProtectionActivator.sys.mjs"
 );
@@ -95,6 +98,15 @@ async function putServerInRemoteSettings(
   await client.db.clear();
   await client.db.create(US);
   await client.db.importChanges({}, Date.now());
+
+  // In MOZ_ENTERPRISE builds the serverlist is backed by PrefServerList, which
+  // reads a pref and ignores the RemoteSettings collection populated above.
+  if (AppConstants.MOZ_ENTERPRISE) {
+    Services.prefs.setStringPref(
+      "browser.ipProtection.override.serverlist",
+      JSON.stringify([US])
+    );
+  }
 }
 /* exported putServerInRemoteSettings */
 


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2049771

On enterprise builds, `IPProtectionServerlist` is a `PrefServerList` that reads `browser.ipProtection.override.serverlist` and ignores the RemoteSettings collection. The test helper populates RemoteSettings and ignores the `PrefServerList` path. 

This PR updates the helper in `head.js` to populate the serverlist in the pref for enterprise builds.

---

### Testing <!-- OPTIONAL -->

* [ ] Added tests
* [x] Manual testing performed

Try run: https://treeherder.mozilla.org/jobs?repo=enterprise-firefox-try&selectedTaskRun=azesh5nPRoOAizUFNsEOmg.0&revision=4cc1e5cf7f60ca04ebc1679b6af2b00e8233a072&searchStr=xpcshell