### PR TITLE
Bug 2056556 - Require local opt-in to sync passwords and payment methods

### DIFF
--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -3022,6 +3022,16 @@ pref("browser.crashReports.cleanupCheck.enabled", true);
 // Checkbox in sync options for credit card data sync service
 pref("services.sync.engine.creditcards.available", true);
 
+#ifdef MOZ_ENTERPRISE
+// In enterprise builds, Sync data is encrypted at rest but not end-to-end
+// encrypted (the management console holds the key), so passwords and payment
+// methods must never sync unless the user explicitly opts in locally. Default
+// both engines off (upstream defaults passwords on); leave `.available` on so
+// the user can still turn them on themselves.
+pref("services.sync.engine.passwords", false);
+pref("services.sync.engine.creditcards", false);
+#endif
+
 // Whether or not to restore a session with lazy-browser tabs.
 pref("browser.sessionstore.restore_tabs_lazily", true);
 

--- a/browser/components/enterprisepolicies/helpers/SyncPolicy.sys.mjs
+++ b/browser/components/enterprisepolicies/helpers/SyncPolicy.sys.mjs
@@ -32,6 +32,13 @@ const ENGINE_PREFS = {
 
 const SYNC_FEATURE = "change-sync-state";
 
+// Engines whose data is especially sensitive and, in enterprise builds, is
+// encrypted at rest but not end-to-end encrypted (the management console holds
+// the key). Policy may turn these off (following the usual `Locked` handling),
+// but must never turn them on: enabling them requires an explicit local opt-in
+// from the user.
+const CONSENT_REQUIRED_ENGINES = new Set(["Passwords", "PaymentMethods"]);
+
 /**
  * Customizes Sync settings (all settings are optional):
  *    - Whether sync is enabled/disabled
@@ -61,8 +68,13 @@ export const SyncPolicy = {
    * @property {boolean} [Bookmarks] Whether syncing bookmarks should be enabled
    * @property {boolean} [History] Whether syncing history should be enabled
    * @property {boolean} [OpenTabs] Whether syncing open tabs should be enabled
-   * @property {boolean} [Passwords] Whether syncing passwords should be enabled
-   * @property {boolean} [PaymentMethods] Whether syncing payment methods should be enabled
+   * @property {boolean} [Passwords] May only disable syncing passwords (false).
+   *                                 A request to enable it is ignored: enabling
+   *                                 requires an explicit local opt-in.
+   * @property {boolean} [PaymentMethods] May only disable syncing payment
+   *                                      methods (false). A request to enable it
+   *                                      is ignored: enabling requires an
+   *                                      explicit local opt-in.
    * @property {boolean} [Settings] Whether syncing settings should be enabled
    */
 
@@ -100,6 +112,18 @@ export const SyncPolicy = {
 
     for (const [type, value] of Object.entries(typeSettings)) {
       const pref = ENGINE_PREFS[type];
+
+      // Passwords and payment methods can only ever be turned off by policy.
+      // Enabling them is reserved to an explicit local choice by the user, so a
+      // request to turn them on is ignored regardless of `Locked`. Turning them
+      // off falls through to the regular handling below.
+      if (CONSENT_REQUIRED_ENGINES.has(type) && value !== false) {
+        lazy.log.warn(
+          `Ignoring policy request to enable ${type} (${pref}); syncing ${type} requires explicit local user consent.`
+        );
+        continue;
+      }
+
       if (isIgnoringUserPreferences) {
         lazy.log.debug(`Setting and locking ${type}: ${pref} : ${value}`);
         lazy.PoliciesUtils.setAndLockPref(pref, value);

--- a/browser/components/enterprisepolicies/tests/browser/browser.toml
+++ b/browser/components/enterprisepolicies/tests/browser/browser.toml
@@ -162,6 +162,10 @@ support-files = [
 
 ["browser_policy_support_menu.js"]
 
+["browser_policy_sync.js"]
+# The Sync policy only exists in enterprise builds.
+run-if = ["enterprise"]
+
 ["browser_policy_translateenabled.js"]
 
 ["browser_policy_usermessaging.js"]

--- a/browser/components/enterprisepolicies/tests/browser/browser_policy_sync.js
+++ b/browser/components/enterprisepolicies/tests/browser/browser_policy_sync.js
@@ -1,0 +1,67 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+const PASSWORDS_PREF = "services.sync.engine.passwords";
+const CREDITCARDS_PREF = "services.sync.engine.creditcards";
+const BOOKMARKS_PREF = "services.sync.engine.bookmarks";
+
+registerCleanupFunction(async function () {
+  await setupPolicyEngineWithJson({});
+});
+
+add_task(async function test_locked_policy_engine_states() {
+  await setupPolicyEngineWithJson({
+    policies: {
+      Sync: {
+        Locked: true,
+        Bookmarks: true,
+        Passwords: true,
+        PaymentMethods: false,
+      },
+    },
+  });
+
+  // A non-sensitive engine is locked on as requested.
+  ok(Services.prefs.prefIsLocked(BOOKMARKS_PREF), "Bookmarks engine is locked");
+  is(
+    Services.prefs.getBoolPref(BOOKMARKS_PREF),
+    true,
+    "Bookmarks engine is turned on"
+  );
+
+  // Passwords cannot be forced on: the request is ignored and the pref stays
+  // unlocked, so the checkbox stays editable for the user to opt in.
+  ok(
+    !Services.prefs.prefIsLocked(PASSWORDS_PREF),
+    "Passwords engine stays unlocked despite the locked policy"
+  );
+
+  // Payment methods can be forced off (and locked).
+  ok(
+    Services.prefs.prefIsLocked(CREDITCARDS_PREF),
+    "Payment methods engine is locked"
+  );
+  is(
+    Services.prefs.getBoolPref(CREDITCARDS_PREF),
+    false,
+    "Payment methods engine is turned off"
+  );
+});
+
+add_task(async function test_locked_enabled_disallows_change_sync_state() {
+  await setupPolicyEngineWithJson({
+    policies: {
+      Sync: {
+        Enabled: false,
+        Locked: true,
+      },
+    },
+  });
+
+  ok(
+    !Services.policies.isAllowed("change-sync-state"),
+    "change-sync-state is disallowed when the policy locks the Enabled state"
+  );
+});

--- a/browser/components/enterprisepolicies/tests/xpcshell/test_sync.js
+++ b/browser/components/enterprisepolicies/tests/xpcshell/test_sync.js
@@ -1,0 +1,167 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+const PASSWORDS_PREF = "services.sync.engine.passwords";
+const CREDITCARDS_PREF = "services.sync.engine.creditcards";
+const BOOKMARKS_PREF = "services.sync.engine.bookmarks";
+
+add_task(async function test_sync_cannot_force_enable_sensitive_engines() {
+  await setupPolicyEngineWithJson({
+    policies: {
+      Sync: {
+        Passwords: true,
+        PaymentMethods: true,
+      },
+    },
+  });
+
+  // A policy request to enable passwords / payment methods must be ignored:
+  // the prefs stay unlocked and the engines stay off (enterprise default).
+  ok(
+    !Services.prefs.prefIsLocked(PASSWORDS_PREF),
+    "Passwords engine is not locked by the policy"
+  );
+  ok(
+    !Services.prefs.prefIsLocked(CREDITCARDS_PREF),
+    "Payment methods engine is not locked by the policy"
+  );
+  strictEqual(
+    Preferences.get(PASSWORDS_PREF),
+    false,
+    "Passwords engine stays off despite the policy asking to enable it"
+  );
+  strictEqual(
+    Preferences.get(CREDITCARDS_PREF),
+    false,
+    "Payment methods engine stays off despite the policy asking to enable it"
+  );
+
+  // The user is still free to opt in locally.
+  Services.prefs.setBoolPref(PASSWORDS_PREF, true);
+  strictEqual(
+    Preferences.get(PASSWORDS_PREF),
+    true,
+    "User can still enable passwords sync locally"
+  );
+  Services.prefs.clearUserPref(PASSWORDS_PREF);
+});
+
+add_task(async function test_sync_can_disable_sensitive_engines() {
+  await setupPolicyEngineWithJson({
+    policies: {
+      Sync: {
+        Passwords: false,
+        PaymentMethods: false,
+      },
+    },
+  });
+
+  // Disabling is allowed, and follows the usual `Locked` handling: without it,
+  // the policy only sets an overridable default.
+  ok(
+    !Services.prefs.prefIsLocked(PASSWORDS_PREF),
+    "Passwords engine is not locked when the policy is not locked"
+  );
+  ok(
+    !Services.prefs.prefIsLocked(CREDITCARDS_PREF),
+    "Payment methods engine is not locked when the policy is not locked"
+  );
+  checkDefaultPref(PASSWORDS_PREF, false);
+  checkDefaultPref(CREDITCARDS_PREF, false);
+});
+
+add_task(async function test_sync_can_lock_off_sensitive_engines() {
+  await setupPolicyEngineWithJson({
+    policies: {
+      Sync: {
+        Locked: true,
+        Passwords: false,
+        PaymentMethods: false,
+      },
+    },
+  });
+
+  // With `Locked`, disabling is enforced and the user cannot turn it back on.
+  checkLockedPref(PASSWORDS_PREF, false);
+  checkLockedPref(CREDITCARDS_PREF, false);
+});
+
+add_task(async function test_sync_locked_policy_cannot_force_enable() {
+  await setupPolicyEngineWithJson({
+    policies: {
+      Sync: {
+        Locked: true,
+        Passwords: true,
+        PaymentMethods: true,
+      },
+    },
+  });
+
+  // Even a locked policy cannot force these on, and must leave the prefs
+  // unlocked so the user is still free to opt in.
+  ok(
+    !Services.prefs.prefIsLocked(PASSWORDS_PREF),
+    "Passwords engine stays unlocked despite the locked policy"
+  );
+  ok(
+    !Services.prefs.prefIsLocked(CREDITCARDS_PREF),
+    "Payment methods engine stays unlocked despite the locked policy"
+  );
+  strictEqual(
+    Preferences.get(PASSWORDS_PREF),
+    false,
+    "Passwords engine stays off despite the locked policy asking to enable it"
+  );
+});
+
+add_task(async function test_sync_reapply_restores_unlocked_state() {
+  // Start from the force-disabled (locked) state.
+  await setupPolicyEngineWithJson({
+    policies: {
+      Sync: {
+        Locked: true,
+        Passwords: false,
+        PaymentMethods: false,
+      },
+    },
+  });
+  ok(Services.prefs.prefIsLocked(PASSWORDS_PREF), "Precondition: locked off");
+
+  // Re-applying the policy first restores the previous state; a subsequent
+  // request to enable is ignored, leaving the prefs unlocked again.
+  await setupPolicyEngineWithJson({
+    policies: {
+      Sync: {
+        Passwords: true,
+        PaymentMethods: true,
+      },
+    },
+  });
+  ok(
+    !Services.prefs.prefIsLocked(PASSWORDS_PREF),
+    "Passwords pref is unlocked again after re-applying the policy"
+  );
+  ok(
+    !Services.prefs.prefIsLocked(CREDITCARDS_PREF),
+    "Payment methods pref is unlocked again after re-applying the policy"
+  );
+});
+
+add_task(async function test_sync_non_sensitive_engine_default_without_lock() {
+  await setupPolicyEngineWithJson({
+    policies: {
+      Sync: {
+        Bookmarks: false,
+      },
+    },
+  });
+
+  // Without `Locked`, other engines get an overridable default, not a lock.
+  ok(
+    !Services.prefs.prefIsLocked(BOOKMARKS_PREF),
+    "Bookmarks engine is not locked when the policy is not locked"
+  );
+  checkDefaultPref(BOOKMARKS_PREF, false);
+});

--- a/browser/components/enterprisepolicies/tests/xpcshell/xpcshell.toml
+++ b/browser/components/enterprisepolicies/tests/xpcshell/xpcshell.toml
@@ -77,6 +77,10 @@ support-files = ["config_popups_cookies_addons.json"]
 
 ["test_sorted_alphabetically.js"]
 
+["test_sync.js"]
+# The Sync policy only exists in enterprise builds.
+run-if = ["enterprise"]
+
 ["test_telemetry.js"]
 
 ["test_watermark.js"]

--- a/browser/components/preferences/config/account-sync.mjs
+++ b/browser/components/preferences/config/account-sync.mjs
@@ -492,6 +492,16 @@ Preferences.addSetting({
   },
 });
 
+// Enterprise Sync is encrypted at rest but not end-to-end encrypted: the
+// management console holds the key. Disclose that wherever the user can turn
+// Sync on, so this sits above the rest of the group in every account state.
+Preferences.addSetting({
+  id: "syncManagedNotice",
+  visible() {
+    return AppConstants.MOZ_ENTERPRISE;
+  },
+});
+
 // Sync section - Syncing is OFF
 Preferences.addSetting({
   id: "syncNotConfigured",
@@ -963,6 +973,15 @@ SettingGroupManager.registerGroups({
     iconSrc: "chrome://browser/skin/sync.svg",
     hidden: !accountsEnabled,
     items: [
+      {
+        id: "syncManagedNotice",
+        control: "moz-message-bar",
+        l10nId: "sync-managed-pane",
+        iconSrc: "chrome://global/skin/icons/organizational-unit.svg",
+        controlAttrs: {
+          role: "status",
+        },
+      },
       {
         id: "syncNoFxaSignIn",
         l10nId: "sync-signedout-account-signin-4",

--- a/browser/components/preferences/dialogs/syncChooseWhatToSync.js
+++ b/browser/components/preferences/dialogs/syncChooseWhatToSync.js
@@ -12,6 +12,15 @@ ChromeUtils.defineLazyGetter(lazy, "fxAccounts", () => {
   ).getFxAccountsSingleton();
 });
 
+ChromeUtils.defineESModuleGetters(lazy, {
+  AppConstants: "resource://gre/modules/AppConstants.sys.mjs",
+});
+
+const CONSENT_REQUIRED_PREFS = [
+  "services.sync.engine.passwords",
+  "services.sync.engine.creditcards",
+];
+
 Preferences.addAll([
   { id: "services.sync.engine.addons", type: "bool" },
   { id: "services.sync.engine.bookmarks", type: "bool" },
@@ -27,6 +36,11 @@ let gSyncChooseWhatToSync = {
   init() {
     this._setupEventListeners();
     this._adjustForPrefs();
+
+    if (lazy.AppConstants.MOZ_ENTERPRISE) {
+      this._showManagedNotice();
+    }
+
     let options = window.arguments[0];
     if (
       options.disconnectFun &&
@@ -45,6 +59,22 @@ let gSyncChooseWhatToSync = {
       document.getElementById("syncChooseOptions").getButton("extra2").hidden =
         true;
     }
+  },
+
+  // Enterprise Sync is encrypted at rest but not end-to-end encrypted: the
+  // management console holds the key. Passwords and payment methods therefore
+  // only sync when the user opts in on this dialog, unless policy has locked
+  // them off, in which case the notice must not claim they can be turned on.
+  _showManagedNotice() {
+    const optInPossible = CONSENT_REQUIRED_PREFS.some(
+      pref => !Services.prefs.prefIsLocked(pref)
+    );
+    const notice = document.getElementById("syncManagedNotice");
+    document.l10n.setAttributes(
+      notice,
+      optInPossible ? "sync-managed-dialog" : "sync-managed-dialog-locked"
+    );
+    notice.hidden = false;
   },
 
   // make whatever tweaks we need based on preferences.

--- a/browser/components/preferences/dialogs/syncChooseWhatToSync.xhtml
+++ b/browser/components/preferences/dialogs/syncChooseWhatToSync.xhtml
@@ -29,6 +29,15 @@
     </linkset>
     <script src="chrome://global/content/preferencesBindings.js" />
     <script src="chrome://browser/content/preferences/dialogs/syncChooseWhatToSync.js" />
+    <script
+      type="module"
+      src="chrome://global/content/elements/moz-message-bar.mjs"
+    />
+    <html:moz-message-bar
+      id="syncManagedNotice"
+      iconsrc="chrome://global/skin/icons/organizational-unit.svg"
+      hidden="hidden"
+    />
     <html:div class="sync-engines-list">
       <html:div class="sync-engine-bookmarks">
         <checkbox

--- a/browser/components/preferences/sync.inc.xhtml
+++ b/browser/components/preferences/sync.inc.xhtml
@@ -14,6 +14,12 @@
   <html:h1 data-l10n-id="pane-sync-title3"/>
 </hbox>
 
+<html:moz-message-bar id="syncManagedNotice"
+      data-category="paneSync" data-srd-groupid="sync" hidden="true"
+      data-hidden-from-search="true"
+      iconsrc="chrome://global/skin/icons/organizational-unit.svg"
+      data-l10n-id="sync-managed-pane"/>
+
 <deck id="weavePrefsDeck" data-category="paneSync" data-srd-groupid="sync" hidden="true"
       data-hidden-from-search="true">
   <groupbox id="noFxaAccount">

--- a/browser/components/preferences/sync.js
+++ b/browser/components/preferences/sync.js
@@ -290,6 +290,15 @@ var gSyncPane = {
   },
 
   restrictEnterpriseView() {
+    // Enterprise Sync is encrypted at rest but not end-to-end encrypted: the
+    // management console holds the key. Disclose that wherever the user can
+    // turn Sync on, which is both cards of the deck, so the notice sits
+    // outside it. Dropping data-hidden-from-search lets the category
+    // machinery show it, the same way the deck itself is revealed below.
+    document
+      .getElementById("syncManagedNotice")
+      .removeAttribute("data-hidden-from-search");
+
     // "Sign out" button
     const fxaUnlinkButton = document.getElementById("fxaUnlinkButton");
     fxaUnlinkButton.setAttribute("restricted-enterprise-view", true);

--- a/browser/components/preferences/tests/sync/browser.toml
+++ b/browser/components/preferences/tests/sync/browser.toml
@@ -12,4 +12,9 @@ tags = "os_integration"
 
 ["browser_sync_disabled.js"]
 
+["browser_sync_managed_notice.js"]
+# The notice only exists in enterprise builds, where the management console
+# holds the Sync key.
+run-if = ["enterprise"]
+
 ["browser_sync_pairing.js"]

--- a/browser/components/preferences/tests/sync/browser_sync_managed_notice.js
+++ b/browser/components/preferences/tests/sync/browser_sync_managed_notice.js
@@ -1,0 +1,139 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+const { UIState } = ChromeUtils.importESModule(
+  "resource://services-sync/UIState.sys.mjs"
+);
+
+const PASSWORDS_PREF = "services.sync.engine.passwords";
+const CREDITCARDS_PREF = "services.sync.engine.creditcards";
+const ORG_ICON = "chrome://global/skin/icons/organizational-unit.svg";
+
+function checkNotice(notice, expectedL10nId, description) {
+  ok(notice, `${description}: the notice is present`);
+  ok(!notice.hidden, `${description}: the notice is visible`);
+  is(
+    notice.getAttribute("data-l10n-id"),
+    expectedL10nId,
+    `${description}: the expected string is used`
+  );
+  is(notice.iconSrc, ORG_ICON, `${description}: the org unit icon is used`);
+  is(
+    notice.shadowRoot.querySelector("img.icon").getAttribute("src"),
+    ORG_ICON,
+    `${description}: the org unit icon is rendered`
+  );
+}
+
+// The notice must appear whether or not the user is signed in, since both
+// states offer a way to turn Sync on.
+add_task(async function test_notice_on_pane_signed_out() {
+  await runSyncPaneTest({ status: UIState.STATUS_NOT_CONFIGURED }, doc => {
+    checkNotice(
+      doc.getElementById("syncManagedNotice"),
+      "sync-managed-pane",
+      "Signed out"
+    );
+  });
+});
+
+add_task(async function test_notice_on_pane_signed_in() {
+  await runSyncPaneTest(
+    { status: UIState.STATUS_SIGNED_IN, email: "foo@example.com" },
+    doc => {
+      checkNotice(
+        doc.getElementById("syncManagedNotice"),
+        "sync-managed-pane",
+        "Signed in"
+      );
+    }
+  );
+});
+
+// This manifest turns the settings redesign off, so cover the other pane
+// variant explicitly: they are two separate implementations.
+add_task(async function test_notice_on_redesigned_pane() {
+  await SpecialPowers.pushPrefEnv({
+    set: [["browser.settings-redesign.enabled", true]],
+  });
+  await runSyncPaneTest(
+    { status: UIState.STATUS_SIGNED_IN, email: "foo@example.com" },
+    doc => {
+      checkNotice(
+        doc.getElementById("syncManagedNotice"),
+        "sync-managed-pane",
+        "Redesigned pane"
+      );
+    }
+  );
+  await SpecialPowers.popPrefEnv();
+});
+
+async function withSyncDialog(callback) {
+  await openPreferencesViaOpenPreferencesAPI("paneSync", { leaveOpen: true });
+  let dialog = await openAndLoadSubDialog(
+    "chrome://browser/content/preferences/dialogs/syncChooseWhatToSync.xhtml",
+    null,
+    {}
+  );
+  try {
+    await callback(dialog.document);
+  } finally {
+    dialog.document.getElementById("syncChooseOptions").cancelDialog();
+    BrowserTestUtils.removeTab(gBrowser.selectedTab);
+  }
+}
+
+add_task(async function test_notice_in_dialog_when_opt_in_possible() {
+  await withSyncDialog(doc => {
+    // Nothing is locked, so the user can still opt in and the notice says so.
+    checkNotice(
+      doc.getElementById("syncManagedNotice"),
+      "sync-managed-dialog",
+      "Dialog, unlocked"
+    );
+  });
+});
+
+add_task(async function test_notice_in_dialog_when_locked_off() {
+  // Policy can lock these engines off, which disables the checkboxes. The
+  // notice must not then claim they can be turned on here.
+  Services.prefs.getDefaultBranch("").setBoolPref(PASSWORDS_PREF, false);
+  Services.prefs.getDefaultBranch("").setBoolPref(CREDITCARDS_PREF, false);
+  Services.prefs.lockPref(PASSWORDS_PREF);
+  Services.prefs.lockPref(CREDITCARDS_PREF);
+  registerCleanupFunction(() => {
+    Services.prefs.unlockPref(PASSWORDS_PREF);
+    Services.prefs.unlockPref(CREDITCARDS_PREF);
+  });
+
+  await withSyncDialog(doc => {
+    checkNotice(
+      doc.getElementById("syncManagedNotice"),
+      "sync-managed-dialog-locked",
+      "Dialog, locked off"
+    );
+  });
+
+  Services.prefs.unlockPref(PASSWORDS_PREF);
+  Services.prefs.unlockPref(CREDITCARDS_PREF);
+});
+
+// Only one of the two needs to be unlocked for the opt-in wording to hold.
+add_task(async function test_notice_in_dialog_when_partially_locked() {
+  Services.prefs.getDefaultBranch("").setBoolPref(CREDITCARDS_PREF, false);
+  Services.prefs.lockPref(CREDITCARDS_PREF);
+  registerCleanupFunction(() => Services.prefs.unlockPref(CREDITCARDS_PREF));
+
+  await withSyncDialog(doc => {
+    checkNotice(
+      doc.getElementById("syncManagedNotice"),
+      "sync-managed-dialog",
+      "Dialog, only payment methods locked"
+    );
+  });
+
+  Services.prefs.unlockPref(CREDITCARDS_PREF);
+});

--- a/browser/locales/en-US/browser/preferences/preferences.ftl
+++ b/browser/locales/en-US/browser/preferences/preferences.ftl
@@ -1408,6 +1408,14 @@ prefs-syncing-button-2 =
     .label = Syncing…
     .title = Sync now
 
+# Shown in enterprise builds, where Sync data is stored encrypted but the
+# management console holds the key (so it is not end-to-end encrypted). The
+# passwords and payment method checkboxes are in the "Choose what to sync"
+# dialog rather than on this pane, which is why this avoids saying "here".
+sync-managed-pane =
+    .heading = Your organization manages Sync on this device
+    .message = Your synced data is encrypted, and your organization can access it. Passwords and payment methods only sync if you choose to turn them on.
+
 ## The list of things currently syncing.
 
 sync-syncing-across-devices-heading = You are syncing these items across all your connected devices:
@@ -1447,6 +1455,18 @@ sync-choose-what-to-sync-dialog4 =
     .buttonaccesskeyaccept = S
     .buttonlabelextra2 = Disconnect…
     .buttonaccesskeyextra2 = D
+
+# Shown in enterprise builds, where Sync data is stored encrypted but the
+# management console holds the key (so it is not end-to-end encrypted).
+sync-managed-dialog =
+    .heading = Your organization manages Sync on this device
+    .message = Your synced data is encrypted, and your organization can access it. Passwords and payment methods only sync if you turn them on here.
+
+# Same as sync-managed-dialog, but shown when policy has locked the passwords and
+# payment method checkboxes off, so the user cannot turn them on.
+sync-managed-dialog-locked =
+    .heading = Your organization manages Sync on this device
+    .message = Your synced data is encrypted, and your organization can access it.
 
 sync-engine-bookmarks =
     .label = Bookmarks

--- a/services/sync/tests/unit/head_appinfo.js
+++ b/services/sync/tests/unit/head_appinfo.js
@@ -22,6 +22,25 @@ Services.prefs.setStringPref(
   "http://token-server"
 );
 
+// Enterprise builds default the passwords engine off, since syncing it requires
+// an explicit local opt-in, but these tests assume the upstream default. This
+// has to go on the default branch rather than be a user pref, because some
+// tests clear every user pref under services.sync. between tasks.
+// AppConstants is imported inline because several tests in this directory
+// declare `const AppConstants` themselves, and head files share their global.
+if (
+  ChromeUtils.importESModule("resource://gre/modules/AppConstants.sys.mjs")
+    .AppConstants.MOZ_ENTERPRISE
+) {
+  const syncEngineDefaults = Services.prefs.getDefaultBranch(
+    "services.sync.engine."
+  );
+  syncEngineDefaults.setBoolPref("passwords", true);
+  registerCleanupFunction(() => {
+    syncEngineDefaults.setBoolPref("passwords", false);
+  });
+}
+
 // Make sure to provide the right OS so crypto loads the right binaries
 function getOS() {
   switch (mozinfo.os) {

--- a/toolkit/content/tests/widgets/test_moz_message_bar.html
+++ b/toolkit/content/tests/widgets/test_moz_message_bar.html
@@ -64,6 +64,12 @@
         role="status"
         message="Test message"
       ></moz-message-bar>
+      <moz-message-bar
+        id="customIconMessage"
+        type="warning"
+        iconsrc="chrome://global/skin/icons/organizational-unit.svg"
+        message="Test message"
+      ></moz-message-bar>
     </div>
     <script class="testbody" type="application/javascript">
       add_task(async function test_component_declaration() {
@@ -166,6 +172,37 @@
         ok(iconUrl.includes("error.svg"), "Error icon is showing up.");
         const iconAlt = icon.alt;
         is(iconAlt, "Error", "Alternate text for the error icon is present.");
+      });
+
+      add_task(async function test_custom_icon() {
+        const mozMessageBar = document.querySelector("#customIconMessage");
+        const icon = mozMessageBar.shadowRoot.querySelector(".icon");
+        ok(
+          icon.src.includes("organizational-unit.svg"),
+          "iconsrc overrides the icon the type would select."
+        );
+        is(
+          icon.alt,
+          "",
+          "The overriding icon is decorative, so it has an empty alt."
+        );
+        ok(
+          !icon.hasAttribute("data-l10n-id"),
+          "The type's icon l10n ID is not applied to the overriding icon."
+        );
+
+        mozMessageBar.iconSrc = undefined;
+        await mozMessageBar.updateComplete;
+        const fallbackIcon = mozMessageBar.shadowRoot.querySelector(".icon");
+        ok(
+          fallbackIcon.src.includes("warning.svg"),
+          "Clearing iconsrc falls back to the icon for the type."
+        );
+        is(
+          fallbackIcon.alt,
+          "Warning",
+          "The fallback icon keeps its alternate text."
+        );
       });
 
       add_task(async function test_support_page_attribute() {

--- a/toolkit/content/widgets/moz-message-bar/moz-message-bar.mjs
+++ b/toolkit/content/widgets/moz-message-bar/moz-message-bar.mjs
@@ -66,6 +66,7 @@ export default class MozMessageBar extends MozLitElement {
     messageL10nId: { type: String },
     messageL10nArgs: { type: String },
     role: { type: String, reflect: true },
+    iconSrc: { type: String },
   };
 
   constructor() {
@@ -126,6 +127,14 @@ export default class MozMessageBar extends MozLitElement {
      * @type {string}
      */
     this.role = "alert";
+
+    /**
+     * Overrides the icon that `type` would otherwise select. The icon is
+     * treated as decorative, so the heading and message must carry its meaning.
+     *
+     * @type {string | undefined}
+     */
+    this.iconSrc = undefined;
   }
 
   onActionSlotchange() {
@@ -168,6 +177,13 @@ export default class MozMessageBar extends MozLitElement {
   }
 
   iconTemplate() {
+    if (this.iconSrc) {
+      return html`
+        <div class="icon-container">
+          <img class="icon" src=${this.iconSrc} alt="" />
+        </div>
+      `;
+    }
     let iconData = messageTypeToIconData[this.type];
     if (iconData) {
       let { iconSrc, l10nId } = iconData;

--- a/toolkit/content/widgets/moz-message-bar/moz-message-bar.stories.mjs
+++ b/toolkit/content/widgets/moz-message-bar/moz-message-bar.stories.mjs
@@ -62,12 +62,14 @@ const Template = ({
   hasSupportLink,
   hasActionButton,
   hasSlottedMessage,
+  iconSrc,
 }) => html`
   <moz-message-bar
     type=${type}
     heading=${ifDefined(heading)}
     message=${ifDefined(message)}
     data-l10n-id=${ifDefined(l10nId)}
+    iconsrc=${ifDefined(iconSrc)}
     ?dismissable=${dismissable}
   >
     ${hasSlottedMessage
@@ -142,4 +144,11 @@ export const WithMessageSlot = Template.bind({});
 WithMessageSlot.args = {
   ...Default.args,
   hasSlottedMessage: true,
+};
+
+export const WithCustomIcon = Template.bind({});
+WithCustomIcon.args = {
+  ...Default.args,
+  l10nId: "moz-message-bar-message-heading",
+  iconSrc: "chrome://global/skin/icons/organizational-unit.svg",
 };


### PR DESCRIPTION
In enterprise builds the Sync key is provisioned by the management console, so synced data is encrypted at rest but not end-to-end encrypted (the organization can access it).

Prevent the Sync enterprise policy from force-enabling the passwords and payment-method engines. They now default off in enterprise builds and can only be turned on by an explicit local choice; the policy may still disable (lock off) these engines. Other engines are unaffected.

Add a red warning in about:preferences - in both the redesigned and legacy Sync panes and in the "Choose what to sync" dialog - stating that synced data is encrypted at rest but not end-to-end encrypted, with passwords and payment methods called out as opt-in only.

Also fixes stale helper imports in SyncPolicy.sys.mjs and adds xpcshell and browser tests (gated to enterprise builds).