### PR TITLE
Bug 2054803 - Update FELT login and back button UX

### DIFF
--- a/toolkit/components/felt/content/felt.xhtml
+++ b/toolkit/components/felt/content/felt.xhtml
@@ -179,68 +179,6 @@
               >
               </span>
             </div>
-            <div class="felt-browser-error">
-              <moz-message-bar
-                class="felt-browser-error-multiple-crashes is-hidden"
-                data-l10n-id="felt-browser-error-multiple-crashes2"
-                type="error"
-                dismissable="true"
-              ></moz-message-bar>
-              <moz-message-bar
-                class="felt-browser-error-token-refresh-failed is-hidden"
-                data-l10n-id="felt-browser-error-token-refresh-failed"
-                type="info"
-              ></moz-message-bar>
-              <moz-message-bar
-                class="felt-browser-error-launch-failure is-hidden"
-                data-l10n-id="felt-browser-error-launch-failure"
-                type="error"
-                dismissable="true"
-              ></moz-message-bar>
-              <moz-message-bar
-                class="felt-error-primary-secret is-hidden"
-                data-l10n-id="felt-error-primary-secret"
-                type="error"
-                dismissable="true"
-              ></moz-message-bar>
-              <moz-message-bar
-                class="felt-browser-error-no-network is-hidden"
-                data-l10n-id="felt-browser-error-no-network"
-                type="error"
-                dismissable="true"
-              >
-                <span slot="message" class="felt-browser-error-details"></span>
-              </moz-message-bar>
-              <moz-message-bar
-                class="felt-browser-error-connection is-hidden"
-                data-l10n-id="felt-browser-error-connection2"
-                type="error"
-                dismissable="true"
-              >
-                <span slot="message" class="felt-browser-error-details"></span>
-              </moz-message-bar>
-              <moz-message-bar
-                class="felt-browser-error-sso-timeout is-hidden"
-                data-l10n-id="felt-browser-error-sso-timeout2"
-                type="error"
-                dismissable="true"
-              ></moz-message-bar>
-              <moz-message-bar
-                class="felt-updates-error-messages is-hidden"
-                data-l10n-id="felt-error-updates"
-                type="error"
-                dismissable="true"
-              >
-                <span slot="message" class="felt-browser-error-details"></span>
-              </moz-message-bar>
-              <moz-message-bar
-                class="felt-updates-warning-messages is-hidden"
-                type="warning"
-                dismissable="true"
-              >
-                <span slot="message" class="felt-browser-error-details"></span>
-              </moz-message-bar>
-            </div>
             <div class="felt-login__sso is-hidden">
               <browser
                 xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
@@ -265,6 +203,68 @@
             <span class="felt-version"></span>
             <span class="felt-powered-by" data-l10n-id="felt-powered-by"></span>
           </div>
+        </div>
+        <div class="felt-browser-error">
+          <moz-message-bar
+            class="felt-browser-error-multiple-crashes is-hidden"
+            data-l10n-id="felt-browser-error-multiple-crashes2"
+            type="error"
+            dismissable="true"
+          ></moz-message-bar>
+          <moz-message-bar
+            class="felt-browser-error-token-refresh-failed is-hidden"
+            data-l10n-id="felt-browser-error-token-refresh-failed"
+            type="info"
+          ></moz-message-bar>
+          <moz-message-bar
+            class="felt-browser-error-launch-failure is-hidden"
+            data-l10n-id="felt-browser-error-launch-failure"
+            type="error"
+            dismissable="true"
+          ></moz-message-bar>
+          <moz-message-bar
+            class="felt-error-primary-secret is-hidden"
+            data-l10n-id="felt-error-primary-secret"
+            type="error"
+            dismissable="true"
+          ></moz-message-bar>
+          <moz-message-bar
+            class="felt-browser-error-no-network is-hidden"
+            data-l10n-id="felt-browser-error-no-network"
+            type="error"
+            dismissable="true"
+          >
+            <span slot="message" class="felt-browser-error-details"></span>
+          </moz-message-bar>
+          <moz-message-bar
+            class="felt-browser-error-connection is-hidden"
+            data-l10n-id="felt-browser-error-connection2"
+            type="error"
+            dismissable="true"
+          >
+            <span slot="message" class="felt-browser-error-details"></span>
+          </moz-message-bar>
+          <moz-message-bar
+            class="felt-browser-error-sso-timeout is-hidden"
+            data-l10n-id="felt-browser-error-sso-timeout2"
+            type="error"
+            dismissable="true"
+          ></moz-message-bar>
+          <moz-message-bar
+            class="felt-updates-error-messages is-hidden"
+            data-l10n-id="felt-error-updates"
+            type="error"
+            dismissable="true"
+          >
+            <span slot="message" class="felt-browser-error-details"></span>
+          </moz-message-bar>
+          <moz-message-bar
+            class="felt-updates-warning-messages is-hidden"
+            type="warning"
+            dismissable="true"
+          >
+            <span slot="message" class="felt-browser-error-details"></span>
+          </moz-message-bar>
         </div>
       </div>
     </div>

