### PR TITLE
Bug 2049771, Bug 2049773 - Populate PrefServerList in ipprotection xpcshell tests on enterprise builds

### DIFF
--- a/toolkit/components/ipprotection/tests/xpcshell/head.js
+++ b/toolkit/components/ipprotection/tests/xpcshell/head.js
@@ -19,6 +19,9 @@ const { ProxyPass, ProxyUsage, Entitlement } = ChromeUtils.importESModule(
 const { RemoteSettings } = ChromeUtils.importESModule(
   "resource://services-settings/remote-settings.sys.mjs"
 );
+const { AppConstants } = ChromeUtils.importESModule(
+  "resource://gre/modules/AppConstants.sys.mjs"
+);
 const { IPProtectionActivator } = ChromeUtils.importESModule(
   "moz-src:///toolkit/components/ipprotection/IPProtectionActivator.sys.mjs"
 );
@@ -95,8 +98,33 @@ async function putServerInRemoteSettings(
   await client.db.clear();
   await client.db.create(US);
   await client.db.importChanges({}, Date.now());
+
+  maybeSetEnterpriseServerlistOverride([US]);
 }
 /* exported putServerInRemoteSettings */
+
+/**
+ * Mirrors a serverlist into the pref read by PrefServerList on MOZ_ENTERPRISE
+ * builds, where the RemoteSettings-backed serverlist is not used. No-op on
+ * other builds.
+ *
+ * The value is set on the default branch so that per-test user-branch changes
+ * and clearUserPref() calls revert to this list rather than emptying it.
+ *
+ * @param {Array<object>} countries - Country entries, as stored in RemoteSettings.
+ */
+function maybeSetEnterpriseServerlistOverride(countries) {
+  if (!AppConstants.MOZ_ENTERPRISE) {
+    return;
+  }
+  Services.prefs
+    .getDefaultBranch("")
+    .setStringPref(
+      "browser.ipProtection.override.serverlist",
+      JSON.stringify(countries)
+    );
+}
+/* exported maybeSetEnterpriseServerlistOverride */
 
 /* exported setupStubs */
 

--- a/toolkit/components/ipprotection/tests/xpcshell/test_IPProtectionServerlist.js
+++ b/toolkit/components/ipprotection/tests/xpcshell/test_IPProtectionServerlist.js
@@ -128,9 +128,16 @@ add_setup(async function () {
   }
   await client.db.importChanges({}, Date.now());
 
+  maybeSetEnterpriseServerlistOverride(TEST_COUNTRIES);
   await IPProtectionServerlist.maybeFetchList();
   await IPProtectionServerlist.initOnStartupCompleted();
-  Assert.ok(IPProtectionServerlist instanceof RemoteSettingsServerlist);
+  const expected = AppConstants.MOZ_ENTERPRISE
+    ? PrefServerList
+    : RemoteSettingsServerlist;
+  Assert.ok(
+    IPProtectionServerlist instanceof expected,
+    "Factory returns the serverlist implementation for this build"
+  );
 });
 
 add_task(async function test_getRecommendedLocation() {
@@ -266,17 +273,27 @@ add_task(async function test_listChangedEvent() {
   );
 
   try {
-    await client.emit("sync", { data: {} });
+    if (AppConstants.MOZ_ENTERPRISE) {
+      Services.prefs.setStringPref(
+        PrefServerList.PREF_NAME,
+        JSON.stringify([])
+      );
+    } else {
+      await client.emit("sync", { data: {} });
+    }
     Assert.greater(
       fired,
       0,
-      "ListChanged event is dispatched when RS sync triggers a refetch"
+      "ListChanged event is dispatched when the serverlist source changes"
     );
   } finally {
     IPProtectionServerlist.removeEventListener(
       "IPProtectionServerlist:ListChanged",
       onChanged
     );
+    if (AppConstants.MOZ_ENTERPRISE) {
+      Services.prefs.clearUserPref(PrefServerList.PREF_NAME);
+    }
   }
 });
 
@@ -333,37 +350,40 @@ add_task(async function test_selectServer() {
   Assert.equal(selected, null, "No server should be selected");
 });
 
-add_task(async function test_syncRespected() {
-  let { country, city } = IPProtectionServerlist.getLocation("US");
-  Assert.equal(country.code, "US", "getLocation('US') returns the US entry");
-  Assert.deepEqual(city, TEST_US_CITY, "The correct city should be returned");
+add_task(
+  { skip_if: () => AppConstants.MOZ_ENTERPRISE },
+  async function test_syncRespected() {
+    let { country, city } = IPProtectionServerlist.getLocation("US");
+    Assert.equal(country.code, "US", "getLocation('US') returns the US entry");
+    Assert.deepEqual(city, TEST_US_CITY, "The correct city should be returned");
 
-  // Now, update the server list: keep only an updated US entry.
-  const updated_server = {
-    ...TEST_SERVER_1,
-    hostname: "updated.example.com",
-  };
-  const updated_city = {
-    ...TEST_US_CITY,
-    servers: [updated_server],
-  };
-  const updated_country = {
-    name: "United States",
-    code: "US",
-    cities: [updated_city],
-  };
+    // Now, update the server list: keep only an updated US entry.
+    const updated_server = {
+      ...TEST_SERVER_1,
+      hostname: "updated.example.com",
+    };
+    const updated_city = {
+      ...TEST_US_CITY,
+      servers: [updated_server],
+    };
+    const updated_country = {
+      name: "United States",
+      code: "US",
+      cities: [updated_city],
+    };
 
-  await client.db.clear();
-  await client.db.create(updated_country);
-  await client.db.importChanges({}, Date.now());
-  await client.emit("sync", { data: {} });
+    await client.db.clear();
+    await client.db.create(updated_country);
+    await client.db.importChanges({}, Date.now());
+    await client.emit("sync", { data: {} });
 
-  await IPProtectionServerlist.maybeFetchList();
+    await IPProtectionServerlist.maybeFetchList();
 
-  ({ country, city } = IPProtectionServerlist.getLocation("US"));
-  Assert.equal(country.code, "US", "getLocation('US') still returns US");
-  Assert.deepEqual(city, updated_city, "The updated city should be returned");
-});
+    ({ country, city } = IPProtectionServerlist.getLocation("US"));
+    Assert.equal(country.code, "US", "getLocation('US') still returns US");
+    Assert.deepEqual(city, updated_city, "The updated city should be returned");
+  }
+);
 
 add_task(async function test_PrefServerList() {
   registerCleanupFunction(() => {
@@ -435,10 +455,16 @@ add_task(async function test_IPProtectionServerlistFactory() {
   registerCleanupFunction(() => {
     Services.prefs.clearUserPref(PrefServerList.PREF_NAME);
   });
-  // Without the pref set, it should return RemoteSettingsServerlist
+  // Without the pref set, non-enterprise builds return a
+  // RemoteSettingsServerlist; MOZ_ENTERPRISE builds always return a
+  // PrefServerList regardless of the pref.
   Services.prefs.clearUserPref(PrefServerList.PREF_NAME);
   let instance = IPProtectionServerlistFactory();
-  Assert.ok(instance instanceof RemoteSettingsServerlist);
+  if (AppConstants.MOZ_ENTERPRISE) {
+    Assert.ok(instance instanceof PrefServerList);
+  } else {
+    Assert.ok(instance instanceof RemoteSettingsServerlist);
+  }
   Services.prefs.setCharPref(
     PrefServerList.PREF_NAME,
     JSON.stringify(TEST_COUNTRIES)


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2049771, Bug-2049773

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

On enterprise builds, `IPProtectionServerlist` is a `PrefServerList` that reads `browser.ipProtection.override.serverlist` and ignores the `RemoteSettings` collection. The ipprotection xpcshell tests only populate RemoteSettings, so the serverlist is empty on enterprise and any check on IPProtectionServerlist.hasList fails. 

This PR adds a shared `head.js` helper that mirrors the serverlist into the override pref on `MOZ_ENTERPRISE` builds and skips two RS-sync tests that are not applicable to Enterprise.

---

### Testing <!-- OPTIONAL -->

* [ ] Added tests
* [x] Manual testing performed

Try run: https://treeherder.mozilla.org/jobs?repo=enterprise-firefox-try&searchStr=xpcshell&revision=0facd6ea7f4358b4b641dfa2d098004dc62f4851