### PR TITLE
Make patch for 2050550 Windows specific.

### DIFF
--- a/toolkit/xre/nsAppRunner.cpp
+++ b/toolkit/xre/nsAppRunner.cpp
@@ -5522,15 +5522,16 @@ int XREMain::XRE_mainStartup(bool* aExitFlag,
 #  endif
 
     if (NS_SUCCEEDED(rv)) {
-#  if defined(MOZ_ENTERPRISE)
+#  if defined(MOZ_ENTERPRISE) && defined(XP_WIN)
       if (is_felt_ui()) {
-        // Key remoting on the profile's leaf name rather than its full path.
-        // The FELT profile holds no important state (hence it lives under
-        // %TEMP%), but that %TEMP% prefix varies by launch context (8.3 vs long
-        // form, per-session or relocated temp), which breaks the remote-window
-        // lookup across launchers. The leaf name is hardcoded and embeds the
-        // update channel ("felt-<channel>"), so it is stable across launchers
-        // and unlikely to collide with other channels running in parallel.
+        // On Windows, key remoting on the profile's leaf name rather than its
+        // full path. The FELT profile holds no important state (hence it lives
+        // under %TEMP%), but that %TEMP% prefix varies by launch context (8.3
+        // vs long form, per-session or relocated temp), which breaks the
+        // remote-window lookup across launchers. The leaf name is hardcoded and
+        // embeds the update channel ("felt-<channel>"), so it is stable across
+        // launchers and unlikely to collide with other channels running in
+        // parallel.
         nsAutoString profileName;
         if (NS_SUCCEEDED(mProfD->GetLeafName(profileName))) {
           CopyUTF16toUTF8(profileName, profilePath);


### PR DESCRIPTION
The %TEMP% instability this works around is Windows-specific. macOS and Linux resolve their temp directory differently and don't need it.

### Description

Bugzilla: Bug-2054968

The leafName patch for remoting on 2050550 should be Windows specific.