--- a/toolkit/components/felt/content/felt.xhtml
+++ b/toolkit/components/felt/content/felt.xhtml
@@ -115,155 +115,157 @@
     </xul:box>
 
     <div class="felt">
-      <div class="felt-body">
-        <div class="felt-logo">
-          <div class="felt-logo__container"></div>
-        </div>
-        <div class="felt-updates is-hidden">
-          <div class="felt-updates-pane">
-            <img class="enterprise-wordmark" />
-            <div class="felt-updates__infos">
-              <h1
-                class="felt-updates__title"
-                data-l10n-id="felt-updates-title"
-              ></h1>
-              <div class="felt-updates-checking is-hidden">
-                <img class="felt-updates-spinner" />
-                <span
-                  class="felt-updates-checking-msg"
-                  data-l10n-id="felt-updates-checking"
-                >
-                </span>
-              </div>
-              <div class="felt-updates-application is-hidden">
-                <label
-                  class="felt-updates-application-msg"
-                  for="felt-updates-progress"
-                  data-l10n-id="felt-updates-application"
-                ></label>
-                <progress
-                  id="felt-updates-progress"
-                  max="100"
-                  value="0"
-                ></progress>
+      <div class="felt-logo">
+        <div class="felt-logo__container"></div>
+      </div>
+      <div class="felt-main">
+        <div class="felt-card">
+          <div class="felt-updates is-hidden">
+            <div class="felt-updates-pane">
+              <img class="enterprise-wordmark" />
+              <div class="felt-updates__infos">
+                <h1
+                  class="felt-updates__title"
+                  data-l10n-id="felt-updates-title"
+                ></h1>
+                <div class="felt-updates-checking is-hidden">
+                  <img class="felt-updates-spinner" />
+                  <span
+                    class="felt-updates-checking-msg"
+                    data-l10n-id="felt-updates-checking"
+                  >
+                  </span>
+                </div>
+                <div class="felt-updates-application is-hidden">
+                  <label
+                    class="felt-updates-application-msg"
+                    for="felt-updates-progress"
+                    data-l10n-id="felt-updates-application"
+                  ></label>
+                  <progress
+                    id="felt-updates-progress"
+                    max="100"
+                    value="0"
+                  ></progress>
+                </div>
               </div>
             </div>
           </div>
