### PR TITLE
Uplift Crash Reporter policy fixes

### DIFF
--- a/browser/base/content/aboutTabCrashed.js
+++ b/browser/base/content/aboutTabCrashed.js
@@ -149,7 +149,7 @@ var AboutTabCrashed = {
     let data = message.data;
 
     if (data.hasReport || data.policyAutoSubmit) {
-      this.hasReport = !data.policyAutoSubmit;
+      this.hasReport = data.hasReport;
       document.documentElement.classList.add("crashDumpAvailable");
 
       document.getElementById("sendReport").checked = data.sendReport;

--- a/browser/base/content/test/tabcrashed/browser.toml
+++ b/browser/base/content/test/tabcrashed/browser.toml
@@ -21,6 +21,11 @@ skip-if = [
   "true", # Bug 1383315
 ]
 
+["browser_policyDisabled.js"]
+run-if = [
+  "enterprise",
+]
+
 ["browser_printpreview_crash.js"]
 https_first_disabled = true
 

--- a/browser/base/content/test/tabcrashed/browser_policyDisabled.js
+++ b/browser/base/content/test/tabcrashed/browser_policyDisabled.js
@@ -1,0 +1,95 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+const PAGE =
+  "data:text/html,<html><body>A%20regular,%20everyday,%20normal%20page.";
+
+const { EnterprisePolicyTesting, PoliciesPrefTracker } =
+  ChromeUtils.importESModule(
+    "resource://testing-common/EnterprisePolicyTesting.sys.mjs"
+  );
+
+const { TabStateFlusher } = ChromeUtils.importESModule(
+  "resource:///modules/sessionstore/TabStateFlusher.sys.mjs"
+);
+
+// On debug builds, crashing tabs results in much thinking, which
+// slows down the test and results in intermittent test timeouts,
+// so we'll pump up the expected timeout for this test.
+requestLongerTimeout(2);
+
+/**
+ * When the CrashReportsSubmit.Enabled enterprise policy is set to false,
+ * the about:tabcrashed page must not surface any crash report submission UI
+ * and TabCrashHandler.maybeSendCrashReport must short-circuit before
+ * invoking CrashSubmit.submit.
+ */
+add_task(async function test_policyDisabled_hides_report_ui() {
+  PoliciesPrefTracker.start();
+  await EnterprisePolicyTesting.setupPolicyEngineWithJson({
+    policies: {
+      CrashReportsSubmit: {
+        Enabled: false,
+      },
+    },
+  });
+
+  let submitCalls = 0;
+  let { CrashSubmit } = ChromeUtils.importESModule(
+    "resource://gre/modules/CrashSubmit.sys.mjs"
+  );
+  let originalSubmit = CrashSubmit.submit;
+  CrashSubmit.submit = function () {
+    submitCalls++;
+    return Promise.resolve();
+  };
+
+  registerCleanupFunction(async () => {
+    CrashSubmit.submit = originalSubmit;
+    await EnterprisePolicyTesting.setupPolicyEngineWithJson("");
+    PoliciesPrefTracker.stop();
+  });
+
+  await BrowserTestUtils.withNewTab(
+    {
+      gBrowser,
+      url: PAGE,
+    },
+    async function (browser) {
+      // Make sure we've flushed the browser messages so that
+      // we can restore it.
+      await TabStateFlusher.flush(browser);
+
+      await BrowserTestUtils.crashFrame(browser);
+
+      let doc = browser.contentDocument;
+
+      Assert.ok(
+        !doc.documentElement.classList.contains("crashDumpAvailable"),
+        "crashDumpAvailable class should not be set under the Disabled policy"
+      );
+
+      let options = doc.getElementById("options");
+      Assert.ok(
+        options.hidden,
+        "Report submission options should be hidden under the Disabled policy"
+      );
+
+      // Send a restoreTab message; even with sendReport true in the UI's
+      // hypothetical state, maybeSendCrashReport must not invoke CrashSubmit.
+      doc.getElementById("sendReport").checked = true;
+      let restoreButton = doc.getElementById("restoreTab");
+      restoreButton.click();
+
+      await BrowserTestUtils.browserLoaded(browser, false, PAGE);
+
+      Assert.equal(
+        submitCalls,
+        0,
+        "CrashSubmit.submit must not be invoked while the Disabled policy is active"
+      );
+    }
+  );
+});

--- a/browser/components/enterprisepolicies/Policies.sys.mjs
+++ b/browser/components/enterprisepolicies/Policies.sys.mjs
@@ -1107,30 +1107,65 @@ export var Policies = {
 
   CrashReportsSubmit: {
     onBeforeAddons(_manager, param) {
-      if (param.ForceAutoSubmit) {
-        setAndLockPref("browser.crashReports.unsubmittedCheck.enabled", true);
-        setAndLockPref(
-          "browser.crashReports.unsubmittedCheck.autoSubmit2",
-          true
-        );
-        setAndLockPref("browser.tabs.crashReporting.sendReport", true);
-        setAndLockPref("browser.tabs.crashReporting.includeURL", true);
-        Services.env.set("MOZ_CRASHREPORTER_POLICY_AUTO_SUBMIT", "1");
+      if ("Enabled" in param) {
+        if (param.Enabled) {
+          setAndLockPref(
+            "browser.crashReports.unsubmittedCheck.autoSubmit2",
+            true
+          );
+          setAndLockPref("browser.tabs.crashReporting.sendReport", true);
+          setAndLockPref("browser.crashReports.unsubmittedCheck.enabled", true);
+          setAndLockPref("browser.tabs.crashReporting.includeURL", true);
+          setEnvVar("MOZ_CRASHREPORTER_NO_REPORT", "");
+          setEnvVar("MOZ_CRASHREPORTER_POLICY_AUTO_SUBMIT", "1");
+        } else {
+          setAndLockPref(
+            "browser.crashReports.unsubmittedCheck.autoSubmit2",
+            false
+          );
+          setAndLockPref("browser.tabs.crashReporting.sendReport", false);
+          setAndLockPref(
+            "browser.crashReports.unsubmittedCheck.enabled",
+            false
+          );
+          unsetAndUnlockPref("browser.tabs.crashReporting.includeURL");
+          setEnvVar("MOZ_CRASHREPORTER_NO_REPORT", "1");
+          setEnvVar("MOZ_CRASHREPORTER_POLICY_AUTO_SUBMIT", "");
+        }
       } else {
-        // if ForceAutoSubmit is unset or is false
-        unsetAndUnlockPref("browser.crashReports.unsubmittedCheck.enabled");
         unsetAndUnlockPref("browser.crashReports.unsubmittedCheck.autoSubmit2");
         unsetAndUnlockPref("browser.tabs.crashReporting.sendReport");
+        unsetAndUnlockPref("browser.crashReports.unsubmittedCheck.enabled");
         unsetAndUnlockPref("browser.tabs.crashReporting.includeURL");
-        Services.env.set("MOZ_CRASHREPORTER_POLICY_AUTO_SUBMIT", "");
+        unsetEnvVar("MOZ_CRASHREPORTER_POLICY_AUTO_SUBMIT");
+        unsetEnvVar("MOZ_CRASHREPORTER_NO_REPORT");
+      }
+      // The crash callback reads a cached, signal-safe atomic; tell it to
+      // re-read the env vars now that we've changed them.
+      try {
+        Services.appinfo
+          .QueryInterface(Ci.nsICrashReporter)
+          .updateShouldReport();
+      } catch (e) {
+        // nsICrashReporter is unavailable in builds without the crash reporter.
       }
     },
     onRemove(_manager, _oldParams) {
-      unsetAndUnlockPref("browser.crashReports.unsubmittedCheck.enabled");
       unsetAndUnlockPref("browser.crashReports.unsubmittedCheck.autoSubmit2");
       unsetAndUnlockPref("browser.tabs.crashReporting.sendReport");
+      unsetAndUnlockPref("browser.crashReports.unsubmittedCheck.enabled");
       unsetAndUnlockPref("browser.tabs.crashReporting.includeURL");
-      Services.env.set("MOZ_CRASHREPORTER_POLICY_AUTO_SUBMIT", "");
+      unsetEnvVar("MOZ_CRASHREPORTER_POLICY_AUTO_SUBMIT");
+      unsetEnvVar("MOZ_CRASHREPORTER_NO_REPORT");
+      // The crash callback reads a cached, signal-safe atomic; tell it to
+      // re-read the env vars now that we've changed them.
+      try {
+        Services.appinfo
+          .QueryInterface(Ci.nsICrashReporter)
+          .updateShouldReport();
+      } catch (e) {
+        // nsICrashReporter is unavailable in builds without the crash reporter.
+      }
     },
   },
 
@@ -3929,6 +3964,20 @@ export function setAndLockPref(prefName, prefValue) {
 }
 
 /**
+ * setEnvVar
+ *
+ * Sets the value of an environment variable.
+ *
+ * @param {string} envVarName
+ *        The environment variable to be changed
+ * @param {string} envVarValue
+ *        The value to set the environment variable to
+ */
+export function setEnvVar(envVarName, envVarValue) {
+  PoliciesUtils.setEnvVar(envVarName, envVarValue);
+}
+
+/**
  * unsetAndUnlockPref
  *
  * Unsets the _default_ value of a pref, and unlocks it (meaning that
@@ -3939,6 +3988,19 @@ export function setAndLockPref(prefName, prefValue) {
  */
 export function unsetAndUnlockPref(prefName) {
   PoliciesUtils.unsetDefaultPref(prefName);
+}
+
+/**
+ * unsetEnvVar
+ *
+ * Unsets the value of an environment variable,
+ * restoring it to the value before any policy modification.
+ *
+ * @param {string} envVarName
+ *        The environment variable to be changed
+ */
+export function unsetEnvVar(envVarName) {
+  PoliciesUtils.unsetEnvVar(envVarName);
 }
 
 /**
@@ -3974,8 +4036,11 @@ export var PoliciesUtils = {
    * @property {boolean} isLocked - whether the preference is locked
    */
 
-  /** @type {PreferenceState} */
+  /** @type {{[key: string]: PreferenceState}} */
   _initialPrefState: {},
+
+  /** @type {{[key: string]: string}} */
+  _initialEnvVarState: {},
 
   /**
    * Reads a typed preference value from the given branch, returning null when
@@ -4052,6 +4117,22 @@ export var PoliciesUtils = {
   },
 
   /**
+   * Saves the current value of an env var before a policy changes it.
+   * No-op if the env var was already saved.
+   *
+   * @param {string} envVarName
+   */
+  saveEnvVarState(envVarName) {
+    if (envVarName in this._initialEnvVarState) {
+      return;
+    }
+
+    const envVarValue = Services.env.get(envVarName);
+
+    this._initialEnvVarState[envVarName] = envVarValue;
+  },
+
+  /**
    * Restores the preference to the state before any policy was applied. The user
    * value of a preference is only restored if the preference was locked by the policy
    * or was locked even before
@@ -4103,6 +4184,25 @@ export var PoliciesUtils = {
         this._writePref(Services.prefs, prefName, type, prefState.userValue);
       }
     }
+  },
+
+  /**
+   * Restores the value of an env var to the state before any policy was applied,
+   * or "" if it didn't exist before.
+   * No-op if no state was saved for the env var.
+   *
+   * @param {string} envVarName
+   */
+  restoreEnvVarState(envVarName) {
+    if (!(envVarName in this._initialEnvVarState)) {
+      // Nothing to restore
+      return;
+    }
+
+    const envVarValue = this._initialEnvVarState[envVarName];
+    Services.env.set(envVarName, envVarValue);
+
+    delete this._initialEnvVarState[envVarName];
   },
 
   /**
@@ -4167,6 +4267,23 @@ export var PoliciesUtils = {
   },
 
   /**
+   * setEnvVar
+   *
+   * Sets the value of an env var and stores the prior value
+   * so it can be restored.
+   *
+   * @param {string} envVarName
+   *        The env var to be changed
+   * @param {string} envVarValue
+   *        The value to set
+   */
+  setEnvVar(envVarName, envVarValue) {
+    this.saveEnvVarState(envVarName);
+
+    Services.env.set(envVarName, envVarValue);
+  },
+
+  /**
    * unsetDefaultPref
    *
    * Unsets the _default_ value of a pref and unlock it if it was locked.
@@ -4181,6 +4298,18 @@ export var PoliciesUtils = {
     }
 
     this.restorePreferenceState(prefName);
+  },
+
+  /**
+   * unsetEnvVar
+   *
+   * Restores the env var to its previous state, or "" if it didn't exist before.
+   *
+   * @param {string} envVarName
+   *        The env var to be changed
+   */
+  unsetEnvVar(envVarName) {
+    this.restoreEnvVarState(envVarName);
   },
 };
 

--- a/browser/components/enterprisepolicies/schemas/policies-schema.json
+++ b/browser/components/enterprisepolicies/schemas/policies-schema.json
@@ -850,13 +850,16 @@
       "description": "Configure crash report submission settings.",
       "examples": [
         {
-          "ForceAutoSubmit": true
+          "Enabled": false
+        },
+        {
+          "Enabled": true
         }
       ],
       "x-category": "Cloud reporting",
       "type": "object",
       "properties": {
-        "ForceAutoSubmit": {
+        "Enabled": {
           "type": "boolean"
         }
       }

--- a/browser/components/enterprisepolicies/tests/xpcshell/test_simple_pref_policies.js
+++ b/browser/components/enterprisepolicies/tests/xpcshell/test_simple_pref_policies.js
@@ -1374,9 +1374,56 @@ const POLICIES_TESTS = [
       "browser.tabs.groups.smart.userEnabled": false,
     },
   },
+
+  // CrashReportsSubmit - enabled
+  {
+    policies: {
+      CrashReportsSubmit: {
+        Enabled: true,
+      },
+    },
+    lockedPrefs: {
+      "browser.tabs.crashReporting.sendReport": true,
+      "browser.tabs.crashReporting.includeURL": true,
+      "browser.crashReports.unsubmittedCheck.enabled": true,
+      "browser.crashReports.unsubmittedCheck.autoSubmit2": true,
+    },
+    env: {
+      MOZ_CRASHREPORTER_NO_REPORT: "",
+      MOZ_CRASHREPORTER_POLICY_AUTO_SUBMIT: "1",
+    },
+  },
+
+  // CrashReportsSubmit - disabled
+  {
+    policies: {
+      CrashReportsSubmit: {
+        Enabled: false,
+      },
+    },
+    lockedPrefs: {
+      "browser.tabs.crashReporting.sendReport": false,
+      "browser.crashReports.unsubmittedCheck.enabled": false,
+      "browser.crashReports.unsubmittedCheck.autoSubmit2": false,
+    },
+    env: {
+      MOZ_CRASHREPORTER_NO_REPORT: "1",
+      MOZ_CRASHREPORTER_POLICY_AUTO_SUBMIT: "",
+    },
+  },
 ];
 
 add_task(async function test_policy_simple_prefs() {
+  // The test harness sets MOZ_CRASHREPORTER_NO_REPORT, which disables crash
+  // reports.  This test doesn't do crashes, but changes the env variable
+  // as part of a policy, so clear the env variable to a clean slate at the
+  // start of the test.
+  let noReport = Services.env.get("MOZ_CRASHREPORTER_NO_REPORT");
+  Services.env.set("MOZ_CRASHREPORTER_NO_REPORT", "");
+  registerCleanupFunction(function () {
+    Services.env.set("MOZ_CRASHREPORTER_NO_REPORT", noReport);
+  });
+
   for (let test of POLICIES_TESTS) {
     await setupPolicyEngineWithJson({
       policies: test.policies,
@@ -1392,6 +1439,14 @@ add_task(async function test_policy_simple_prefs() {
       test.unlockedPrefs || {}
     )) {
       checkUnlockedPref(prefName, prefValue);
+    }
+
+    for (let [envName, envValue] of Object.entries(test.env || {})) {
+      equal(
+        Services.env.get(envName),
+        envValue,
+        `Env var ${envName} should be "${envValue}"`
+      );
     }
   }
 });

--- a/browser/modules/ContentCrashHandlers.sys.mjs
+++ b/browser/modules/ContentCrashHandlers.sys.mjs
@@ -78,6 +78,21 @@ class BrowserWeakMap extends WeakMap {
   }
 }
 
+function reportSubmissionDisabledByPolicy() {
+  return (
+    AppConstants.MOZ_ENTERPRISE &&
+    Services.policies?.getActivePolicies()?.CrashReportsSubmit?.Enabled ===
+      false
+  );
+}
+
+function reportSubmissionForcedByPolicy() {
+  return (
+    AppConstants.MOZ_ENTERPRISE &&
+    Services.policies?.getActivePolicies()?.CrashReportsSubmit?.Enabled === true
+  );
+}
+
 export var TabCrashHandler = {
   _crashedTabCount: 0,
   childMap: new Map(),
@@ -539,10 +554,7 @@ export var TabCrashHandler = {
    *        The browser that has recently crashed.
    */
   sendToTabCrashedPage(browser) {
-    if (
-      AppConstants.MOZ_CRASHREPORTER &&
-      Services.policies.getActivePolicies()?.CrashReportsSubmit?.ForceAutoSubmit
-    ) {
+    if (AppConstants.MOZ_CRASHREPORTER && reportSubmissionForcedByPolicy()) {
       let dumpID = this.getDumpID(browser);
       if (dumpID) {
         lazy.CrashSubmit.submit(dumpID, lazy.CrashSubmit.SUBMITTED_FROM_AUTO);
@@ -589,6 +601,10 @@ export var TabCrashHandler = {
    */
   maybeSendCrashReport(browser, message) {
     if (!AppConstants.MOZ_CRASHREPORTER) {
+      return;
+    }
+
+    if (reportSubmissionDisabledByPolicy()) {
       return;
     }
 
@@ -697,12 +713,17 @@ export var TabCrashHandler = {
       this.unseenCrashedChildIDs.splice(index, 1);
     }
 
+    if (reportSubmissionDisabledByPolicy()) {
+      return {
+        hasReport: false,
+      };
+    }
+
     let dumpID = this.getDumpID(browser);
-    let policyAutoSubmit =
-      !!Services.policies.getActivePolicies()?.CrashReportsSubmit
-        ?.ForceAutoSubmit;
-    // When ForceAutoSubmit is active, the crash report is submitted automatically
-    // at crash time, so no dumpID is available. Allow the flow to continue.
+    let policyAutoSubmit = reportSubmissionForcedByPolicy();
+    // When CrashReportsSubmit.Enabled is set to true,
+    // the crash report is submitted automatically at crash time,
+    // so no dumpID is available. Allow the flow to continue.
     if (!dumpID && !policyAutoSubmit) {
       return {
         hasReport: false,
@@ -713,8 +734,9 @@ export var TabCrashHandler = {
     let sendReport = this.prefs.getBoolPref("sendReport");
     let includeURL = this.prefs.getBoolPref("includeURL");
 
-    // With ForceAutoSubmit, the report was already submitted so we skip the
-    // normal report UI, but still signal the policy state to the crash page.
+    // With CrashReportsSubmit.Enabled set to true,
+    // the report was already submitted so we skip the normal report UI,
+    // but still signal the policy state to the crash page.
     if (policyAutoSubmit) {
       return {
         hasReport: false,

--- a/toolkit/components/crashes/CrashManager.in.sys.mjs
+++ b/toolkit/components/crashes/CrashManager.in.sys.mjs
@@ -118,6 +118,14 @@ async function cleanupPings() {
   return exitCode === 0;
 }
 
+function reportSubmissionDisabledByPolicy() {
+  return (
+    AppConstants.MOZ_ENTERPRISE &&
+    Services.policies?.getActivePolicies()?.CrashReportsSubmit?.Enabled ===
+      false
+  );
+}
+
 /**
  * A gateway to crash-related data.
  *
@@ -469,7 +477,11 @@ CrashManager.prototype = Object.freeze({
       let offset = this.PURGE_OLDER_THAN_DAYS * MILLISECONDS_IN_DAY;
       await this.pruneOldCrashes(new Date(Date.now() - offset));
 
-      if (AppConstants.platform !== "android" && !this._disableGleanPing) {
+      if (
+        !reportSubmissionDisabledByPolicy() &&
+        AppConstants.platform !== "android" &&
+        !this._disableGleanPing
+      ) {
         this._cleanupPingsResult = await cleanupPings().catch(error => {
           // The pipes can race (especially if the program exits quickly) and
           // throw File closed. Don't treat it as an error.
@@ -794,6 +806,7 @@ CrashManager.prototype = Object.freeze({
       true
     );
     if (
+      !reportSubmissionDisabledByPolicy() &&
       telemetryEnabled &&
       AppConstants.platform !== "android" &&
       !this._disableGleanPing
@@ -815,6 +828,9 @@ CrashManager.prototype = Object.freeze({
       // is passed the ping data (if applicable). This _doesn't_ mean the ping
       // was received by the telemetry server. We rely on the crashreporter
       // client's Glean instance to handle reliable delivery.
+      // When CrashReportsSubmit.Enabled is set to false we deliberately
+      // skip the send above but still mark as submitted so the ping is not
+      // retried forever; the admin chose not to deliver this data.
       store.setPingSubmitted(crashId);
     }
   },

--- a/toolkit/components/crashes/tests/xpcshell/test_crash_manager_policies.js
+++ b/toolkit/components/crashes/tests/xpcshell/test_crash_manager_policies.js
@@ -1,0 +1,126 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+const { TelemetryArchiveTesting } = ChromeUtils.importESModule(
+  "resource://testing-common/TelemetryArchiveTesting.sys.mjs"
+);
+const { configureLogging, getManager } = ChromeUtils.importESModule(
+  "resource://testing-common/CrashManagerTest.sys.mjs"
+);
+const { makeFakeAppDir } = ChromeUtils.importESModule(
+  "resource://testing-common/AppData.sys.mjs"
+);
+const { EnterprisePolicyTesting } = ChromeUtils.importESModule(
+  "resource://testing-common/EnterprisePolicyTesting.sys.mjs"
+);
+
+// Initialize the policy engine for xpcshell
+let policies = Cc["@mozilla.org/enterprisepolicies;1"].getService(
+  Ci.nsIObserver
+);
+policies.observe(null, "policies-startup", null);
+
+const DUMMY_DATE = new Date(Date.now() - 10 * 24 * 60 * 60 * 1000);
+DUMMY_DATE.setMilliseconds(0);
+
+function run_test() {
+  do_get_profile();
+  configureLogging();
+  TelemetryArchiveTesting.setup();
+  // Initialize FOG for glean tests
+  Services.fog.initializeFOG();
+
+  // We need a UAppData directory for the glean store.
+  //
+  // We use `do_test_pending()`/`do_test_finished()` because `run_test()` must
+  // not return until all tests are complete.
+  do_test_pending();
+  makeFakeAppDir().then(() => {
+    run_next_test();
+    do_test_finished();
+  });
+}
+
+add_task(async function test_schedule_maintenance_policyDisabled() {
+  await EnterprisePolicyTesting.setupPolicyEngineWithJson({
+    policies: {
+      CrashReportsSubmit: {
+        Enabled: false,
+      },
+    },
+  });
+
+  try {
+    let m = await getManager();
+    m._disableGleanPing = false;
+    await m.createEventsFile("1", "crash.main.3", DUMMY_DATE, "id1", "{}");
+
+    let oldDate = new Date(
+      Date.now() - m.PURGE_OLDER_THAN_DAYS * 2 * 24 * 60 * 60 * 1000
+    );
+    await m.createEventsFile("2", "crash.main.3", oldDate, "id2", "{}");
+
+    await m.scheduleMaintenance(25);
+
+    // The aggregate / prune phases of maintenance must still run.
+    let crashes = await m.getCrashes();
+    Assert.equal(crashes.length, 1);
+    Assert.equal(crashes[0].id, "id1");
+
+    // But cleanupPings must be skipped: the helper is never invoked, so the
+    // result property stays undefined.
+    Assert.strictEqual(
+      m._cleanupPingsResult,
+      undefined,
+      "cleanupPings must not run while CrashReportsSubmit.Enabled is set to false"
+    );
+  } finally {
+    await EnterprisePolicyTesting.setupPolicyEngineWithJson("");
+  }
+});
+
+add_task(async function test_sendUnsubmittedPings_policyDisabled() {
+  await EnterprisePolicyTesting.setupPolicyEngineWithJson({
+    policies: {
+      CrashReportsSubmit: {
+        Enabled: false,
+      },
+    },
+  });
+
+  try {
+    let m = await getManager();
+    let store = await m._getStore();
+    store.addCrash(
+      m.processTypes[Ci.nsIXULRuntime.PROCESS_TYPE_DEFAULT],
+      m.CRASH_TYPE_CRASH,
+      "policy-disabled-crash",
+      DUMMY_DATE,
+      {}
+    );
+
+    {
+      const crashes = store.crashesWithoutPingSubmissions();
+      Assert.equal(crashes.length, 1);
+      Assert.equal(crashes[0].id, "policy-disabled-crash");
+    }
+
+    m._disableGleanPing = false;
+
+    await m.sendUnsubmittedPings();
+    Assert.equal(
+      m._gleanPingPromise,
+      null,
+      "Should not enqueue a Glean ping while CrashReportsSubmit.Enabled is set to false"
+    );
+    Assert.equal(
+      store.crashesWithoutPingSubmissions().length,
+      0,
+      "Pings under the Disabled policy must still be marked submitted to avoid endless retries"
+    );
+  } finally {
+    await EnterprisePolicyTesting.setupPolicyEngineWithJson("");
+  }
+});

--- a/toolkit/components/crashes/tests/xpcshell/xpcshell.toml
+++ b/toolkit/components/crashes/tests/xpcshell/xpcshell.toml
@@ -10,6 +10,13 @@ skip-if = [
   "os == 'android'",
 ]
 
+["test_crash_manager_policies.js"]
+run-if = ["enterprise"]
+skip-if = [
+  "os == 'android'",
+]
+firefox-appdir = "browser"
+
 ["test_crash_service.js"]
 skip-if = [
   "os == 'android'",

--- a/toolkit/crashreporter/client/app/src/logic.rs
+++ b/toolkit/crashreporter/client/app/src/logic.rs
@@ -700,7 +700,10 @@ impl ReportCrash {
     /// Form the extra data, taking into account user input.
     fn current_extra_data(&self) -> serde_json::Value {
         let include_address = self.settings.borrow().include_url;
-        let comment = if !self.config.auto_submit {
+        let get_comment = !self.config.auto_submit;
+        #[cfg(feature = "enterprise")]
+        let get_comment = get_comment && !self.config.policy_auto_submit;
+        let comment = if get_comment {
             self.ui().wait(|r| r.comment.get())
         } else {
             Default::default()

--- a/toolkit/crashreporter/content/crashes.js
+++ b/toolkit/crashreporter/content/crashes.js
@@ -10,7 +10,16 @@ const { CrashReports } = ChromeUtils.importESModule(
 
 ChromeUtils.defineESModuleGetters(this, {
   CrashSubmit: "resource://gre/modules/CrashSubmit.sys.mjs",
+  AppConstants: "resource://gre/modules/AppConstants.sys.mjs",
 });
+
+function reportSubmissionDisabledByPolicy() {
+  return (
+    AppConstants.MOZ_ENTERPRISE &&
+    Services.policies?.getActivePolicies()?.CrashReportsSubmit?.Enabled ===
+      false
+  );
+}
 
 document.addEventListener("DOMContentLoaded", () => {
   populateReportLists();
@@ -50,6 +59,10 @@ function populateReportLists() {
   if (!reportURL) {
     document.getElementById("noConfig").classList.remove("hidden");
     return;
+  }
+
+  if (reportSubmissionDisabledByPolicy()) {
+    document.getElementById("submitAllUnsubmittedReports").hidden = true;
   }
 
   const reports = CrashReports.getReports();
@@ -95,15 +108,17 @@ function addReportRow(isPending, isIgnored, id, date, dateFormatter) {
     if (isIgnored) {
       row.classList.add("ignored");
     }
-    const buttonTemplate = document.getElementById("crashSubmitButton");
-    const button = document
-      .importNode(buttonTemplate.content, true)
-      .querySelector("button");
-    const buttonText = button.querySelector("span");
-    button.addEventListener("click", () =>
-      submitPendingReport(id, row, button, buttonText, dateFormatter)
-    );
-    cells[2].appendChild(button);
+    if (!reportSubmissionDisabledByPolicy()) {
+      const buttonTemplate = document.getElementById("crashSubmitButton");
+      const button = document
+        .importNode(buttonTemplate.content, true)
+        .querySelector("button");
+      const buttonText = button.querySelector("span");
+      button.addEventListener("click", () =>
+        submitPendingReport(id, row, button, buttonText, dateFormatter)
+      );
+      cells[2].appendChild(button);
+    }
     document.getElementById("unsubmitted").appendChild(row);
   } else {
     const linkTemplate = document.getElementById("viewCrashLink");
@@ -152,6 +167,9 @@ function showAppropriateSections() {
  * @param {object}              dateFormatter formatter for presenting dates to users
  */
 function submitPendingReport(reportId, row, button, buttonText, dateFormatter) {
+  if (reportSubmissionDisabledByPolicy()) {
+    return;
+  }
   button.classList.add("submitting");
   document.getElementById("submitAllUnsubmittedReports").disabled = true;
   CrashSubmit.submit(reportId, CrashSubmit.SUBMITTED_FROM_ABOUT_CRASHES, {
@@ -211,6 +229,9 @@ async function clearUnsubmittedReports() {
  * and add them to submitted crash reports.
  */
 async function submitAllUnsubmittedReports() {
+  if (reportSubmissionDisabledByPolicy()) {
+    return;
+  }
   for (
     var i = 0;
     i < document.getElementById("unsubmitted").childNodes.length;

--- a/toolkit/crashreporter/nsDummyExceptionHandler.cpp
+++ b/toolkit/crashreporter/nsDummyExceptionHandler.cpp
@@ -165,6 +165,8 @@ nsresult SetSubmitReports(bool aSubmitReports) {
   return NS_ERROR_NOT_IMPLEMENTED;
 }
 
+void UpdateShouldReport() {}
+
 void SetProfileDirectory(nsIFile* aDir) {}
 
 void SetUserAppDataDirectory(nsIFile* aDir) {}

--- a/toolkit/crashreporter/nsExceptionHandler.cpp
+++ b/toolkit/crashreporter/nsExceptionHandler.cpp
@@ -234,7 +234,7 @@ static MOZ_GLIBCXX_CONSTINIT xpstring memoryReportPath;
 static MOZ_GLIBCXX_CONSTINIT xpstring eventsDirectory;
 
 // If this is false, we don't launch the crash reporter
-static bool doReport = true;
+static mozilla::Atomic<bool> doReport(true);
 
 // if this is true, we pass the exception on to the OS crash reporter
 static bool showOSCrashReporter = false;
@@ -1911,8 +1911,8 @@ nsresult SetExceptionHandler(nsIFile* aXREDirectory, bool force /*=false*/) {
   if (envvar && *envvar && !force) return NS_OK;
 #endif
 
-  // this environment variable prevents us from launching
-  // the crash reporter client
+  // Initialize the launch-client decision from the environment. Policies and
+  // other callers can update it later via UpdateShouldReport().
   doReport = ShouldReport();
 
   RegisterRuntimeExceptionModule();
@@ -2791,6 +2791,8 @@ nsresult SetSubmitReports(bool aSubmitReports) {
   obsServ->NotifyObservers(nullptr, "submit-reports-pref-changed", nullptr);
   return NS_OK;
 }
+
+void UpdateShouldReport() { doReport = ShouldReport(); }
 
 static void SetCrashEventsDir(nsIFile* aDir) {
   static const XP_CHAR eventsDirectoryEnv[] =

--- a/toolkit/crashreporter/nsExceptionHandler.h
+++ b/toolkit/crashreporter/nsExceptionHandler.h
@@ -206,6 +206,13 @@ nsresult AppendObjCExceptionInfoToAppNotes(void* inException);
 nsresult GetSubmitReports(bool* aSubmitReport);
 nsresult SetSubmitReports(bool aSubmitReport);
 
+// Re-evaluate environment variables that gate whether the crash reporter
+// client is launched after a crash. Call this after modifying any of the
+// MOZ_CRASHREPORTER_NO_REPORT / MOZ_CRASHREPORTER_FULLDUMP environment
+// variables so the cached, signal-safe value used by the crash callback
+// stays in sync.
+void UpdateShouldReport();
+
 // Out-of-process crash reporter API.
 
 // Return true if a dump was found for |aChildID|, and return the

--- a/toolkit/crashreporter/test/browser/browser.toml
+++ b/toolkit/crashreporter/test/browser/browser.toml
@@ -3,6 +3,11 @@ support-files = ["head.js"]
 
 ["browser_aboutCrashes.js"]
 
+["browser_aboutCrashesPolicyDisabled.js"]
+run-if = [
+  "enterprise",
+]
+
 ["browser_aboutCrashesResubmit.js"]
 https_first_disabled = true
 

--- a/toolkit/crashreporter/test/browser/browser_aboutCrashesPolicyDisabled.js
+++ b/toolkit/crashreporter/test/browser/browser_aboutCrashesPolicyDisabled.js
@@ -1,0 +1,70 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+/**
+ * Tests that when the CrashReportsSubmit.Enabled enterprise policy is
+ * set to false, about:crashes hides its bulk-submit button and
+ * does not render per-row submit buttons for pending reports.
+ */
+
+const { EnterprisePolicyTesting, PoliciesPrefTracker } =
+  ChromeUtils.importESModule(
+    "resource://testing-common/EnterprisePolicyTesting.sys.mjs"
+  );
+
+add_task(async function test_aboutCrashes_with_policyDisabled() {
+  const appD = make_fake_appdir();
+  const crD = appD.clone();
+  crD.append("Crash Reports");
+
+  const pendingCrash = addPendingCrashreport(crD, Date.now(), { foo: "bar" });
+
+  PoliciesPrefTracker.start();
+  await EnterprisePolicyTesting.setupPolicyEngineWithJson({
+    policies: {
+      CrashReportsSubmit: {
+        Enabled: false,
+      },
+    },
+  });
+
+  registerCleanupFunction(async () => {
+    cleanup_fake_appdir();
+    PoliciesPrefTracker.stop();
+    await EnterprisePolicyTesting.setupPolicyEngineWithJson("");
+  });
+
+  await BrowserTestUtils.withNewTab(
+    { gBrowser, url: "about:crashes" },
+    browser => {
+      info(
+        "about:crashes loaded under CrashReportsSubmit.Enabled set to false"
+      );
+      return SpecialPowers.spawn(browser, [pendingCrash], pendingCrash => {
+        const doc = content.document;
+
+        const submitAll = doc.getElementById("submitAllUnsubmittedReports");
+        Assert.ok(
+          submitAll.hidden,
+          "submitAllUnsubmittedReports must be hidden under the Disabled policy"
+        );
+
+        const unsubmitted = doc.getElementById("reportListUnsubmitted");
+        Assert.ok(
+          !unsubmitted.classList.contains("hidden"),
+          "the unsubmitted crash list is still visible"
+        );
+
+        const pendingRow = doc.getElementById(pendingCrash.id);
+        Assert.ok(pendingRow, "pending crash row exists");
+        Assert.equal(
+          pendingRow.cells[2].childElementCount,
+          0,
+          "pending crash row must not render a submit button under the Disabled policy"
+        );
+      });
+    }
+  );
+});

--- a/toolkit/xre/nsAppRunner.cpp
+++ b/toolkit/xre/nsAppRunner.cpp
@@ -1975,6 +1975,12 @@ nsXULAppInfo::SetSubmitReports(bool aEnabled) {
 }
 
 NS_IMETHODIMP
+nsXULAppInfo::UpdateShouldReport() {
+  CrashReporter::UpdateShouldReport();
+  return NS_OK;
+}
+
+NS_IMETHODIMP
 nsXULAppInfo::UpdateCrashEventsDir() {
   CrashReporter::UpdateCrashEventsDir();
   return NS_OK;

--- a/xpcom/system/nsICrashReporter.idl
+++ b/xpcom/system/nsICrashReporter.idl
@@ -181,6 +181,15 @@ interface nsICrashReporter : nsISupports
   void UpdateCrashEventsDir();
 
   /**
+   * Re-evaluate environment variables that gate whether the crash reporter
+   * client is launched after a crash (MOZ_CRASHREPORTER_NO_REPORT and
+   * MOZ_CRASHREPORTER_FULLDUMP). Call this after modifying those env vars
+   * so the signal-safe cached value used by the crash callback stays in
+   * sync.
+   */
+  void updateShouldReport();
+
+  /**
    * Save an anonymized memory report file for inclusion in a future crash
    * report in this session.
    *


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2026983 Bug-2039308

The crash reporter submit policy structure was changed in `enterprise-main` and is now inconsistent across the branches, making the configuration from the console not work in some scenarios. This uplifts the change to the policy as well as the fix that was preventing crash reporter from working on Mac and Linux when the auto submit behavior was enabled.

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Uplift of: #965 #1145 