### PR TITLE
Bug 2051293 - Fix omitted policy callback error message in about:policies

### DIFF
--- a/toolkit/components/enterprisepolicies/EnterprisePoliciesParent.sys.mjs
+++ b/toolkit/components/enterprisepolicies/EnterprisePoliciesParent.sys.mjs
@@ -681,7 +681,8 @@ EnterprisePoliciesManager.prototype = {
         boundCallback();
       } catch (ex) {
         lazy.log.error(
-          `Error running ${timing} callback for policy ${policyName}: ${ex}`
+          `Error running ${timing} callback for policy ${policyName}: ${ex}`,
+          ex
         );
       }
     }

--- a/toolkit/components/enterprisepolicies/EnterprisePoliciesParent.sys.mjs
+++ b/toolkit/components/enterprisepolicies/EnterprisePoliciesParent.sys.mjs
@@ -675,12 +675,14 @@ EnterprisePoliciesManager.prototype = {
   _runPoliciesCallbacks(timing) {
     let callbacks = this._callbacks[timing];
     while (callbacks.length) {
-      let { callback, impl, params } = callbacks.shift();
+      let { callback, impl, params, policyName } = callbacks.shift();
       const boundCallback = callback.bind(impl, this, params);
       try {
         boundCallback();
       } catch (ex) {
-        lazy.log.error("Error running ", boundCallback, `for ${timing}:`, ex);
+        lazy.log.error(
+          `Error running ${timing} callback for policy ${policyName}: ${ex}`
+        );
       }
     }
   },


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2051293

Logs the policy callback error message as a single formatted string so the message isn't dropped

---

### Testing <!-- OPTIONAL -->

* [X] Manual testing performed