### PR TITLE
Bug 2054570 - Add progress indicator to FELT SSO browser panel

### DIFF
--- a/testing/enterprise/manifest.toml
+++ b/testing/enterprise/manifest.toml
@@ -154,6 +154,8 @@ run-if = [
 
 ["test_felt_starts_utf8.py"]
 
+["test_felt_status_panel.py"]
+
 ["test_felt_ui_scratch_reset.py"]
 disabled = "Bug 1996558: scaffolding for the Felt UI scratch-reset flow; not run in CI yet."
 

--- a/testing/enterprise/test_felt_status_panel.py
+++ b/testing/enterprise/test_felt_status_panel.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import os
+import sys
+
+sys.path.append(os.path.dirname(__file__))
+
+from felt_tests import FeltTests
+
+CONNECTING_STATUS = "Connecting to example.com…"
+
+
+class FeltStatusPanel(FeltTests):
+    """
+    Test the FELT SSO loading status box (bottom-left of the login pane):
+    it is hidden before signing in, renders a visible label when populated
+    via update(), is emptied by clear(), and is cleared once the SSO page
+    finishes loading.
+
+    The clear-after-load assertion guards against the network status (e.g.
+    "Transferring data from…") staying stuck after a page loads or while
+    background requests keep firing.
+    """
+
+    def teardown(self):
+        # The test never completes authentication, so no child browser to teardown.
+        self._manually_closed_child = True
+        super().teardown()
+
+    def _status_panel_hidden(self):
+        return not self.find_elem("#felt-statuspanel").is_displayed()
+
+    def test_felt_status_panel(self):
+        self._driver.set_context("chrome")
+        assert self._status_panel_hidden(), (
+            "Status panel is hidden before the user starts signing in"
+        )
+
+        # A live network status has no deterministic point to catch, so drive
+        # update()/clear() directly, as Firefox tests StatusPanel.
+        self._driver.execute_script(
+            "window.FeltStatusPanel.update(arguments[0]);", [CONNECTING_STATUS]
+        )
+        label = self.find_elem("#felt-statuspanel-label")
+        assert label.is_displayed(), "update() shows the panel"
+        assert label.text == CONNECTING_STATUS, "update() sets the label text"
+
+        self._driver.execute_script("window.FeltStatusPanel.clear();")
+        assert self._status_panel_hidden(), "clear() hides the panel"
+        self._driver.set_context("content")
+
+        self.run_felt_chrome_on_email_submit()
+        self.run_wait_until_sso_loaded()
+
+        self._driver.set_context("chrome")
+        self._wait.until(
+            lambda _: self._status_panel_hidden(),
+            message="Status panel is cleared once the SSO page finishes loading",
+        )
+        self._driver.set_context("content")

--- a/toolkit/components/felt/content/felt.xhtml
+++ b/toolkit/components/felt/content/felt.xhtml
@@ -191,6 +191,13 @@
               ></browser>
             </div>
           </div>
+          <div id="felt-statuspanel" class="is-hidden">
+            <span
+              id="felt-statuspanel-label"
+              role="status"
+              aria-live="off"
+            ></span>
+          </div>
         </div>
         <div class="felt-footer">
           <button

--- a/toolkit/components/felt/content/styles/felt.css
+++ b/toolkit/components/felt/content/styles/felt.css
@@ -265,6 +265,29 @@ moz-input-text::part(label) {
   content: "\2192";
 }
 
+#felt-statuspanel {
+  position: absolute;
+  bottom: 0;
+  inset-inline-start: 0;
+  max-width: 100%;
+  pointer-events: none;
+}
+
+#felt-statuspanel-label {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  padding: var(--space-xxsmall) var(--space-xsmall);
+  font-size: small;
+  color: var(--text-color);
+  background-color: var(--background-color-box);
+  border: 1px solid var(--border-color);
+  border-block-end: none;
+  border-inline-start: none;
+  border-start-end-radius: var(--border-radius-small);
+}
+
 .is-hidden {
   display: none !important;
 }

--- a/toolkit/components/felt/content/window.js
+++ b/toolkit/components/felt/content/window.js
@@ -28,6 +28,28 @@ Services.obs.notifyObservers(window, "browser-delayed-startup-finished");
 
 let cancelActiveSso = null;
 
