### PR TITLE
Bug 2058187 - Skip tests that expected unencrypted database upgrade to encrypted database

### DIFF
--- a/toolkit/components/satchel/test/unit/xpcshell.toml
+++ b/toolkit/components/satchel/test/unit/xpcshell.toml
@@ -2,7 +2,7 @@
 head = "head_satchel.js"
 tags = "condprof"
 skip-if = [
-  "os == 'android'",
+  "os == 'android' || enterprise", # Bug 2058187 - SQLite Encryption migration not handled: test copies unencrypted data into profile where it is expected to be encrypted.
 ]
 support-files = [
   "asyncformhistory_expire.sqlite",


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2058187

There is no support yet for upgrading an unencrypted database to an encrypted one. Those tests relies on copying a non encrypted database in a profile where encryption is enabled.