+          <div class="felt-login">
+            <div class="felt-login__email-pane">
+              <img class="enterprise-wordmark" />
+              <form class="felt-form">
+                <h1 class="felt-form__title" data-l10n-id="felt-sso-title"></h1>
+                <div class="felt-form__elements">
+                  <moz-input-text
+                    id="felt-form__email"
+                    data-l10n-id="felt-sso-input-email"
+                    class="fill-width"
+                  ></moz-input-text>
+                  <moz-button
+                    id="felt-form__sign-in-btn"
+                    data-l10n-id="felt-sso-continue-btn"
+                    type="primary"
+                    class="fill-width"
+                    disabled="true"
+                  ></moz-button>
+                </div>
+              </form>
+            </div>
+            <div class="felt-updates-message is-hidden">
+              <span
+                class="felt-updates-uptodate"
+                data-l10n-id="felt-updates-uptodate"
+              >
+              </span>
+            </div>
+            <div class="felt-browser-error">
+              <moz-message-bar
+                class="felt-browser-error-multiple-crashes is-hidden"
+                data-l10n-id="felt-browser-error-multiple-crashes2"
+                type="error"
+                dismissable="true"
+              ></moz-message-bar>
+              <moz-message-bar
+                class="felt-browser-error-token-refresh-failed is-hidden"
+                data-l10n-id="felt-browser-error-token-refresh-failed"
+                type="info"
+              ></moz-message-bar>
+              <moz-message-bar
+                class="felt-browser-error-launch-failure is-hidden"
+                data-l10n-id="felt-browser-error-launch-failure"
+                type="error"
+                dismissable="true"
+              ></moz-message-bar>
+              <moz-message-bar
+                class="felt-error-primary-secret is-hidden"
+                data-l10n-id="felt-error-primary-secret"
+                type="error"
+                dismissable="true"
+              ></moz-message-bar>
+              <moz-message-bar
+                class="felt-browser-error-no-network is-hidden"
+                data-l10n-id="felt-browser-error-no-network"
+                type="error"
+                dismissable="true"
+              >
+                <span slot="message" class="felt-browser-error-details"></span>
+              </moz-message-bar>
+              <moz-message-bar
+                class="felt-browser-error-connection is-hidden"
+                data-l10n-id="felt-browser-error-connection2"
+                type="error"
+                dismissable="true"
+              >
+                <span slot="message" class="felt-browser-error-details"></span>
+              </moz-message-bar>
+              <moz-message-bar
+                class="felt-browser-error-sso-timeout is-hidden"
+                data-l10n-id="felt-browser-error-sso-timeout2"
+                type="error"
+                dismissable="true"
+              ></moz-message-bar>
+              <moz-message-bar
+                class="felt-updates-error-messages is-hidden"
+                data-l10n-id="felt-error-updates"
+                type="error"
+                dismissable="true"
+              >
+                <span slot="message" class="felt-browser-error-details"></span>
+              </moz-message-bar>
+              <moz-message-bar
+                class="felt-updates-warning-messages is-hidden"
+                type="warning"
+                dismissable="true"
+              >
+                <span slot="message" class="felt-browser-error-details"></span>
+              </moz-message-bar>
+            </div>
+            <div class="felt-login__sso is-hidden">
+              <browser
+                xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
+                id="browser"
+                type="content"
+                disablehistory="true"
+                disableglobalhistory="true"
+                remote="true"
+                maychangeremoteness="true"
+              ></browser>
+            </div>
+          </div>
         </div>
