### PR TITLE
Bug 2055586 - Remove duplicate AppConstants import in test_IPPFxaActivateAuthProvider.js

### DIFF
--- a/toolkit/components/ipprotection/tests/xpcshell/test_IPPFxaActivateAuthProvider.js
+++ b/toolkit/components/ipprotection/tests/xpcshell/test_IPPFxaActivateAuthProvider.js
@@ -11,10 +11,6 @@ const { IPPFxaActivateAuthProvider, IPPFxaActivateAuthProviderSingleton } =
 const { IPPSignInWatcher } = ChromeUtils.importESModule(
   "moz-src:///toolkit/components/ipprotection/fxa/IPPSignInWatcher.sys.mjs"
 );
-
-const { AppConstants } = ChromeUtils.importESModule(
-  "resource://gre/modules/AppConstants.sys.mjs"
-);
 const { AddonTestUtils } = ChromeUtils.importESModule(
   "resource://testing-common/AddonTestUtils.sys.mjs"
 );


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2055586

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

#1131  landed simultaneously with #1127 that initially fixed this test. #1131 imported `AppConstants` in `head.js` so it should be removed from `toolkit/components/ipprotection/tests/xpcshell/test_IPPFxaActivateAuthProvider.js`. 