### PR TITLE
Bug 2020682 - Keep the enterprise-managed SDR unlocked and fail closed on unlock failure

### DIFF
--- a/browser/components/BrowserGlue.sys.mjs
+++ b/browser/components/BrowserGlue.sys.mjs
@@ -1119,72 +1119,64 @@ BrowserGlue.prototype = {
             false
           ),
         task: async () => {
-          // Get the primary secret from the console backend
-          // The API returns { data: "secret_value" }
+          // A managed browser that cannot establish its SDR unlock must not keep
+          // running: it would prompt for a primarySecret the user does not know,
+          // or operate against a profile it cannot decrypt. Fail the launch with
+          // a dedicated exit code (Bug 2020682), mirroring the launcher-side
+          // abort in FeltProcessParent.
+          const fail = (msg, e) => {
+            console.error(
+              `EnterpriseStorageEncryption.load: ${msg}${e ? ": " + e : ""}`
+            );
+            Services.startup.quit(
+              Ci.nsIAppStartup.eForceQuit,
+              Ci.nsIFelt.FeltEncryptionExitCode_UnlockFailed
+            );
+          };
+
+          // The API returns { data: "secret_value" }.
           let primarySecret;
           try {
-            const payload = await lazy.ConsoleClient.getPrimarySecret();
-            primarySecret = payload.data;
-            if (!primarySecret) {
-              console.error(
-                "EnterpriseStorageEncryption.load: No data field in payload:",
-                payload
-              );
-              return;
-            }
+            primarySecret = (await lazy.ConsoleClient.getPrimarySecret()).data;
           } catch (e) {
-            console.error(
-              "EnterpriseStorageEncryption.load: Failed to get primary secret:",
-              e
-            );
-            return;
+            return fail("Failed to get primary secret", e);
+          }
+          if (!primarySecret) {
+            return fail("No primary secret in payload");
           }
 
-          // Load the PK11 token
           let pk11token;
           try {
             pk11token = Cc[
               "@mozilla.org/security/internalkeytoken;1"
             ].createInstance(Ci.nsIPKCS11Token);
           } catch (e) {
-            console.error(
-              "EnterpriseStorageEncryption.load: Error getting PK11 token: " + e
-            );
-            return;
+            return fail("Error getting PK11 token", e);
           }
 
-          // Check if the PK11 token needs initialization
+          // Ensure the internal token's password is the primarySecret.
           if (!pk11token.hasPassword) {
-            // Token doesn't need login (empty password), set it to primarySecret
             try {
               await pk11token.changePassword("", primarySecret);
             } catch (e) {
-              console.error(
-                "EnterpriseStorageEncryption.load: Failed to change password from empty to primarySecret: " +
-                  e
-              );
+              return fail("Failed to set the primary secret on the token", e);
             }
-          } else {
-            // Token needs login - verify the password matches primarySecret
-            let isPasswordValid;
-            try {
-              let sdr = Cc["@mozilla.org/security/sdr;1"].getService(
-                Ci.nsISecretDecoderRing
-              );
-              isPasswordValid = sdr.login(primarySecret);
-            } catch (e) {
-              console.error(
-                "EnterpriseStorageEncryption.load: Error logging into the Secret Decoder Ring with the primary secret: " +
-                  e
-              );
-              return;
-            }
+          }
 
-            if (!isPasswordValid) {
-              console.error(
-                "EnterpriseStorageEncryption.load: Password against the PK11 token is not valid"
-              );
+          // Setting the password (PK11_ChangePW) does not leave the token logged
+          // in, and on a returning profile the token starts this session logged
+          // out. Log in explicitly and verify, so the SDR is unlocked for the
+          // whole session; otherwise the first login/cookie/import SDR operation
+          // would prompt for a primary password the user cannot supply.
+          try {
+            const sdr = Cc["@mozilla.org/security/sdr;1"].getService(
+              Ci.nsISecretDecoderRing
+            );
+            if (!sdr.login(primarySecret) || !pk11token.isLoggedIn) {
+              return fail("Internal token not logged in after unlock");
             }
+          } catch (e) {
+            return fail("SDR login failed", e);
           }
         },
       },

--- a/security/manager/ssl/SecretDecoderRing.cpp
+++ b/security/manager/ssl/SecretDecoderRing.cpp
@@ -308,16 +308,34 @@ SecretDecoderRing::Login(const nsACString& password, bool* success) {
   return NS_OK;
 }
 
+// The enterprise storage-encryption feature unlocks the internal token once at
+// startup with a console-supplied primarySecret the user does not know. While
+// that feature manages the primary password, no SDR-driven logout may
+// de-authenticate the internal token, or later SDR use would prompt for a
+// password the user cannot supply (Bug 2020682). Non-token teardown (TLS cache,
+// connection pruning) still runs.
+static bool EnterpriseManagesPrimaryPassword() {
+#if defined(MOZ_ENTERPRISE)
+  return mozilla::StaticPrefs::security_storage_encryption_enabled();
+#else
+  return false;
+#endif
+}
+
 NS_IMETHODIMP
 SecretDecoderRing::Logout() {
-  PK11_LogoutAll();
+  if (!EnterpriseManagesPrimaryPassword()) {
+    PK11_LogoutAll();
+  }
   mozilla::net::SSLTokensCache::ClearSessionCacheAndTokens();
   return NS_OK;
 }
 
 NS_IMETHODIMP
 SecretDecoderRing::LogoutAndTeardown() {
-  PK11_LogoutAll();
+  if (!EnterpriseManagesPrimaryPassword()) {
+    PK11_LogoutAll();
+  }
   nsCOMPtr<nsINSSComponent> nssComponent(do_GetService(NS_NSSCOMPONENT_CID));
   if (!nssComponent) {
     return NS_ERROR_NOT_AVAILABLE;

--- a/toolkit/components/felt/rust/nsIFelt.idl
+++ b/toolkit/components/felt/rust/nsIFelt.idl
@@ -10,6 +10,10 @@
 interface nsIFelt : nsISupports {
   const unsigned long FeltEncryptionExitCode_Archive = 0x93;
   const unsigned long FeltEncryptionExitCode_Delete = 0x94;
+  // The spawned browser could not establish its SDR unlock (no primarySecret,
+  // or the internal token could not be logged in). Exit with this code rather
+  // than run against a profile it cannot decrypt (Bug 2020682).
+  const unsigned long FeltEncryptionExitCode_UnlockFailed = 0x95;
 
   [must_use]
   ACString oneShotIpcServer();


### PR DESCRIPTION
### Description

Bugzilla: Bug-2020682

The enterprise storage-encryption feature sets the NSS internal token's primary password to the console-supplied primarySecret and is meant to unlock it once at startup. Two gaps let a primary-password prompt reach the user for a secret they cannot supply:

- EnterpriseStorageEncryption.load set the password on a fresh token via changePassword("", primarySecret) but never logged the token in (PK11_ChangePW does not authenticate), so the first SDR consumer -- e.g. importing logins from another browser -- prompted. Make the login explicit and symmetric across both the fresh and returning branches, verify pk11token.isLoggedIn, and fail the launch with a dedicated exit code (FeltEncryptionExitCode_UnlockFailed) if any step fails instead of continuing half-unlocked.

- Any CLEAR_AUTH_TOKENS clear (Clear Recent History, sanitize, site-data) routed through SecretDecoderRing::Logout / LogoutAndTeardown ran PK11_LogoutAll, re-locking the internal token mid-session with no re-login. Skip the token logout while the primary password is enterprise-managed; the rest of the teardown (TLS cache, connection pruning) still runs.