### PR TITLE
Bug 2056566 - For enterprise addon install complete event, inherit keys from install event. Add missing key

### DIFF
--- a/toolkit/mozapps/extensions/AddonManager.sys.mjs
+++ b/toolkit/mozapps/extensions/AddonManager.sys.mjs
@@ -5921,6 +5921,8 @@ AMTelemetry = {
           updated_from,
           install_origins,
           step: extraVars?.step,
+          // will be undefined for non-site permission addons
+          site_permission: install.newSitePerm,
         })
       );
       GleanPings.enterprise.submit();

--- a/toolkit/mozapps/extensions/metrics.yaml
+++ b/toolkit/mozapps/extensions/metrics.yaml
@@ -248,7 +248,7 @@ addons_manager:
       - interaction
     notification_emails:
       - addons-dev-internal@mozilla.com
-    extra_keys:
+    extra_keys: &install_update_extra_keys
       addon_id:
         description: Id of the addon (when available).
         type: string
@@ -345,77 +345,9 @@ addons_manager:
       - security-telemetry@mozilla.org
       - enterprise-telemetry@mozilla.org
     extra_keys:
-      addon_id:
-        description: Id of the addon (when available).
-        type: string
+      <<: *install_update_extra_keys
       addon_name:
         description: Name of the addon (when available).
-        type: string
-      addon_type:
-        description: |
-          Addon type, one of: extension, theme, locale, dictionary,
-          sitepermission, siteperm_deprecated, other, unknown.
-        type: string
-      install_id:
-        description: |
-          Shared by events related to the same install or update flow.
-        type: string
-      download_time:
-        description: The number of ms needed to complete the download.
-        type: quantity
-      error:
-        description: |
-          The AddonManager error related to an install or update failure.
-        type: string
-      source:
-        description: |
-          The source that originally triggered the installation, one
-          of: "about:addons", "about:debugging", "about:preferences",
-          "amo", "browser-import", "disco", "distribution",
-          "extension", "enterprise-policy", "file-url",
-          "geckoview-app", "gmp-plugin", "internal", "plugin",
-          "rtamo", "siteperm-addon-provider" "sync", "system-addon",
-          "temporary-addon", "unknown", "about:editprofile", "about:newprofile",
-          "nimbus-newtabTrainhopAddon".
-          For events with method set to "sideload", the source value
-          is derived from the XPIProvider location name (e.g. possible
-          values are "app-builtin", "app-global", "app-profile",
-          "app-system-addons", "app-system-defaults",
-          "app-system-local", "app-system-profile",
-          "app-system-share", "app-system-user", "winreg-app-user",
-          "winreg-app-gobal").
-        type: string
-      source_method:
-        description: |
-          The method used by the source to install the add-on
-          (included when the source can use more than one, e.g.
-          install events with source "about:addons" may have
-          "install-from-file" or "url" as method), one of: "amWebAPI",
-          "drag-and-drop", "installTrigger", "install-from-file",
-          "link", "management-webext-api", "sideload", "onboarding",
-          "synthetic-install", "url", "product-updates".
-        type: string
-      num_strings:
-        description: |
-          The number of permission description strings in the
-          extension permission doorhanger.
-        type: quantity
-      updated_from:
-        description: |
-          Determine if an update has been requested by the user or
-          the application ("app" / "user").
-        type: string
-      install_origins:
-        description: |
-          This flag indicates whether install_origins is defined in
-          the addon manifest. ("1" / "0")
-        type: string
-      step:
-        description: |
-          The current step in the install or update flow: started,
-          postponed, cancelled, failed, permissions_prompt, completed,
-          site_warning, site_blocked,install_disabled_warning,
-          download_started, download_completed, download_failed
         type: string
     expires: never
     send_in_pings:


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2056566

A recent change added an extra key `site_permission` to the addon install metric, causing drift for our enterprise-specific addon install-completed event. I've updated the yaml so that the enterprise event inherits the keys from the regular event, just adding the enterprise-specific `addon_name`. I've included the new key's data in the recording of the event.

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->
