### PR TITLE
Bug 2053982 - Use www.mozilla.org for Access Connector test r?jporter-dev

### DIFF
--- a/testing/enterprise/test_felt_browser_access_connector.py
+++ b/testing/enterprise/test_felt_browser_access_connector.py
@@ -191,9 +191,9 @@ class BrowserAccessConnector(FeltTests):
     def run_load_page_with_access_connector(self):
         with self.assertRaisesRegex(
             UnknownException,
-            r"Reached error page: about:neterror\?e=proxyResolveFailure&u=https%3A//support\.mozilla\.org",
+            r"Reached error page: about:neterror\?e=proxyResolveFailure&u=https%3A//www\.mozilla\.org",
         ):
-            self.open_tab_child("https://support.mozilla.org/en-US/")
+            self.open_tab_child("https://www.mozilla.org/en-US/about/this-site")
             assert self.get_access_connector_icon_is_displayed(), (
                 "Access Connector icon is displayed"
             )
@@ -203,7 +203,10 @@ class BrowserAccessConnector(FeltTests):
         self.run_load_page_ok(f"http://localhost:{self.console_port}/ping", "Pong!")
 
     def run_load_page_without_access_connector(self):
-        self.run_load_page_ok("https://support.mozilla.org/en-US/", "Mozilla Support")
+        self.run_load_page_ok(
+            "https://www.mozilla.org/en-US/about/this-site/",
+            "About this site — Mozilla",
+        )
         assert not self.get_access_connector_icon_is_displayed(), (
             "Access Connector icon is not displayed"
         )


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2053982

Support is blocking by WAF now when running on TaskCluster. Probably better solution would be to have a local server running and hitting this, but as a quick fix to make tests readable, this is good enough.