-        <div class="felt-login">
-          <div class="felt-login__email-pane">
-            <img class="enterprise-wordmark" />
-            <form class="felt-form">
-              <h1 class="felt-form__title" data-l10n-id="felt-sso-title"></h1>
-              <div class="felt-form__elements">
-                <moz-input-text
-                  id="felt-form__email"
-                  data-l10n-id="felt-sso-input-email"
-                  class="fill-width"
-                ></moz-input-text>
-                <moz-button
-                  id="felt-form__sign-in-btn"
-                  data-l10n-id="felt-sso-continue-btn"
-                  type="primary"
-                  class="fill-width"
-                  disabled="true"
-                ></moz-button>
-              </div>
-            </form>
-          </div>
-          <div class="felt-updates-message is-hidden">
-            <span
-              class="felt-updates-uptodate"
-              data-l10n-id="felt-updates-uptodate"
-            >
-            </span>
-          </div>
-          <div class="felt-browser-error">
-            <moz-message-bar
-              class="felt-browser-error-multiple-crashes is-hidden"
-              data-l10n-id="felt-browser-error-multiple-crashes2"
-              type="error"
-              dismissable="true"
-            ></moz-message-bar>
-            <moz-message-bar
-              class="felt-browser-error-token-refresh-failed is-hidden"
-              data-l10n-id="felt-browser-error-token-refresh-failed"
-              type="info"
-            ></moz-message-bar>
-            <moz-message-bar
-              class="felt-browser-error-launch-failure is-hidden"
-              data-l10n-id="felt-browser-error-launch-failure"
-              type="error"
-              dismissable="true"
-            ></moz-message-bar>
-            <moz-message-bar
-              class="felt-error-primary-secret is-hidden"
-              data-l10n-id="felt-error-primary-secret"
-              type="error"
-              dismissable="true"
-            ></moz-message-bar>
-            <moz-message-bar
-              class="felt-browser-error-no-network is-hidden"
-              data-l10n-id="felt-browser-error-no-network"
-              type="error"
-              dismissable="true"
-            >
-              <span slot="message" class="felt-browser-error-details"></span>
-            </moz-message-bar>
-            <moz-message-bar
-              class="felt-browser-error-connection is-hidden"
-              data-l10n-id="felt-browser-error-connection2"
-              type="error"
-              dismissable="true"
-            >
-              <span slot="message" class="felt-browser-error-details"></span>
-            </moz-message-bar>
-            <moz-message-bar
-              class="felt-browser-error-sso-timeout is-hidden"
-              data-l10n-id="felt-browser-error-sso-timeout2"
-              type="error"
-              dismissable="true"
-            ></moz-message-bar>
-            <moz-message-bar
-              class="felt-updates-error-messages is-hidden"
-              data-l10n-id="felt-error-updates"
-              type="error"
-              dismissable="true"
-            >
-              <span slot="message" class="felt-browser-error-details"></span>
-            </moz-message-bar>
-            <moz-message-bar
-              class="felt-updates-warning-messages is-hidden"
-              type="warning"
-              dismissable="true"
-            >
-              <span slot="message" class="felt-browser-error-details"></span>
-            </moz-message-bar>
-          </div>
-          <div class="felt-login__sso is-hidden">
-            <browser
-              xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
-              id="browser"
-              type="content"
-              disablehistory="true"
-              disableglobalhistory="true"
-              remote="true"
-              maychangeremoteness="true"
-            ></browser>
+        <div class="felt-footer">
+          <button
+            id="felt-back-button"
+            class="is-hidden"
+            data-l10n-id="felt-back-button"
+            type="button"
+          ></button>
+          <div id="felt-footer-content">
+            <span class="felt-version"></span>
+            <span class="felt-powered-by" data-l10n-id="felt-powered-by"></span>
           </div>
         </div>
-      </div>
-      <div class="felt-footer">
-        <div id="felt-footer-content">
-          <span class="felt-version"></span>
-          <span class="felt-powered-by" data-l10n-id="felt-powered-by"></span>
-        </div>
-        <button
-          id="felt-back-button"
-          class="is-hidden"
-          data-l10n-id="felt-back-button"
-          type="button"
-        ></button>
       </div>
     </div>
   </body>

--- a/toolkit/components/felt/content/styles/felt-tokens.css
+++ b/toolkit/components/felt/content/styles/felt-tokens.css
@@ -24,5 +24,5 @@
 }
 
 :root {
-  --background-color-tabstrip: light-dark(var(--color-gray-20), var(--color-gray-90));
+  --felt-background-color-tabstrip: light-dark(var(--color-gray-20), var(--color-gray-90));
 }

--- a/toolkit/components/felt/content/styles/felt-tokens.css
+++ b/toolkit/components/felt/content/styles/felt-tokens.css
@@ -22,3 +22,7 @@
     --felt-update-checkmark-img-url: url("chrome://felt/content/assets/enterprise-update-checkmark-hcm.svg");
   }
 }
+
+:root {
+  --background-color-tabstrip: light-dark(var(--color-gray-20), var(--color-gray-90));
+}