+// define as a var so it is exposed as window.FeltStatusPanel for the marionette test
+var FeltStatusPanel = {
+  get _panel() {
+    return document.getElementById("felt-statuspanel");
+  },
+  get _label() {
+    return document.getElementById("felt-statuspanel-label");
+  },
+  update(text) {
+    if (text) {
+      this._label.textContent = text;
+      this._panel.classList.remove("is-hidden");
+    } else {
+      this._panel.classList.add("is-hidden");
+      this._label.textContent = "";
+    }
+  },
+  clear() {
+    this.update("");
+  },
+};
+
 function clearSsoSessionData() {
   return new Promise(resolve => {
     Services.clearData.deleteDataFromOriginAttributesPattern(
@@ -39,6 +61,7 @@ function clearSsoSessionData() {
 
 function resetToLoginPage() {
   cancelActiveSso?.();
+  FeltStatusPanel.clear();
   document.querySelector(".felt-login__sso").classList.add("is-hidden");
   document
     .querySelector(".felt-login__email-pane")
@@ -142,6 +165,9 @@ async function connectToConsole(email) {
         return;
       }
 
+      // Clear status panel. onStatusChange stops firing once the load stops.
+      FeltStatusPanel.clear();
+
       const uri = webProgress.browsingContext?.currentWindowGlobal?.documentURI;
       if (!uri || !callbackPattern.matches(uri.spec)) {
         return;
@@ -191,6 +217,14 @@ async function connectToConsole(email) {
       }
     },
 
+    onStatusChange(_webProgress, _request, _status, message) {
+      if (browser.webProgress.isLoadingDocument) {
+        FeltStatusPanel.update(message);
+      } else {
+        FeltStatusPanel.clear();
+      }
+    },
+
     onLocationChange(_webProgress, _request, _location, flags) {
       if (flags & Ci.nsIWebProgressListener.LOCATION_CHANGE_ERROR_PAGE) {
         clearTimeout(ssoTimeout);
@@ -209,7 +243,9 @@ async function connectToConsole(email) {
   };
   browser.addProgressListener(
     progressListener,
-    Ci.nsIWebProgress.NOTIFY_STATE_NETWORK | Ci.nsIWebProgress.NOTIFY_LOCATION
+    Ci.nsIWebProgress.NOTIFY_STATE_NETWORK |
+      Ci.nsIWebProgress.NOTIFY_LOCATION |
+      Ci.nsIWebProgress.NOTIFY_STATUS
   );
 
   lazy.FeltErrorReport.reset();

--- a/toolkit/components/felt/content/window.js
+++ b/toolkit/components/felt/content/window.js
@@ -28,8 +28,7 @@ Services.obs.notifyObservers(window, "browser-delayed-startup-finished");
 
 let cancelActiveSso = null;
 
-// define as a var so it is exposed as window.FeltStatusPanel for the marionette test
-var FeltStatusPanel = {
+const FeltStatusPanel = {
   get _panel() {
     return document.getElementById("felt-statuspanel");
   },
@@ -296,6 +295,8 @@ function informAboutPotentialStartupFailure() {
 
 function setupMarionetteEnvironment() {
   window.fullScreen = false;
+
+  window.FeltStatusPanel = FeltStatusPanel;
 
   window.FullScreen = {
     exitDomFullScreen() {},


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2054570

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

Adds a status panel to the bottom left corner of the FELT SSO login pane that shows the network progress (ex: `Connecting to...`, `Transferring data from...`) while the SSO browser is loading a page. This mirrors Firefox's behavior and gives users feedback when page load is slower.

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

<img width="723" height="775" alt="felt-statuspanel" src="https://github.com/user-attachments/assets/42d9cc24-453c-4e87-8036-733ca87cc95b" />

_FELT with status panel_

---

### Testing <!-- OPTIONAL -->

* [x] Added tests
* [x] Manual testing performed


**Steps to verify changes:**

1. Launch FELT
2. Progress through login flow

**Expected result:**

Statusbar in bottom left shows progress updates as they fire.