### PR TITLE
Bug 2051323 - Exclude the enterprise console address when a Proxy policy is set

### DIFF
--- a/browser/components/enterprisepolicies/Policies.sys.mjs
+++ b/browser/components/enterprisepolicies/Policies.sys.mjs
@@ -3500,14 +3500,18 @@ export var Policies = {
   },
 
   Proxy: {
-    onBeforeAddons(manager, param) {
+    async onBeforeAddons(manager, param) {
       if (param.Locked) {
         manager.disallowFeature("changeProxySettings");
       }
-      lazy.ProxyPolicies.configureProxySettings(
-        param,
-        lazy.PoliciesUtils.setDefaultPref.bind(lazy.PoliciesUtils)
+      let setDefaultPref = lazy.PoliciesUtils.setDefaultPref.bind(
+        lazy.PoliciesUtils
       );
+      lazy.ProxyPolicies.configureProxySettings(param, setDefaultPref);
+
+      if (AppConstants.MOZ_ENTERPRISE) {
+        await lazy.ProxyPolicies.excludeConsoleFromProxy(param, setDefaultPref);
+      }
     },
     onRemove(manager, oldParams) {
       if (oldParams.Locked) {
@@ -3517,6 +3521,10 @@ export var Policies = {
         oldParams,
         lazy.PoliciesUtils.setDefaultPref.bind(lazy.PoliciesUtils)
       );
+
+      if (AppConstants.MOZ_ENTERPRISE) {
+        lazy.PoliciesUtils.unsetDefaultPref("network.proxy.no_proxies_on");
+      }
     },
   },
 

--- a/browser/components/enterprisepolicies/Policies.sys.mjs
+++ b/browser/components/enterprisepolicies/Policies.sys.mjs
@@ -3500,17 +3500,20 @@ export var Policies = {
   },
 
   Proxy: {
-    async onBeforeAddons(manager, param) {
+    onBeforeAddons(manager, param) {
       if (param.Locked) {
         manager.disallowFeature("changeProxySettings");
       }
-      let setDefaultPref = lazy.PoliciesUtils.setDefaultPref.bind(
+      const setDefaultPref = lazy.PoliciesUtils.setDefaultPref.bind(
         lazy.PoliciesUtils
       );
       lazy.ProxyPolicies.configureProxySettings(param, setDefaultPref);
 
       if (AppConstants.MOZ_ENTERPRISE) {
-        await lazy.ProxyPolicies.excludeConsoleFromProxy(param, setDefaultPref);
+        lazy.ProxyPolicies.excludeConsoleFromProxy(param, setDefaultPref).then(
+          null,
+          lazy.log.error
+        );
       }
     },
     onRemove(manager, oldParams) {

--- a/browser/components/enterprisepolicies/helpers/ProxyPolicies.sys.mjs
+++ b/browser/components/enterprisepolicies/helpers/ProxyPolicies.sys.mjs
@@ -6,6 +6,10 @@ const PREF_LOGLEVEL = "browser.policies.loglevel";
 
 const lazy = {};
 
+ChromeUtils.defineESModuleGetters(lazy, {
+  ConsoleClient: "resource://gre/modules/enterprise/ConsoleClient.sys.mjs",
+});
+
 ChromeUtils.defineLazyGetter(lazy, "log", () => {
   let { ConsoleAPI } = ChromeUtils.importESModule(
     "resource://gre/modules/Console.sys.mjs"
@@ -137,6 +141,30 @@ export var ProxyPolicies = {
           Services.prefs.unlockPref(preference);
         }
       }
+    }
+  },
+
+  /**
+   * Keeps the enterprise console reachable on a direct connection whenever a
+   * proxy is configured, so a broken proxy can be recovered from via a remote
+   * policy update. Any admin-provided Passthrough value is preserved.
+   *
+   * @param {object} param The Proxy policy parameters.
+   * @param {Function} setPref A function to set a preference value.
+   * @returns {Promise<void>}
+   */
+  async excludeConsoleFromProxy(param, setPref) {
+    try {
+      const { hostname } = await lazy.ConsoleClient.consoleBaseURI;
+      if (!hostname) {
+        return;
+      }
+      const passthrough = param.Passthrough
+        ? `${param.Passthrough}, ${hostname}`
+        : hostname;
+      setPref("network.proxy.no_proxies_on", passthrough, param.Locked);
+    } catch (e) {
+      lazy.log.error("Failed to exclude enterprise console:", e);
     }
   },
   resetProxySettings(oldParams, setPref) {

--- a/browser/components/enterprisepolicies/tests/xpcshell/test_proxy.js
+++ b/browser/components/enterprisepolicies/tests/xpcshell/test_proxy.js
@@ -68,6 +68,54 @@ add_task(async function test_proxy_socks_and_passthrough() {
   checkUnlockedPref("network.proxy.no_proxies_on", "a, b, c");
 });
 
+add_task(async function test_proxy_exclude_console_from_proxy() {
+  const CONSOLE_ADDRESS_PREF = "enterprise.console.address";
+  let { ProxyPolicies } = ChromeUtils.importESModule(
+    "resource:///modules/policies/ProxyPolicies.sys.mjs"
+  );
+  registerCleanupFunction(() => {
+    Services.prefs.clearUserPref(CONSOLE_ADDRESS_PREF);
+  });
+
+  let calls = [];
+  let setPref = (name, value, locked) => calls.push({ name, value, locked });
+  const NO_PROXIES = "network.proxy.no_proxies_on";
+
+  // Set the address only after the call so the console-host injection has to
+  // survive the address arriving late in startup (bug 2051323).
+  let pending = ProxyPolicies.excludeConsoleFromProxy(
+    { Mode: "manual" },
+    setPref
+  );
+  Services.prefs.setStringPref(
+    CONSOLE_ADDRESS_PREF,
+    "https://console.example.com"
+  );
+  await pending;
+  Assert.deepEqual(calls, [
+    { name: NO_PROXIES, value: "console.example.com", locked: undefined },
+  ]);
+
+  calls = [];
+  await ProxyPolicies.excludeConsoleFromProxy(
+    { Mode: "manual", Passthrough: "a, b", Locked: true },
+    setPref
+  );
+  Assert.deepEqual(calls, [
+    { name: NO_PROXIES, value: "a, b, console.example.com", locked: true },
+  ]);
+
+  // no_proxies_on is honored for PAC too, since CanUseProxy runs before the PAC.
+  calls = [];
+  await ProxyPolicies.excludeConsoleFromProxy(
+    { Mode: "autoConfig", Passthrough: "a, b" },
+    setPref
+  );
+  Assert.deepEqual(calls, [
+    { name: NO_PROXIES, value: "a, b, console.example.com", locked: undefined },
+  ]);
+});
+
 add_task(async function test_proxy_addresses() {
   function checkProxyPref(proxytype, address, port) {
     checkUnlockedPref(`network.proxy.${proxytype}`, address);

--- a/browser/components/enterprisepolicies/tests/xpcshell/test_proxy.js
+++ b/browser/components/enterprisepolicies/tests/xpcshell/test_proxy.js
@@ -2,6 +2,10 @@
  * http://creativecommons.org/publicdomain/zero/1.0/ */
 "use strict";
 
+const { AppConstants } = ChromeUtils.importESModule(
+  "resource://gre/modules/AppConstants.sys.mjs"
+);
+
 add_task(async function test_proxy_modes_and_autoconfig() {
   // Directly test the proxy Mode and AutoconfigURL parameters through
   // the API instead of the policy engine, because the test harness
@@ -68,53 +72,60 @@ add_task(async function test_proxy_socks_and_passthrough() {
   checkUnlockedPref("network.proxy.no_proxies_on", "a, b, c");
 });
 
-add_task(async function test_proxy_exclude_console_from_proxy() {
-  const CONSOLE_ADDRESS_PREF = "enterprise.console.address";
-  let { ProxyPolicies } = ChromeUtils.importESModule(
-    "resource:///modules/policies/ProxyPolicies.sys.mjs"
-  );
-  registerCleanupFunction(() => {
-    Services.prefs.clearUserPref(CONSOLE_ADDRESS_PREF);
-  });
+add_task(
+  { skip_if: () => !AppConstants.MOZ_ENTERPRISE },
+  async function test_proxy_exclude_console_from_proxy() {
+    const CONSOLE_ADDRESS_PREF = "enterprise.console.address";
+    let { ProxyPolicies } = ChromeUtils.importESModule(
+      "resource:///modules/policies/ProxyPolicies.sys.mjs"
+    );
+    registerCleanupFunction(() => {
+      Services.prefs.clearUserPref(CONSOLE_ADDRESS_PREF);
+    });
 
-  let calls = [];
-  let setPref = (name, value, locked) => calls.push({ name, value, locked });
-  const NO_PROXIES = "network.proxy.no_proxies_on";
+    let calls = [];
+    let setPref = (name, value, locked) => calls.push({ name, value, locked });
+    const NO_PROXIES = "network.proxy.no_proxies_on";
 
-  // Set the address only after the call so the console-host injection has to
-  // survive the address arriving late in startup (bug 2051323).
-  let pending = ProxyPolicies.excludeConsoleFromProxy(
-    { Mode: "manual" },
-    setPref
-  );
-  Services.prefs.setStringPref(
-    CONSOLE_ADDRESS_PREF,
-    "https://console.example.com"
-  );
-  await pending;
-  Assert.deepEqual(calls, [
-    { name: NO_PROXIES, value: "console.example.com", locked: undefined },
-  ]);
+    // Set the address only after the call so the console-host injection has to
+    // survive the address arriving late in startup (bug 2051323).
+    let pending = ProxyPolicies.excludeConsoleFromProxy(
+      { Mode: "manual" },
+      setPref
+    );
+    Services.prefs.setStringPref(
+      CONSOLE_ADDRESS_PREF,
+      "https://console.example.com"
+    );
+    await pending;
+    Assert.deepEqual(calls, [
+      { name: NO_PROXIES, value: "console.example.com", locked: undefined },
+    ]);
 
-  calls = [];
-  await ProxyPolicies.excludeConsoleFromProxy(
-    { Mode: "manual", Passthrough: "a, b", Locked: true },
-    setPref
-  );
-  Assert.deepEqual(calls, [
-    { name: NO_PROXIES, value: "a, b, console.example.com", locked: true },
-  ]);
+    calls = [];
+    await ProxyPolicies.excludeConsoleFromProxy(
+      { Mode: "manual", Passthrough: "a, b", Locked: true },
+      setPref
+    );
+    Assert.deepEqual(calls, [
+      { name: NO_PROXIES, value: "a, b, console.example.com", locked: true },
+    ]);
 
-  // no_proxies_on is honored for PAC too, since CanUseProxy runs before the PAC.
-  calls = [];
-  await ProxyPolicies.excludeConsoleFromProxy(
-    { Mode: "autoConfig", Passthrough: "a, b" },
-    setPref
-  );
-  Assert.deepEqual(calls, [
-    { name: NO_PROXIES, value: "a, b, console.example.com", locked: undefined },
-  ]);
-});
+    // no_proxies_on is honored for PAC too, since CanUseProxy runs before the PAC.
+    calls = [];
+    await ProxyPolicies.excludeConsoleFromProxy(
+      { Mode: "autoConfig", Passthrough: "a, b" },
+      setPref
+    );
+    Assert.deepEqual(calls, [
+      {
+        name: NO_PROXIES,
+        value: "a, b, console.example.com",
+        locked: undefined,
+      },
+    ]);
+  }
+);
 
 add_task(async function test_proxy_addresses() {
   function checkProxyPref(proxytype, address, port) {


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2051323

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

A broken and locked `Proxy` policy can break networking with no in-browser recovery path since all traffic is routed through the proxy by default. Updated policies are fetched from the enterprise console, so a bad proxy config could break the console connection, leaving the browser unable to retrieve the fix. 

This PR excludes the console endpoint from proxying so the console remains accessible. 

- Adds `ProxyPolicies.excludeConsoleFromProxy`, which appends the console host to `network.proxy.no_proxies_on`
- The console address is provisioned asynchronously at startup, so the implementation uses `ConsoleClient.consoleBaseURI` instead of reading the pref directly

---

### Testing <!-- OPTIONAL -->

* [x] Added tests
* [x] Manual testing performed


**Steps to verify changes:**

1. Configure a proxy policy with an invalid `HTTProxy`, e.g.:
```
{
  "Mode": "manual",
  "HTTPProxy": "192.168.1.10:3128",
  "UseHTTPProxyForAllProtocols": true
}
``` 
2. Access the console URL

**Expected result:**

Console URL loads as expected and no proxy error is shown.