### PR TITLE
Bug 2039308 - Avoid trying to access CrashReporter ui when not ready in auto-submit flow

### DIFF
--- a/toolkit/crashreporter/client/app/src/logic.rs
+++ b/toolkit/crashreporter/client/app/src/logic.rs
@@ -700,7 +700,10 @@ impl ReportCrash {
     /// Form the extra data, taking into account user input.
     fn current_extra_data(&self) -> serde_json::Value {
         let include_address = self.settings.borrow().include_url;
-        let comment = if !self.config.auto_submit {
+        let get_comment = !self.config.auto_submit;
+        #[cfg(feature = "enterprise")]
+        let get_comment = get_comment && !self.config.policy_auto_submit;
+        let comment = if get_comment {
             self.ui().wait(|r| r.comment.get())
         } else {
             Default::default()


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2039308

On linux (and likely mac), the code that is trying to read the comment field accesses the UI before it is ready. The comment field is disabled for the policy auto-submit flow, so we don't need to read it. The code already was guarded for the non-UI auto-submit flow, so I added a guard for the policy auto-submit flow as well.

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Testing <!-- OPTIONAL -->

* [x] Manual testing performed on wsl, untested on mac