### PR TITLE
Bug 2055023 - Fix intermittent neterror reset race in FELT

### DIFF
--- a/toolkit/components/felt/content/window.js
+++ b/toolkit/components/felt/content/window.js
@@ -37,26 +37,23 @@ function clearSsoSessionData() {
   });
 }
 
-async function resetToLogin(errorType = null, details = null, cause = null) {
+function resetToLoginPage() {
   cancelActiveSso?.();
-  await clearSsoSessionData();
-  document.getElementById("browser").fixupAndLoadURIString("about:blank", {
-    triggeringPrincipal: Services.scriptSecurityManager.getSystemPrincipal(),
-  });
   document.querySelector(".felt-login__sso").classList.add("is-hidden");
   document
     .querySelector(".felt-login__email-pane")
     .classList.remove("is-hidden");
   document.getElementById("felt-back-button").classList.add("is-hidden");
+}
 
-  if (errorType) {
-    lazy.FeltErrorReport.update(
-      errorType,
-      details,
-      cause,
-      lazy.ERROR_SOURCE.RESET
-    );
-  }
+function resetToLoginPageWithError(errorType, details = null, cause = null) {
+  resetToLoginPage();
+  lazy.FeltErrorReport.update(
+    errorType,
+    details,
+    cause,
+    lazy.ERROR_SOURCE.RESET
+  );
 }
 
 async function connectToConsole(email) {
@@ -128,7 +125,7 @@ async function connectToConsole(email) {
 
   let ssoTimeout = setTimeout(() => {
     lazy.log.error("SSO login timed out");
-    resetToLogin("felt-browser-error-sso-timeout");
+    resetToLoginPageWithError("felt-browser-error-sso-timeout");
   }, SSO_TIMEOUT_MS);
 
   const progressListener = {
@@ -156,7 +153,7 @@ async function connectToConsole(email) {
         lazy.log.error(
           `SSO callback page failed to load: 0x${status.toString(16)}`
         );
-        resetToLogin(
+        resetToLoginPageWithError(
           "felt-browser-error-connection",
           lazy.FeltErrorReport.getFluentIdForStatus(status),
           { hostname: uri.host }
@@ -167,7 +164,7 @@ async function connectToConsole(email) {
       const windowGlobal = browser.browsingContext?.currentWindowGlobal;
       if (!windowGlobal) {
         lazy.log.error("No WindowGlobal for SSO callback page");
-        resetToLogin("felt-browser-error-connection");
+        resetToLoginPageWithError("felt-browser-error-connection");
         return;
       }
 
@@ -181,23 +178,23 @@ async function connectToConsole(email) {
           .then(sent => {
             if (!sent) {
               lazy.log.error("Fallback token extraction found no token data");
-              resetToLogin("felt-browser-error-connection");
+              resetToLoginPageWithError("felt-browser-error-connection");
             }
           })
           .catch(err => {
             lazy.log.error(`Fallback token extraction failed: ${err}`);
-            resetToLogin("felt-browser-error-connection");
+            resetToLoginPageWithError("felt-browser-error-connection");
           });
       } catch (err) {
         lazy.log.error(`Could not reach FeltWindow actor: ${err}`);
-        resetToLogin("felt-browser-error-connection");
+        resetToLoginPageWithError("felt-browser-error-connection");
       }
     },
 
     onLocationChange(_webProgress, _request, _location, flags) {
       if (flags & Ci.nsIWebProgressListener.LOCATION_CHANGE_ERROR_PAGE) {
         clearTimeout(ssoTimeout);
-        resetToLogin("felt-browser-error-connection");
+        resetToLoginPageWithError("felt-browser-error-connection");
         return;
       }
       // Reset the timeout on each navigation so the limit applies per-page
@@ -206,7 +203,7 @@ async function connectToConsole(email) {
       clearTimeout(ssoTimeout);
       ssoTimeout = setTimeout(() => {
         lazy.log.error("SSO login timed out");
-        resetToLogin("felt-browser-error-sso-timeout");
+        resetToLoginPageWithError("felt-browser-error-sso-timeout");
       }, SSO_TIMEOUT_MS);
     },
   };
@@ -456,7 +453,11 @@ function macosActivateApplication() {
 function setupBackButton() {
   const backButton = document.getElementById("felt-back-button");
   backButton.addEventListener("click", async () => {
-    await resetToLogin();
+    resetToLoginPage();
+    await clearSsoSessionData();
+    document.getElementById("browser").fixupAndLoadURIString("about:blank", {
+      triggeringPrincipal: Services.scriptSecurityManager.getSystemPrincipal(),
+    });
   });
 }
 


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2055023

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

Bug-2031400 caused this regression by resetting the SSO pane on all `resetToLoginPage` calls, as well as making this function async. This broke the `ERROR_SOURCE.NET` reset + error paths by introducing a race between that path and the `ERROR_SOURCE.RESET` path. 

This PR implements the suggested refactor not applied that splits `resetToLoginPage` into two separate calls - one with the error and one without. Additionally, it removes the SSO reset from `resetToLoginPage` and reset the SSO browser and calls `clearSsoSessionData()` explicitly in the back button handler, which in turn removes the need for making `resetToLoginPage` async.