### PR TITLE
Bug 2012440 - Switch category to Miscellaneous

### DIFF
--- a/browser/components/enterprisepolicies/schemas/policies-schema.json
+++ b/browser/components/enterprisepolicies/schemas/policies-schema.json
@@ -1079,7 +1079,7 @@
     },
     "DisableLocalPolicies": {
       "type": "boolean",
-      "x-category": "Policy engine",
+      "x-category": "Miscellaneous",
       "description": "Disable all local policy sources (policies.json, Windows GPO and macOS plist).",
       "examples": [true, false]
     },


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2012440

Switches category from "Policy engine" to "Miscellaneous"
