### PR TITLE
Bug 2026616 - Fix session loss on browser restart

### DIFF
--- a/testing/enterprise/manifest.toml
+++ b/testing/enterprise/manifest.toml
@@ -153,6 +153,11 @@ run-if = [
 
 ["test_felt_restart_is_quit.py"]
 
+["test_felt_restart_persists_session.py"]
+run-if = [
+  "buildapp == 'browser'", # browser specific: SessionStore tab restore
+]
+
 ["test_felt_restart_works.py"]
 
 ["test_felt_starts_missing_bin.py"]

--- a/testing/enterprise/test_felt_restart_persists_session.py
+++ b/testing/enterprise/test_felt_restart_persists_session.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import os
+import sys
+
+sys.path.append(os.path.dirname(__file__))
+
+from felt_tests import FeltTests
+from marionette_driver.errors import (
+    NoSuchWindowException,
+    UnknownException,
+)
+
+
+class AppRestartPersistsSession(FeltTests):
+    """A FELT restart must preserve the open tabs.
+
+    Seeds tabs, restarts, and reconnects to the relaunched browser
+    to confirm it resumed the session with those tabs open.
+    """
+
+    def test_restart_persists_session(self):
+        super().run_felt_base()
+
+        session_tabs = [
+            "about:support",
+            "about:policies",
+            f"http://localhost:{self.console_port}/ping",
+        ]
+
+        self.connect_child_browser()
+        self._browser_pid = self._child_driver.session_capabilities["moz:processID"]
+
+        self._open_child_tabs(session_tabs)
+        opened = self._child_tab_urls()
+        assert set(session_tabs).issubset(opened), (
+            f"Tabs were not open before the restart: {opened}"
+        )
+
+        self._child_longwait.until(
+            lambda _: set(session_tabs).issubset(self._child_session_urls()),
+            message="SessionStore did not record the tabs before restart",
+        )
+
+        self.issue_child_restart()
+        self.wait_process_exit(self._browser_pid)
+
+        self._logger.info("Connecting to new browser")
+        self.connect_child_browser()
+        new_browser_pid = self._child_driver.session_capabilities["moz:processID"]
+        assert new_browser_pid != self._browser_pid, (
+            f"Expected a new process, still {new_browser_pid}"
+        )
+
+        self._child_longwait.until(
+            lambda _: set(session_tabs).issubset(set(self._child_tab_urls())),
+            message="Relaunched browser did not restore the session tabs",
+        )
+
+    def issue_child_restart(self):
+        try:
+            self._logger.info("Issuing restart being done by felt")
+            self._child_driver.set_context("chrome")
+            self._child_driver.execute_script(
+                "Services.startup.quit(Ci.nsIAppStartup.eRestart | Ci.nsIAppStartup.eAttemptQuit);"
+            )
+        except UnknownException:
+            self._logger.info("Received expected UnknownException")
+        except NoSuchWindowException:
+            self._logger.info("Received expected NoSuchWindowException")
+        except OSError:
+            self._logger.info(
+                "Firefox quit before execute_script returned, no data received over Marionette socket"
+            )
+
+    def _open_child_tabs(self, urls):
+        for url in urls:
+            self.open_tab_child(url)
+
+    def _child_tab_urls(self):
+        self._child_driver.set_context("chrome")
+        return self._child_driver.execute_script(
+            "return Array.from(gBrowser.tabs).map(t => t.linkedBrowser.currentURI.spec);"
+        )
+
+    def _child_session_urls(self):
+        self._child_driver.set_context("chrome")
+        return self._child_driver.execute_script(
+            """
+            const { SessionStore } = ChromeUtils.importESModule(
+              "resource:///modules/sessionstore/SessionStore.sys.mjs"
+            );
+            const state = JSON.parse(SessionStore.getBrowserState());
+            return state.windows.flatMap(w =>
+              w.tabs.flatMap(t => (t.entries || []).map(e => e.url))
+            );
+            """
+        )

--- a/testing/enterprise/test_felt_restart_works.py
+++ b/testing/enterprise/test_felt_restart_works.py
@@ -8,6 +8,7 @@ import sys
 
 sys.path.append(os.path.dirname(__file__))
 
+import psutil
 from felt_tests import FeltTests
 from marionette_driver.errors import (
     NoSuchWindowException,
@@ -16,7 +17,7 @@ from marionette_driver.errors import (
 
 
 class AppRestartWorks(FeltTests):
-    def test_app_resart_works(self):
+    def test_app_restart_works(self):
         super().run_felt_base()
         self.run_felt_perform_restart()
         self.run_felt_restart_new_process()
@@ -61,8 +62,31 @@ class AppRestartWorks(FeltTests):
             f"PID changed from {self._browser_pid} to {new_browser_pid}"
         )
 
+        felt_ui_pid = self._driver.session_capabilities["moz:processID"]
+        target_exe = psutil.Process(felt_ui_pid).exe()
+        felt_browser_pids = set(self._get_felt_browser_pids(target_exe))
+        unexpected = felt_browser_pids - {new_browser_pid}
+        assert not unexpected, (
+            f"Extra FELT browser process(es) after restart (double relaunch?): {unexpected}"
+        )
+        assert new_browser_pid in felt_browser_pids, (
+            f"Relaunched browser PID {new_browser_pid} is not running"
+        )
+
         self._logger.info(f"Closing new browser with PID {new_browser_pid}")
         self._child_driver.set_context("chrome")
         self._child_driver.execute_script(
             "Services.startup.quit(Ci.nsIAppStartup.eForceQuit);"
         )
+
+    def _get_felt_browser_pids(self, target_exe):
+        pids = []
+        for proc in psutil.process_iter(["pid", "exe", "cmdline"]):
+            try:
+                cmdline = proc.info["cmdline"] or []
+                # Check for FELT browser process with -felt.
+                if proc.info["exe"] == target_exe and "-felt" in cmdline:
+                    pids.append(proc.info["pid"])
+            except (psutil.NoSuchProcess, psutil.ZombieProcess, psutil.AccessDenied):
+                continue
+        return pids

--- a/toolkit/components/felt/content/FeltProcessParent.sys.mjs
+++ b/toolkit/components/felt/content/FeltProcessParent.sys.mjs
@@ -16,6 +16,8 @@ ChromeUtils.defineESModuleGetters(lazy, {
     "resource://gre/modules/enterprise/EnterpriseCommon.sys.mjs",
   FeltCommon: "chrome://felt/content/FeltCommon.sys.mjs",
   FeltStorage: "resource://gre/modules/enterprise/FeltStorage.sys.mjs",
+  setTimeout: "resource://gre/modules/Timer.sys.mjs",
+  clearTimeout: "resource://gre/modules/Timer.sys.mjs",
 });
 
 if (lazy.isBuildAppBrowser()) {
@@ -157,6 +159,12 @@ export class FeltProcessParent extends JSProcessActorParent {
           }
 
           case "felt-firefox-restarting": {
+            if (gFeltProcessParentInstance) {
+              gFeltProcessParentInstance.restartReported = true;
+              gFeltProcessParentInstance.firefox = null;
+            }
+
+            const proc = gFeltProcessParentInstance?.proc;
             const restartDisabled = Services.prefs.getBoolPref(
               "enterprise.disable_restart",
               false
@@ -188,19 +196,31 @@ export class FeltProcessParent extends JSProcessActorParent {
                 lazy.log.debug(
                   `ParentProcess: restart notification, restartDisabled=${restartDisabled}`
                 );
-                // Kill Firefox directly instead of broadcasting to receiveMessage()
-                // since gFeltProcessParentInstance is accessible here
-                if (gFeltProcessParentInstance?.proc) {
-                  gFeltProcessParentInstance.restartReported = true;
-                  gFeltProcessParentInstance.firefox = null;
+                if (proc) {
                   lazy.log.debug(
-                    `ParentProcess: Killing Firefox PID=${gFeltProcessParentInstance.proc.pid}`
+                    `ParentProcess: Waiting for Firefox PID=${proc.pid} to exit for restart`
                   );
-                  gFeltProcessParentInstance.proc
-                    .kill()
+
+                  // exitPromise never rejects and has no timeout. kill after a timeout, set above the
+                  // toolkit.asyncshutdown.crash_timeout, to avoid hangs if the child is truly unresponsive.
+                  const restartShutdownTimeout = Services.prefs.getIntPref(
+                    "enterprise.browser.restart_shutdown_timeout",
+                    90000
+                  );
+                  const forceKillTimer = lazy.setTimeout(() => {
+                    if (proc.exitCode === null) {
+                      lazy.log.error(
+                        `ParentProcess: Firefox PID=${proc.pid} did not exit within ${restartShutdownTimeout}ms; killing for restart`
+                      );
+                      proc.kill();
+                    }
+                  }, restartShutdownTimeout);
+
+                  proc.exitPromise
                     .then(() => {
+                      lazy.clearTimeout(forceKillTimer);
                       lazy.log.debug(
-                        `ParentProcess: Killed Firefox, restartDisabled=${restartDisabled}`
+                        `ParentProcess: Firefox exited for restart, restartDisabled=${restartDisabled}`
                       );
 
                       if (!restartDisabled && !pendingUpdate) {
@@ -227,11 +247,28 @@ export class FeltProcessParent extends JSProcessActorParent {
                       }
                     })
                     .catch(err => {
-                      lazy.log.debug(`ParentProcess: Kill failed: ${err}`);
+                      lazy.clearTimeout(forceKillTimer);
+                      lazy.log.error(
+                        `ParentProcess: Restart continuation failed after exit: ${err}; sending normal exit`
+                      );
+                      Services.cpmm.sendAsyncMessage(
+                        "FeltParent:FirefoxNormalExit",
+                        {}
+                      );
                     });
                 } else {
-                  lazy.log.debug(`ParentProcess: No proc to kill!`);
+                  lazy.log.debug(`ParentProcess: No proc to wait for!`);
                 }
+              })
+              .catch(err => {
+                lazy.log.error(
+                  `ParentProcess: Restart failed: ${err}; killing proc and quitting via normal exit`
+                );
+                proc?.kill();
+                Services.cpmm.sendAsyncMessage(
+                  "FeltParent:FirefoxNormalExit",
+                  {}
+                );
               });
             break;
           }

--- a/toolkit/xre/nsAppRunner.cpp
+++ b/toolkit/xre/nsAppRunner.cpp
@@ -7281,14 +7281,7 @@ int XREMain::XRE_main(int argc, char* argv[], const BootstrapConfig& aConfig) {
   }
 #endif
 
-#if defined(MOZ_ENTERPRISE)
-  // Do not restart when running as Felt client (i.e. Enterprise browser)
-  if (!is_felt_browser()) {
-#endif
-    mozilla::AppShutdown::MaybeDoRestart();
-#if defined(MOZ_ENTERPRISE)
-  }
-#endif
+  mozilla::AppShutdown::MaybeDoRestart();
 
   XRE_DeinitCommandLine();
 

--- a/xpcom/base/AppShutdown.cpp
+++ b/xpcom/base/AppShutdown.cpp
@@ -29,6 +29,9 @@
 #include "nsExceptionHandler.h"
 #include "nsICertStorage.h"
 #include "nsThreadUtils.h"
+#if defined(MOZ_ENTERPRISE)
+#  include "mozilla/toolkit/components/felt/felt.h"
+#endif
 
 // TODO: understand why on Android we cannot include this and if we should
 #ifndef ANDROID
@@ -148,6 +151,13 @@ const char* AppShutdown::GetShutdownPhaseName(ShutdownPhase aPhase) {
 
 void AppShutdown::MaybeDoRestart() {
   if (sShutdownMode == AppShutdownMode::Restart) {
+#if defined(MOZ_ENTERPRISE)
+    // Do not restart when running as FELT client (i.e. Enterprise browser)
+    if (is_felt_browser()) {
+      return;
+    }
+#endif
+
     StopLateWriteChecks();
 
     // Since we'll be launching our child while we're still alive, make sure


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2026616

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

When a FELT-managed browser requests a restart, `FeltProcessParent` force-kills the browser process immediately and then relaunches it. This races the browser's graceful shutdown before its session store has flushed to disk, so the relaunch comes up looking like a crash instead of restoring the previous session.

This PR updates the `felt-firefox-restarting` branch in `FeltProcessParent.sys.mjs` to wait for the child browser's `proc.exitPromise` to resolve rather than calling `proc.kill()` before relaunching a new child browser. This allows the graceful shutdown to write the session to disk before relaunching. 

In addition to fixing the session persistence, this PR also moves `AppShutdown::MaybeDoRestart` guard from wrapping the call in `nsAppRunner.cpp` to guarding directly in the `AppShutdown::MaybeDoRestart` function itself in `AppShutdown.cpp`. A [second unguarded call](https://searchfox.org/enterprise-main/source/xpcom/base/AppShutdown.cpp#258) to this method was causing a second browser window to appear on restarts.

---

### Testing <!-- OPTIONAL -->

* [x] Added tests
* [x] Manual testing performed


**Steps to verify changes:**

1.  In `about:preferences`, ensure "Open previous windows and tabs" is unchecked
2. Start the FELT browser and open a few tabs
3. Trigger a restart. Options:
    - Type "Restart" into the urlbar and click "Restart Firefox Enterprise"
    - Navigate to `about:restartrequired` and click "Restart Firefox Enterprise"
    - Navigate to `about:profiles` and click "Restart Normally"
    - In the browser console:
   `Services.startup.quit(Ci.nsIAppStartup.eRestart | Ci.nsIAppStartup.eAttemptQuit);`
    - In the browser console: `Services.obs.notifyObservers(null, "felt-update-ready");`, then click "Update Available - Restart Now" 
5. Wait for the browser to reopen

**Expected result:**

The browser exits cleanly and relaunches once, with the previous session/tabs restored, and no extra browser windows or tabs.