--- a/toolkit/components/felt/content/styles/felt.css
+++ b/toolkit/components/felt/content/styles/felt.css
@@ -23,22 +23,36 @@ body {
 
 .felt {
   display: flex;
-  flex-direction: column;
   flex: 1 0 0;
   overflow: hidden;
-  background-image: var(--felt-logo-background-gradient);
-}
-
-.felt-body {
-  display: flex;
-  flex: 1 0 0;
 }
 
 .felt-logo {
   display: flex;
+  background-image: var(--felt-logo-background-gradient);
   overflow: hidden;
   flex-direction: column;
+  flex-shrink: 0;
   justify-content: center;
+}
+
+.felt-main {
+  display: flex;
+  flex-direction: column;
+  flex: 1 0 0;
+  /* stylelint-disable-next-line stylelint-plugin-mozilla/use-design-tokens */
+  background-color: var(--background-color-tabstrip);
+}
+
+.felt-card {
+  display: flex;
+  flex-direction: column;
+  flex: 1 0 0;
+  overflow: hidden;
+  position: relative;
+  background: var(--background-color-box);
+  border-radius: var(--card-border-radius);
+  margin: var(--space-large) var(--space-large) 0 var(--space-large);
 }
 
 .felt-logo__container {
@@ -206,8 +220,6 @@ moz-input-text::part(label) {
   display: flex;
   flex-grow: 1;
   /* stylelint-disable-next-line stylelint-plugin-mozilla/use-design-tokens */
-  width: 400px;
-  /* stylelint-disable-next-line stylelint-plugin-mozilla/use-design-tokens */
   padding: 60px 5px;
 }
 
@@ -219,29 +231,38 @@ moz-input-text::part(label) {
 
 .felt-footer {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  padding: 0 var(--space-medium) var(--space-xsmall);
+  padding: var(--space-medium) var(--space-large);
 }
 
 #felt-footer-content {
   display: flex;
   flex-direction: column;
+  align-items: end;
+  text-align: end;
+  margin-inline-start: auto;
   font-size: small;
-  /* On the blue footer gradient in both themes; must stay white. */
-  /* stylelint-disable-next-line stylelint-plugin-mozilla/use-design-tokens */
-  color: var(--color-white);
+  color: var(--text-color-deemphasized);
 }
 
 #felt-back-button {
   padding: 0;
   border: none;
   background: none;
-  /* On the blue footer gradient in both themes; must stay white. */
-  /* stylelint-disable-next-line stylelint-plugin-mozilla/use-design-tokens */
-  color: var(--color-white);
+  color: var(--link-color);
   font-size: small;
   text-decoration: underline;
+  cursor: pointer;
+}
+
+#felt-back-button::before {
+  content: "\2190";
+  display: inline-block;
+  margin-inline-end: var(--space-xsmall);
+}
+
+#felt-back-button:dir(rtl)::before {
+  content: "\2192";
 }
 
 .is-hidden {

--- a/toolkit/components/felt/content/styles/felt.css
+++ b/toolkit/components/felt/content/styles/felt.css
@@ -40,8 +40,9 @@ body {
   display: flex;
   flex-direction: column;
   flex: 1 0 0;
+  position: relative;
   /* stylelint-disable-next-line stylelint-plugin-mozilla/use-design-tokens */
-  background-color: var(--background-color-tabstrip);
+  background-color: var(--felt-background-color-tabstrip);
 }
 
 .felt-card {
@@ -74,7 +75,6 @@ body {
 .felt-updates {
   display: flex;
   flex-direction: column;
-  background: var(--background-color-box);
   flex: 1 0 0;
   justify-content: center;
   position: relative;


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2054803

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

Refresh the FELT login window layout and improve the back button UX based on the updated design.

- Reverts UX changes from #1137 
- Fixes the right pane visibly widening when moving from the email step to the SSO step due to added card margins
- Adds a `--background-color-tabstrip` token based on design

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on: #1137 

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

<img width="727" height="772" alt="FELT Login Page" src="https://github.com/user-attachments/assets/e384820b-aa0a-46e5-a0ca-b0c12e35c3f1" />

_FELT Login Page_

<img width="727" height="772" alt="FELT SSO Page" src="https://github.com/user-attachments/assets/86931fb2-0693-41f2-ac95-21b52c61986d" />

_FELT SSO Page_

<img width="723" height="775" alt="felt-back-button-ux-errors" src="https://github.com/user-attachments/assets/af7bb17b-a217-4030-b8f1-7c3a38e6a891" />

_FELT with multiple errors_

<img width="723" height="775" alt="felt-back-button-ux-updater" src="https://github.com/user-attachments/assets/5bbef757-d32d-4f4a-9e88-d151a488ef9b" />

_FELT with update checker_

<img width="723" height="775" alt="felt-back-button-ux-updater2" src="https://github.com/user-attachments/assets/f0d15202-bfbd-4790-badf-cac157f11f8f" />

_FELT with update downloader_

<img width="723" height="775" alt="felt-back-button-ux-updates-message" src="https://github.com/user-attachments/assets/a7d3b4ce-7873-4894-a4cf-8cf1fb722270" />

_FELT with updated message_