### PR TITLE
Bug 2044495 - Add built-in DLP policy (and Bug 2042853 - Active ContentAnalysis policy wins over DLP policy)

### DIFF
--- a/browser/components/enterprisepolicies/Policies.sys.mjs
+++ b/browser/components/enterprisepolicies/Policies.sys.mjs
@@ -21,6 +21,8 @@ ChromeUtils.defineESModuleGetters(lazy, {
   AddonManager: "resource://gre/modules/AddonManager.sys.mjs",
   AddonManagerPrivate: "resource://gre/modules/AddonManager.sys.mjs",
   BookmarksPolicies: "resource:///modules/policies/BookmarksPolicies.sys.mjs",
+  ContentAnalysisPolicies:
+    "resource:///modules/policies/ContentAnalysisPolicies.sys.mjs",
   CustomizableUI:
     "moz-src:///browser/components/customizableui/CustomizableUI.sys.mjs",
   ExtensionPermissions: "resource://gre/modules/ExtensionPermissions.sys.mjs",
@@ -908,171 +910,12 @@ export var Policies = {
 
   ContentAnalysis: {
     onBeforeAddons(manager, param) {
-      // For security reasons, all of the Content Analysis related prefs should be locked in
-      // this method, even if the values aren't specified in Enterprise Policies.
-      lazy.PoliciesUtils.setPrefIfPresentAndLock(
-        param,
-        "PipePathName",
-        "browser.contentanalysis.pipe_path_name"
-      );
-      if ("AgentTimeout" in param) {
-        if (!Number.isInteger(param.AgentTimeout)) {
-          lazy.log.error(
-            `Non-integer value for AgentTimeout: ${param.AgentTimeout}`
-          );
-        } else {
-          lazy.PoliciesUtils.setAndLockPref(
-            "browser.contentanalysis.agent_timeout",
-            param.AgentTimeout
-          );
-        }
-      } else {
-        Services.prefs.lockPref("browser.contentanalysis.agent_timeout");
+      // The external agent is authoritative only when it is actually enabled; a
+      // ContentAnalysis block that does not enable an agent doesn't suppress
+      // built-in DLP.
+      if (param?.Enabled === true) {
+        lazy.ContentAnalysisPolicies.applyExternalContentAnalysis(param);
       }
-      lazy.PoliciesUtils.setPrefIfPresentAndLock(
-        param,
-        "AllowUrlRegexList",
-        "browser.contentanalysis.allow_url_regex_list"
-      );
-      lazy.PoliciesUtils.setPrefIfPresentAndLock(
-        param,
-        "DenyUrlRegexList",
-        "browser.contentanalysis.deny_url_regex_list"
-      );
-      lazy.PoliciesUtils.setPrefIfPresentAndLock(
-        param,
-        "AgentName",
-        "browser.contentanalysis.agent_name"
-      );
-      lazy.PoliciesUtils.setPrefIfPresentAndLock(
-        param,
-        "ClientSignature",
-        "browser.contentanalysis.client_signature"
-      );
-      lazy.PoliciesUtils.setPrefIfPresentAndLock(
-        param,
-        "MaxConnectionsCount",
-        "browser.contentanalysis.max_connections"
-      );
-      let resultPrefs = [
-        ["DefaultResult", "default_result"],
-        ["TimeoutResult", "timeout_result"],
-      ];
-      for (let pref of resultPrefs) {
-        if (pref[0] in param) {
-          if (
-            !Number.isInteger(param[pref[0]]) ||
-            param[pref[0]] < 0 ||
-            param[pref[0]] > 2
-          ) {
-            lazy.log.error(
-              `Non-integer or out of range value for ${pref[0]}: ${param[pref[0]]}`
-            );
-            Services.prefs.lockPref(`browser.contentanalysis.${pref[1]}`);
-          } else {
-            lazy.PoliciesUtils.setAndLockPref(
-              `browser.contentanalysis.${pref[1]}`,
-              param[pref[0]]
-            );
-          }
-        } else {
-          Services.prefs.lockPref(`browser.contentanalysis.${pref[1]}`);
-        }
-      }
-      let boolPrefs = [
-        ["IsPerUser", "is_per_user"],
-        ["ShowBlockedResult", "show_blocked_result"],
-        ["BypassForSameTabOperations", "bypass_for_same_tab_operations"],
-      ];
-      for (let pref of boolPrefs) {
-        if (pref[0] in param) {
-          lazy.PoliciesUtils.setAndLockPref(
-            `browser.contentanalysis.${pref[1]}`,
-            !!param[pref[0]]
-          );
-        } else {
-          Services.prefs.lockPref(`browser.contentanalysis.${pref[1]}`);
-        }
-      }
-      let interceptionPointPrefs = [
-        ["Clipboard", "clipboard"],
-        ["Download", "download"],
-        ["DragAndDrop", "drag_and_drop"],
-        ["FileUpload", "file_upload"],
-        ["Print", "print"],
-      ];
-      if ("InterceptionPoints" in param) {
-        for (let pref of interceptionPointPrefs) {
-          let value = true;
-          if (pref[0] in param.InterceptionPoints) {
-            if ("Enabled" in param.InterceptionPoints[pref[0]]) {
-              value = !!param.InterceptionPoints[pref[0]].Enabled;
-            }
-          }
-          lazy.PoliciesUtils.setAndLockPref(
-            `browser.contentanalysis.interception_point.${pref[1]}.enabled`,
-            value
-          );
-        }
-      } else {
-        for (let pref of interceptionPointPrefs) {
-          Services.prefs.lockPref(
-            `browser.contentanalysis.interception_point.${pref[1]}.enabled`
-          );
-        }
-      }
-      let plainTextOnlyPrefs = [
-        ["Clipboard", "clipboard"],
-        ["DragAndDrop", "drag_and_drop"],
-      ];
-      if ("InterceptionPoints" in param) {
-        for (let pref of plainTextOnlyPrefs) {
-          // Need to set and lock this value even if the enterprise
-          // policy isn't set so users can't change it
-          let value = true;
-          if ("InterceptionPoints" in param) {
-            if (pref[0] in param.InterceptionPoints) {
-              if ("PlainTextOnly" in param.InterceptionPoints[pref[0]]) {
-                value = !!param.InterceptionPoints[pref[0]].PlainTextOnly;
-              }
-            }
-          }
-          lazy.PoliciesUtils.setAndLockPref(
-            `browser.contentanalysis.interception_point.${pref[1]}.plain_text_only`,
-            value
-          );
-        }
-      } else {
-        for (let pref of plainTextOnlyPrefs) {
-          Services.prefs.lockPref(
-            `browser.contentanalysis.interception_point.${pref[1]}.plain_text_only`
-          );
-        }
-      }
-      if ("Enabled" in param) {
-        let enabled = !!param.Enabled;
-        lazy.PoliciesUtils.setAndLockPref(
-          "browser.contentanalysis.enabled",
-          enabled
-        );
-        let ca = Cc["@mozilla.org/contentanalysis;1"].getService(
-          Ci.nsIContentAnalysis
-        );
-        ca.isSetByEnterprisePolicy = true;
-      } else {
-        // Probably not strictly necessary, but let's lock everything
-        // to be consistent.
-        Services.prefs.lockPref("browser.contentanalysis.enabled");
-      }
-      // This will eventually be set by policy.
-      lazy.PoliciesUtils.setAndLockPref(
-        "browser.contentanalysis.use_wasm_backend",
-        false
-      );
-      lazy.PoliciesUtils.setAndLockPref(
-        "browser.contentanalysis.wasm_module_extension_require_signature",
-        true
-      );
     },
   },
 
@@ -1334,6 +1177,22 @@ export var Policies = {
       } catch (e) {
         // nsICrashReporter is unavailable in builds without the crash reporter.
       }
+    },
+  },
+
+  DataLossPrevention: {
+    onBeforeAddons(manager, param) {
+      // Surface rule problems the schema can't express (invalid ContentPatterns
+      // regexes) in about:policies#errors. Built-in DLP otherwise drives the
+      // same Content Analysis service as the external ContentAnalysis policy;
+      // reconcileContentAnalysis owns the shared prefs and the precedence.
+      for (let error of lazy.ContentAnalysisPolicies.validateDlpRules(
+        param.Rules ?? []
+      ).errors) {
+        lazy.log.error(error);
+      }
+
+      lazy.ContentAnalysisPolicies.applyBuiltinDlp(param);
     },
   },
 

--- a/browser/components/enterprisepolicies/Policies.sys.mjs
+++ b/browser/components/enterprisepolicies/Policies.sys.mjs
@@ -909,13 +909,12 @@ export var Policies = {
   },
 
   ContentAnalysis: {
-    onBeforeAddons(manager, param) {
-      // The external agent is authoritative only when it is actually enabled; a
-      // ContentAnalysis block that does not enable an agent doesn't suppress
-      // built-in DLP.
-      if (param?.Enabled === true) {
-        lazy.ContentAnalysisPolicies.applyExternalContentAnalysis(param);
-      }
+    onBeforeAddons(manager) {
+      // All Content Analysis prefs -- external-agent-only, the prefs shared with
+      // the built-in DataLossPrevention policy, and common (non-backend) prefs --
+      // are set and locked by reconcileContentAnalysis so the two policies
+      // arbitrate consistently, including on live policy updates.
+      lazy.ContentAnalysisPolicies.reconcileContentAnalysis(manager);
     },
   },
 
@@ -1191,8 +1190,7 @@ export var Policies = {
       ).errors) {
         lazy.log.error(error);
       }
-
-      lazy.ContentAnalysisPolicies.applyBuiltinDlp(param);
+      lazy.ContentAnalysisPolicies.reconcileContentAnalysis(manager);
     },
   },
 

--- a/browser/components/enterprisepolicies/content/aboutPolicies.js
+++ b/browser/components/enterprisepolicies/content/aboutPolicies.js
@@ -254,6 +254,7 @@ function generateErrors() {
     "WindowsGPOParser",
     "Enterprise Policies Child",
     "BookmarksPolicies",
+    "ContentAnalysisPolicies",
     "ProxyPolicies",
     "WebsiteFilter Policy",
     "macOSPoliciesParser",

--- a/browser/components/enterprisepolicies/helpers/ContentAnalysisPolicies.sys.mjs
+++ b/browser/components/enterprisepolicies/helpers/ContentAnalysisPolicies.sys.mjs
@@ -1,0 +1,318 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// ===========================================================================
+// Content Analysis / built-in DLP backend arbitration
+// ===========================================================================
+//
+// The ContentAnalysis (external agent) and DataLossPrevention (built-in WASM)
+// policies drive the same single-backend Content Analysis service, so a single
+// arbiter owns every pref they share. reconcileContentAnalysis runs from all
+// activation/removal callbacks of both policies: reading the full active set
+// of policies here yields the right result no matter which callbacks run.
+// The C++ service reselects its backend on EnterprisePolicies:PolicyUpdatesApplied,
+// after these prefs have settled.
+
+const PREF_LOGLEVEL = "browser.policies.loglevel";
+
+const lazy = {};
+
+ChromeUtils.defineESModuleGetters(lazy, {
+  PoliciesUtils: "resource://gre/modules/PoliciesHelpers.sys.mjs",
+});
+
+ChromeUtils.defineLazyGetter(lazy, "log", () => {
+  let { ConsoleAPI } = ChromeUtils.importESModule(
+    "resource://gre/modules/Console.sys.mjs"
+  );
+  return new ConsoleAPI({
+    prefix: "ContentAnalysisPolicies",
+    // tip: set maxLogLevel to "debug" and use log.debug() to create detailed
+    // messages during development. See LOG_LEVELS in Console.sys.mjs for details.
+    maxLogLevel: "warn",
+    maxLogLevelPref: PREF_LOGLEVEL,
+  });
+});
+
+// Build a browser.contentanalysis.* pref name.
+function caPrefName(suffix) {
+  return `browser.contentanalysis.${suffix}`;
+}
+
+// ContentAnalysis InterceptionPoints member name -> pref suffix.
+const CA_INTERCEPTION_POINTS = [
+  ["Clipboard", "clipboard"],
+  ["Download", "download"],
+  ["DragAndDrop", "drag_and_drop"],
+  ["FileUpload", "file_upload"],
+  ["Print", "print"],
+];
+const CA_PLAIN_TEXT_POINTS = [
+  ["Clipboard", "clipboard"],
+  ["DragAndDrop", "drag_and_drop"],
+];
+
+export const ContentAnalysisPolicies = {
+  // Apply prefs for setting up the external-agent provider.
+  applyExternalContentAnalysis(caParam) {
+    lazy.PoliciesUtils.setAndLockPref(caPrefName("enabled"), true);
+    lazy.PoliciesUtils.setAndLockPref(caPrefName("use_wasm_backend"), false);
+    lazy.PoliciesUtils.setAndLockPref(
+      caPrefName("wasm_module_extension_require_signature"),
+      true
+    );
+
+    applyContentAnalysisConfig(caParam);
+    lazy.PoliciesUtils.unsetAndUnlockPref(caPrefName("dlp_rules"));
+    markContentAnalysisPolicyControlled();
+  },
+
+  // Apply prefs for setting up the built-in DLP provider.
+  applyBuiltinDlp(dlpParam) {
+    lazy.PoliciesUtils.setAndLockPref(caPrefName("enabled"), true);
+    lazy.PoliciesUtils.setAndLockPref(caPrefName("use_wasm_backend"), true);
+    lazy.PoliciesUtils.setAndLockPref(
+      caPrefName("wasm_module_extension_require_signature"),
+      true
+    );
+
+    // The external agent isn't running, so these prefs are released.
+    for (let suffix of [
+      "pipe_path_name",
+      "client_signature",
+      "max_connections",
+      "is_per_user",
+    ]) {
+      lazy.PoliciesUtils.unsetAndUnlockPref(caPrefName(suffix));
+    }
+
+    // Built-in DLP policy does not have an explicit deny list, but encodes
+    // domain deny behavior in the DLP rules for processing by the engine.
+    lazy.PoliciesUtils.setAndLockPref(caPrefName("deny_url_regex_list"), "");
+    // The request timeout stays generous (the in-process module completes quickly)
+    lazy.PoliciesUtils.setAndLockPref(caPrefName("agent_timeout"), 300);
+    // Built-in DLP needs to show blocked results in Firefox
+    lazy.PoliciesUtils.setAndLockPref(caPrefName("show_blocked_result"), true);
+    // Built-in DLP does not allow bypassing same-tab operations
+    lazy.PoliciesUtils.setAndLockPref(
+      caPrefName("bypass_for_same_tab_operations"),
+      false
+    );
+    lazy.PoliciesUtils.setAndLockPref(
+      caPrefName("agent_name"),
+      "Firefox Enterprise DLP Engine"
+    );
+
+    // Derive interception points from the union of enabled rules' Actions, using
+    // only rules whose ContentPatterns are valid regexes (the invalid ones are
+    // reported to about:policies#errors and dropped here so they are neither
+    // enforced nor serialized).
+    let rules = this.validateDlpRules(dlpParam.Rules ?? []).valid;
+    // DLP Action -> the interception-point pref suffixes it needs enabled.
+    const DLP_ACTION_INTERCEPTION_POINTS = {
+      TextPaste: ["clipboard", "drag_and_drop"],
+      TextCopy: ["clipboard", "drag_and_drop"],
+      FileUpload: ["file_upload", "drag_and_drop"],
+      FileDownload: ["download"],
+      Print: ["print"],
+    };
+    let activeInterceptionPoints = new Set();
+    for (let rule of rules) {
+      if (rule.Enabled !== true) {
+        continue;
+      }
+      for (let action of rule.Actions ?? []) {
+        for (let suffix of DLP_ACTION_INTERCEPTION_POINTS[action] ?? []) {
+          activeInterceptionPoints.add(suffix);
+        }
+      }
+    }
+    for (let [, suffix] of CA_INTERCEPTION_POINTS) {
+      lazy.PoliciesUtils.setAndLockPref(
+        caPrefName(`interception_point.${suffix}.enabled`),
+        activeInterceptionPoints.has(suffix)
+      );
+    }
+
+    // Only look at plain-text interception points to avoid duplicate
+    // block/warn dialogs for the same action.
+    for (let [, suffix] of CA_PLAIN_TEXT_POINTS) {
+      lazy.PoliciesUtils.setAndLockPref(
+        caPrefName(`interception_point.${suffix}.plain_text_only`),
+        true
+      );
+    }
+
+    lazy.PoliciesUtils.setPrefIfPresentAndLock(
+      dlpParam,
+      "AllowUrlRegexList",
+      caPrefName("allow_url_regex_list")
+    );
+
+    // Map FallbackResult to the ContentAnalysis numeric result (0 = block/deny,
+    // 1 = warn, 2 = allow).
+    const DLP_FALLBACK_RESULT = { block: 0, warn: 1, allow: 2 };
+    let fallback = DLP_FALLBACK_RESULT[dlpParam.FallbackResult ?? "block"] ?? 0;
+    lazy.PoliciesUtils.setAndLockPref(caPrefName("default_result"), fallback);
+    lazy.PoliciesUtils.setAndLockPref(caPrefName("timeout_result"), fallback);
+
+    lazy.PoliciesUtils.setAndLockPref(
+      caPrefName("dlp_rules"),
+      JSON.stringify({ DLPRules: { Rules: rules } })
+    );
+
+    markContentAnalysisPolicyControlled();
+  },
+
+  // Validate DLP rules' ContentPatterns as regular expressions (a JS-regex
+  // approximation of the module's engine), which the JSON schema cannot check.
+  // Returns the rules whose patterns all compile (`valid`) and a message for
+  // each rule with an invalid pattern (`errors`).
+  validateDlpRules(rules) {
+    let valid = [];
+    let errors = [];
+    for (let rule of rules) {
+      let hasBadPattern = false;
+      for (let pattern of rule.ContentPatterns ?? []) {
+        try {
+          // Compiling throws on an invalid pattern; the result is unused.
+          RegExp(pattern);
+        } catch (e) {
+          hasBadPattern = true;
+          errors.push(
+            `DataLossPrevention rule "${rule.Name}": invalid ContentPatterns ` +
+              `regular expression ${JSON.stringify(pattern)} (${e.message})`
+          );
+        }
+      }
+      if (!hasBadPattern) {
+        valid.push(rule);
+      }
+    }
+    return { valid, errors };
+  },
+};
+
+// Set and lock the Content Analysis prefs for an active ContentAnalysis policy.
+// Used for the external agent and for an explicitly-disabled ContentAnalysis policy.
+function applyContentAnalysisConfig(caParam) {
+  lazy.PoliciesUtils.setPrefIfPresentAndLock(
+    caParam,
+    "PipePathName",
+    caPrefName("pipe_path_name")
+  );
+  lazy.PoliciesUtils.setPrefIfPresentAndLock(
+    caParam,
+    "ClientSignature",
+    caPrefName("client_signature")
+  );
+  lazy.PoliciesUtils.setPrefIfPresentAndLock(
+    caParam,
+    "MaxConnectionsCount",
+    caPrefName("max_connections")
+  );
+
+  for (let [key, suffix] of [
+    ["DefaultResult", "default_result"],
+    ["TimeoutResult", "timeout_result"],
+  ]) {
+    if (key in caParam) {
+      let value = caParam[key];
+      if (!Number.isInteger(value) || value < 0 || value > 2) {
+        lazy.log.error(
+          `Non-integer or out of range value for ${key}: ${value}`
+        );
+        Services.prefs.lockPref(caPrefName(suffix));
+      } else {
+        lazy.PoliciesUtils.setAndLockPref(caPrefName(suffix), value);
+      }
+    } else {
+      Services.prefs.lockPref(caPrefName(suffix));
+    }
+  }
+  lazy.PoliciesUtils.setPrefIfPresentAndLock(
+    caParam,
+    "AllowUrlRegexList",
+    caPrefName("allow_url_regex_list")
+  );
+  lazy.PoliciesUtils.setPrefIfPresentAndLock(
+    caParam,
+    "DenyUrlRegexList",
+    caPrefName("deny_url_regex_list")
+  );
+  lazy.PoliciesUtils.setPrefIfPresentAndLock(
+    caParam,
+    "AgentName",
+    caPrefName("agent_name")
+  );
+  if ("AgentTimeout" in caParam) {
+    if (!Number.isInteger(caParam.AgentTimeout)) {
+      lazy.log.error(
+        `Non-integer value for AgentTimeout: ${caParam.AgentTimeout}`
+      );
+    } else {
+      lazy.PoliciesUtils.setAndLockPref(
+        caPrefName("agent_timeout"),
+        caParam.AgentTimeout
+      );
+    }
+  } else {
+    Services.prefs.lockPref(caPrefName("agent_timeout"));
+  }
+  for (let [key, suffix] of [
+    ["IsPerUser", "is_per_user"],
+    ["ShowBlockedResult", "show_blocked_result"],
+    ["BypassForSameTabOperations", "bypass_for_same_tab_operations"],
+  ]) {
+    if (key in caParam) {
+      lazy.PoliciesUtils.setAndLockPref(caPrefName(suffix), !!caParam[key]);
+    } else {
+      Services.prefs.lockPref(caPrefName(suffix));
+    }
+  }
+  if ("InterceptionPoints" in caParam) {
+    for (let [key, suffix] of CA_INTERCEPTION_POINTS) {
+      let value = true;
+      let point = caParam.InterceptionPoints[key];
+      if (point && "Enabled" in point) {
+        value = !!point.Enabled;
+      }
+      lazy.PoliciesUtils.setAndLockPref(
+        caPrefName(`interception_point.${suffix}.enabled`),
+        value
+      );
+    }
+    for (let [key, suffix] of CA_PLAIN_TEXT_POINTS) {
+      let value = true;
+      let point = caParam.InterceptionPoints[key];
+      if (point && "PlainTextOnly" in point) {
+        value = !!point.PlainTextOnly;
+      }
+      lazy.PoliciesUtils.setAndLockPref(
+        caPrefName(`interception_point.${suffix}.plain_text_only`),
+        value
+      );
+    }
+  } else {
+    for (let [, suffix] of CA_INTERCEPTION_POINTS) {
+      Services.prefs.lockPref(
+        caPrefName(`interception_point.${suffix}.enabled`)
+      );
+    }
+    for (let [, suffix] of CA_PLAIN_TEXT_POINTS) {
+      Services.prefs.lockPref(
+        caPrefName(`interception_point.${suffix}.plain_text_only`)
+      );
+    }
+  }
+}
+
+// Ensure the Content Analysis service exists (so it can observe policy updates)
+// and mark it as controlled by enterprise policy.
+function markContentAnalysisPolicyControlled() {
+  let ca = Cc["@mozilla.org/contentanalysis;1"].getService(
+    Ci.nsIContentAnalysis
+  );
+  ca.isSetByEnterprisePolicy = true;
+}

--- a/browser/components/enterprisepolicies/helpers/ContentAnalysisPolicies.sys.mjs
+++ b/browser/components/enterprisepolicies/helpers/ContentAnalysisPolicies.sys.mjs
@@ -54,115 +54,21 @@ const CA_PLAIN_TEXT_POINTS = [
 ];
 
 export const ContentAnalysisPolicies = {
-  // Apply prefs for setting up the external-agent provider.
-  applyExternalContentAnalysis(caParam) {
-    lazy.PoliciesUtils.setAndLockPref(caPrefName("enabled"), true);
-    lazy.PoliciesUtils.setAndLockPref(caPrefName("use_wasm_backend"), false);
-    lazy.PoliciesUtils.setAndLockPref(
-      caPrefName("wasm_module_extension_require_signature"),
-      true
-    );
+  reconcileContentAnalysis(manager) {
+    let active = manager.getActivePolicies() ?? {};
+    let caParam = active.ContentAnalysis;
+    let dlpParam = active.DataLossPrevention;
 
-    applyContentAnalysisConfig(caParam);
-    lazy.PoliciesUtils.unsetAndUnlockPref(caPrefName("dlp_rules"));
-    markContentAnalysisPolicyControlled();
-  },
-
-  // Apply prefs for setting up the built-in DLP provider.
-  applyBuiltinDlp(dlpParam) {
-    lazy.PoliciesUtils.setAndLockPref(caPrefName("enabled"), true);
-    lazy.PoliciesUtils.setAndLockPref(caPrefName("use_wasm_backend"), true);
-    lazy.PoliciesUtils.setAndLockPref(
-      caPrefName("wasm_module_extension_require_signature"),
-      true
-    );
-
-    // The external agent isn't running, so these prefs are released.
-    for (let suffix of [
-      "pipe_path_name",
-      "client_signature",
-      "max_connections",
-      "is_per_user",
-    ]) {
-      lazy.PoliciesUtils.unsetAndUnlockPref(caPrefName(suffix));
+    // The external agent is authoritative only when it is actually enabled; a
+    // ContentAnalysis block that does not enable an agent doesn't suppress
+    // built-in DLP.
+    if (caParam?.Enabled === true) {
+      applyExternalContentAnalysis(caParam);
+    } else if (dlpParam) {
+      applyBuiltinDlp(dlpParam);
+    } else {
+      disableContentAnalysis(caParam);
     }
-
-    // Built-in DLP policy does not have an explicit deny list, but encodes
-    // domain deny behavior in the DLP rules for processing by the engine.
-    lazy.PoliciesUtils.setAndLockPref(caPrefName("deny_url_regex_list"), "");
-    // The request timeout stays generous (the in-process module completes quickly)
-    lazy.PoliciesUtils.setAndLockPref(caPrefName("agent_timeout"), 300);
-    // Built-in DLP needs to show blocked results in Firefox
-    lazy.PoliciesUtils.setAndLockPref(caPrefName("show_blocked_result"), true);
-    // Built-in DLP does not allow bypassing same-tab operations
-    lazy.PoliciesUtils.setAndLockPref(
-      caPrefName("bypass_for_same_tab_operations"),
-      false
-    );
-    lazy.PoliciesUtils.setAndLockPref(
-      caPrefName("agent_name"),
-      "Firefox Enterprise DLP Engine"
-    );
-
-    // Derive interception points from the union of enabled rules' Actions, using
-    // only rules whose ContentPatterns are valid regexes (the invalid ones are
-    // reported to about:policies#errors and dropped here so they are neither
-    // enforced nor serialized).
-    let rules = this.validateDlpRules(dlpParam.Rules ?? []).valid;
-    // DLP Action -> the interception-point pref suffixes it needs enabled.
-    const DLP_ACTION_INTERCEPTION_POINTS = {
-      TextPaste: ["clipboard", "drag_and_drop"],
-      TextCopy: ["clipboard", "drag_and_drop"],
-      FileUpload: ["file_upload", "drag_and_drop"],
-      FileDownload: ["download"],
-      Print: ["print"],
-    };
-    let activeInterceptionPoints = new Set();
-    for (let rule of rules) {
-      if (rule.Enabled !== true) {
-        continue;
-      }
-      for (let action of rule.Actions ?? []) {
-        for (let suffix of DLP_ACTION_INTERCEPTION_POINTS[action] ?? []) {
-          activeInterceptionPoints.add(suffix);
-        }
-      }
-    }
-    for (let [, suffix] of CA_INTERCEPTION_POINTS) {
-      lazy.PoliciesUtils.setAndLockPref(
-        caPrefName(`interception_point.${suffix}.enabled`),
-        activeInterceptionPoints.has(suffix)
-      );
-    }
-
-    // Only look at plain-text interception points to avoid duplicate
-    // block/warn dialogs for the same action.
-    for (let [, suffix] of CA_PLAIN_TEXT_POINTS) {
-      lazy.PoliciesUtils.setAndLockPref(
-        caPrefName(`interception_point.${suffix}.plain_text_only`),
-        true
-      );
-    }
-
-    lazy.PoliciesUtils.setPrefIfPresentAndLock(
-      dlpParam,
-      "AllowUrlRegexList",
-      caPrefName("allow_url_regex_list")
-    );
-
-    // Map FallbackResult to the ContentAnalysis numeric result (0 = block/deny,
-    // 1 = warn, 2 = allow).
-    const DLP_FALLBACK_RESULT = { block: 0, warn: 1, allow: 2 };
-    let fallback = DLP_FALLBACK_RESULT[dlpParam.FallbackResult ?? "block"] ?? 0;
-    lazy.PoliciesUtils.setAndLockPref(caPrefName("default_result"), fallback);
-    lazy.PoliciesUtils.setAndLockPref(caPrefName("timeout_result"), fallback);
-
-    lazy.PoliciesUtils.setAndLockPref(
-      caPrefName("dlp_rules"),
-      JSON.stringify({ DLPRules: { Rules: rules } })
-    );
-
-    markContentAnalysisPolicyControlled();
   },
 
   // Validate DLP rules' ContentPatterns as regular expressions (a JS-regex
@@ -193,6 +99,169 @@ export const ContentAnalysisPolicies = {
     return { valid, errors };
   },
 };
+
+// Apply prefs for setting up the external-agent provider.
+function applyExternalContentAnalysis(caParam) {
+  lazy.PoliciesUtils.setAndLockPref(caPrefName("enabled"), true);
+  lazy.PoliciesUtils.setAndLockPref(caPrefName("use_wasm_backend"), false);
+  lazy.PoliciesUtils.setAndLockPref(
+    caPrefName("wasm_module_extension_require_signature"),
+    true
+  );
+
+  applyContentAnalysisConfig(caParam);
+  lazy.PoliciesUtils.unsetAndUnlockPref(caPrefName("dlp_rules"));
+  markContentAnalysisPolicyControlled();
+}
+
+// Apply prefs for setting up the built-in DLP provider.
+function applyBuiltinDlp(dlpParam) {
+  lazy.PoliciesUtils.setAndLockPref(caPrefName("enabled"), true);
+  lazy.PoliciesUtils.setAndLockPref(caPrefName("use_wasm_backend"), true);
+  lazy.PoliciesUtils.setAndLockPref(
+    caPrefName("wasm_module_extension_require_signature"),
+    true
+  );
+
+  // The external agent isn't running, so these prefs are released.
+  for (let suffix of [
+    "pipe_path_name",
+    "client_signature",
+    "max_connections",
+    "is_per_user",
+  ]) {
+    lazy.PoliciesUtils.unsetAndUnlockPref(caPrefName(suffix));
+  }
+
+  // Built-in DLP policy does not have an explicit deny list, but encodes
+  // domain deny behavior in the DLP rules for processing by the engine.
+  lazy.PoliciesUtils.setAndLockPref(caPrefName("deny_url_regex_list"), "");
+  // The request timeout stays generous (the in-process module completes quickly)
+  lazy.PoliciesUtils.setAndLockPref(caPrefName("agent_timeout"), 300);
+  // Built-in DLP needs to show blocked results in Firefox
+  lazy.PoliciesUtils.setAndLockPref(caPrefName("show_blocked_result"), true);
+  // Built-in DLP does not allow bypassing same-tab operations
+  lazy.PoliciesUtils.setAndLockPref(
+    caPrefName("bypass_for_same_tab_operations"),
+    false
+  );
+  lazy.PoliciesUtils.setAndLockPref(
+    caPrefName("agent_name"),
+    "Firefox Enterprise DLP Engine"
+  );
+
+  // Derive interception points from the union of enabled rules' Actions, using
+  // only rules whose ContentPatterns are valid regexes (the invalid ones are
+  // reported to about:policies#errors and dropped here so they are neither
+  // enforced nor serialized).
+  let rules = ContentAnalysisPolicies.validateDlpRules(
+    dlpParam.Rules ?? []
+  ).valid;
+  // DLP Action -> the interception-point pref suffixes it needs enabled.
+  const DLP_ACTION_INTERCEPTION_POINTS = {
+    TextPaste: ["clipboard", "drag_and_drop"],
+    TextCopy: ["clipboard", "drag_and_drop"],
+    FileUpload: ["file_upload", "drag_and_drop"],
+    FileDownload: ["download"],
+    Print: ["print"],
+  };
+  let activeInterceptionPoints = new Set();
+  for (let rule of rules) {
+    if (rule.Enabled !== true) {
+      continue;
+    }
+    for (let action of rule.Actions ?? []) {
+      for (let suffix of DLP_ACTION_INTERCEPTION_POINTS[action] ?? []) {
+        activeInterceptionPoints.add(suffix);
+      }
+    }
+  }
+  for (let [, suffix] of CA_INTERCEPTION_POINTS) {
+    lazy.PoliciesUtils.setAndLockPref(
+      caPrefName(`interception_point.${suffix}.enabled`),
+      activeInterceptionPoints.has(suffix)
+    );
+  }
+
+  // Only look at plain-text interception points to avoid duplicate
+  // block/warn dialogs for the same action.
+  for (let [, suffix] of CA_PLAIN_TEXT_POINTS) {
+    lazy.PoliciesUtils.setAndLockPref(
+      caPrefName(`interception_point.${suffix}.plain_text_only`),
+      true
+    );
+  }
+
+  lazy.PoliciesUtils.setPrefIfPresentAndLock(
+    dlpParam,
+    "AllowUrlRegexList",
+    caPrefName("allow_url_regex_list")
+  );
+
+  // Map FallbackResult to the ContentAnalysis numeric result (0 = block/deny,
+  // 1 = warn, 2 = allow).
+  const DLP_FALLBACK_RESULT = { block: 0, warn: 1, allow: 2 };
+  let fallback = DLP_FALLBACK_RESULT[dlpParam.FallbackResult ?? "block"] ?? 0;
+  lazy.PoliciesUtils.setAndLockPref(caPrefName("default_result"), fallback);
+  lazy.PoliciesUtils.setAndLockPref(caPrefName("timeout_result"), fallback);
+
+  lazy.PoliciesUtils.setAndLockPref(
+    caPrefName("dlp_rules"),
+    JSON.stringify({ DLPRules: { Rules: rules } })
+  );
+
+  markContentAnalysisPolicyControlled();
+}
+
+// Turn both providers off. A still-present (disabled) ContentAnalysis policy
+// keeps its config locked with the service disabled to match previous behavior.
+function disableContentAnalysis(caParam) {
+  if (!caParam) {
+    for (let suffix of [
+      "enabled",
+      "use_wasm_backend",
+      "wasm_module_extension_require_signature",
+      "default_result",
+      "timeout_result",
+      "dlp_rules",
+      "allow_url_regex_list",
+      "deny_url_regex_list",
+      "agent_timeout",
+      "show_blocked_result",
+      "bypass_for_same_tab_operations",
+      "agent_name",
+      "pipe_path_name",
+      "client_signature",
+      "max_connections",
+      "is_per_user",
+    ]) {
+      lazy.PoliciesUtils.unsetAndUnlockPref(caPrefName(suffix));
+    }
+    for (let [, suffix] of CA_INTERCEPTION_POINTS) {
+      lazy.PoliciesUtils.unsetAndUnlockPref(
+        caPrefName(`interception_point.${suffix}.enabled`)
+      );
+    }
+    for (let [, suffix] of CA_PLAIN_TEXT_POINTS) {
+      lazy.PoliciesUtils.unsetAndUnlockPref(
+        caPrefName(`interception_point.${suffix}.plain_text_only`)
+      );
+    }
+    return;
+  }
+
+  lazy.PoliciesUtils.setAndLockPref(caPrefName("enabled"), false);
+  lazy.PoliciesUtils.setAndLockPref(caPrefName("use_wasm_backend"), false);
+  lazy.PoliciesUtils.setAndLockPref(
+    caPrefName("wasm_module_extension_require_signature"),
+    true
+  );
+  applyContentAnalysisConfig(caParam);
+  lazy.PoliciesUtils.unsetAndUnlockPref(caPrefName("dlp_rules"));
+  if ("Enabled" in caParam) {
+    markContentAnalysisPolicyControlled();
+  }
+}
 
 // Set and lock the Content Analysis prefs for an active ContentAnalysis policy.
 // Used for the external agent and for an explicitly-disabled ContentAnalysis policy.

--- a/browser/components/enterprisepolicies/helpers/moz.build
+++ b/browser/components/enterprisepolicies/helpers/moz.build
@@ -8,6 +8,7 @@ with Files("**"):
 EXTRA_JS_MODULES.policies += [
     "AIChatbotPolicies.sys.mjs",
     "BookmarksPolicies.sys.mjs",
+    "ContentAnalysisPolicies.sys.mjs",
     "ProxyPolicies.sys.mjs",
     "WebsiteFilter.sys.mjs",
 ]

--- a/browser/components/enterprisepolicies/schemas/policies-schema.json
+++ b/browser/components/enterprisepolicies/schemas/policies-schema.json
@@ -917,6 +917,81 @@
       }
     },
 
+    "DataLossPrevention": {
+      "type": "object",
+      "x-category": "Cloud reporting",
+      "description": "Configure built-in Data Loss Prevention rules that warn on or block data actions (paste, copy, upload, download, print) per domain.",
+      "examples": [
+        {
+          "FallbackResult": "block",
+          "AllowUrlRegexList": "https://example.com/.* https://subdomain.example.com/.*",
+          "Rules": [
+            {
+              "Name": "warn-ai-paste",
+              "Enabled": true,
+              "Actions": ["TextPaste"],
+              "Domains": ["chatgpt.com", "claude.ai"],
+              "Type": "warn",
+              "Message": "Pasting work data into AI services may violate company policy."
+            }
+          ]
+        }
+      ],
+      "properties": {
+        "FallbackResult": {
+          "type": "string",
+          "enum": ["block", "warn", "allow"]
+        },
+        "AllowUrlRegexList": {
+          "type": "string"
+        },
+        "Rules": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "Name": {
+                "type": "string",
+                "pattern": "^[a-z0-9-]{1,64}$"
+              },
+              "Enabled": {
+                "type": "boolean"
+              },
+              "Actions": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "type": "string",
+                  "enum": ["TextPaste", "FileUpload", "FileDownload", "Print"]
+                }
+              },
+              "Domains": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "type": "string"
+                }
+              },
+              "ContentPatterns": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "Type": {
+                "type": "string",
+                "enum": ["warn", "block"]
+              },
+              "Message": {
+                "type": "string"
+              }
+            },
+            "required": ["Name", "Actions", "Domains", "Type"]
+          }
+        }
+      }
+    },
+
     "DefaultBrowserSettingEnabled": {
       "type": "boolean",
       "x-category": "Startup",

--- a/browser/components/enterprisepolicies/tests/browser/browser.toml
+++ b/browser/components/enterprisepolicies/tests/browser/browser.toml
@@ -53,6 +53,8 @@ support-files = "favicon.svg"
 ["browser_policy_cookie_settings.js"]
 https_first_disabled = true
 
+["browser_policy_data_loss_prevention.js"]
+
 ["browser_policy_default_browser_setting.js"]
 
 ["browser_policy_disable_buttons.js"]

--- a/browser/components/enterprisepolicies/tests/browser/browser_policy_data_loss_prevention.js
+++ b/browser/components/enterprisepolicies/tests/browser/browser_policy_data_loss_prevention.js
@@ -1,0 +1,145 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+// Verifies the DataLossPrevention policy and its arbitration with the external
+// ContentAnalysis policy, as implemented by reconcileContentAnalysis in
+// Policies.sys.mjs. Assertions are on the browser.contentanalysis.* prefs the
+// handler sets; the built-in WASM backend consumes them.
+
+const CA_PREFIX = "browser.contentanalysis.";
+
+const INTERCEPTION_POINTS = [
+  "clipboard",
+  "download",
+  "drag_and_drop",
+  "file_upload",
+  "print",
+];
+
+function getSerializedRules() {
+  let json = Services.prefs.getStringPref(CA_PREFIX + "dlp_rules", "");
+  return json ? JSON.parse(json).DLPRules.Rules : [];
+}
+
+registerCleanupFunction(async function () {
+  await setupPolicyEngineWithJson({ policies: {} });
+});
+
+add_task(async function test_builtin_dlp_only() {
+  await setupPolicyEngineWithJson({
+    policies: {
+      DataLossPrevention: {
+        FallbackResult: "block",
+        Rules: [
+          {
+            Name: "warn-ai-paste",
+            Enabled: true,
+            Actions: ["TextPaste"],
+            Domains: ["chatgpt.com"],
+            Type: "warn",
+          },
+        ],
+      },
+    },
+  });
+
+  is(Services.prefs.getBoolPref(CA_PREFIX + "enabled"), true, "CA enabled");
+  is(
+    Services.prefs.getBoolPref(CA_PREFIX + "use_wasm_backend"),
+    true,
+    "built-in WASM backend selected"
+  );
+  is(
+    Services.prefs.getStringPref(CA_PREFIX + "agent_name", ""),
+    "Firefox Enterprise DLP Engine",
+    "built-in agent name set"
+  );
+  // FallbackResult "block" maps to the numeric result 0.
+  is(
+    Services.prefs.getIntPref(CA_PREFIX + "default_result"),
+    0,
+    "default_result"
+  );
+  is(
+    Services.prefs.getIntPref(CA_PREFIX + "timeout_result"),
+    0,
+    "timeout_result"
+  );
+
+  // TextPaste derives clipboard + drag_and_drop; the rest are off.
+  let expectedOn = new Set(["clipboard", "drag_and_drop"]);
+  for (let point of INTERCEPTION_POINTS) {
+    is(
+      Services.prefs.getBoolPref(
+        `${CA_PREFIX}interception_point.${point}.enabled`
+      ),
+      expectedOn.has(point),
+      `interception_point.${point}.enabled`
+    );
+  }
+
+  let rules = getSerializedRules();
+  is(rules.length, 1, "one rule serialized to dlp_rules");
+  is(rules[0].Name, "warn-ai-paste", "correct rule serialized");
+});
+
+add_task(async function test_builtin_active_when_external_disabled() {
+  await setupPolicyEngineWithJson({
+    policies: {
+      ContentAnalysis: { Enabled: false },
+      DataLossPrevention: {
+        Rules: [
+          {
+            Name: "block-upload",
+            Enabled: true,
+            Actions: ["FileUpload"],
+            Domains: ["dropbox.com"],
+            Type: "block",
+          },
+        ],
+      },
+    },
+  });
+
+  is(
+    Services.prefs.getBoolPref(CA_PREFIX + "use_wasm_backend"),
+    true,
+    "built-in backend runs when ContentAnalysis is present but disabled"
+  );
+  let rules = getSerializedRules();
+  is(rules.length, 1, "built-in rule delivered");
+  is(rules[0].Name, "block-upload", "correct rule");
+});
+
+add_task(async function test_invalid_regex_rule_excluded() {
+  await setupPolicyEngineWithJson({
+    policies: {
+      DataLossPrevention: {
+        Rules: [
+          {
+            Name: "bad-pattern",
+            Enabled: true,
+            Actions: ["FileUpload"],
+            Domains: ["*"],
+            ContentPatterns: ["("],
+            Type: "block",
+          },
+          {
+            Name: "good-pattern",
+            Enabled: true,
+            Actions: ["FileUpload"],
+            Domains: ["*"],
+            ContentPatterns: ["secret"],
+            Type: "block",
+          },
+        ],
+      },
+    },
+  });
+
+  let rules = getSerializedRules();
+  is(rules.length, 1, "rule with an invalid ContentPatterns regex is excluded");
+  is(rules[0].Name, "good-pattern", "the valid rule survives");
+});

--- a/browser/components/enterprisepolicies/tests/browser/browser_policy_data_loss_prevention.js
+++ b/browser/components/enterprisepolicies/tests/browser/browser_policy_data_loss_prevention.js
@@ -5,8 +5,9 @@
 
 // Verifies the DataLossPrevention policy and its arbitration with the external
 // ContentAnalysis policy, as implemented by reconcileContentAnalysis in
-// Policies.sys.mjs. Assertions are on the browser.contentanalysis.* prefs the
-// handler sets; the built-in WASM backend consumes them.
+// ContentAnalysisPolicies.sys.mjs. Assertions are on the
+// browser.contentanalysis.* prefs the handler sets; the built-in WASM backend
+// consumes them.
 
 const CA_PREFIX = "browser.contentanalysis.";
 
@@ -83,6 +84,37 @@ add_task(async function test_builtin_dlp_only() {
   let rules = getSerializedRules();
   is(rules.length, 1, "one rule serialized to dlp_rules");
   is(rules[0].Name, "warn-ai-paste", "correct rule serialized");
+});
+
+add_task(async function test_external_suppresses_builtin() {
+  await setupPolicyEngineWithJson({
+    policies: {
+      ContentAnalysis: { Enabled: true },
+      DataLossPrevention: {
+        Rules: [
+          {
+            Name: "warn-ai-paste",
+            Enabled: true,
+            Actions: ["TextPaste"],
+            Domains: ["chatgpt.com"],
+            Type: "warn",
+          },
+        ],
+      },
+    },
+  });
+
+  is(Services.prefs.getBoolPref(CA_PREFIX + "enabled"), true, "CA enabled");
+  is(
+    Services.prefs.getBoolPref(CA_PREFIX + "use_wasm_backend"),
+    false,
+    "external agent backend selected when ContentAnalysis is enabled"
+  );
+  is(
+    Services.prefs.getStringPref(CA_PREFIX + "dlp_rules", ""),
+    "",
+    "built-in rules not delivered while the external agent is authoritative"
+  );
 });
 
 add_task(async function test_builtin_active_when_external_disabled() {

--- a/browser/locales/en-US/browser/enterprise/enterprise-policies-descriptions.ftl
+++ b/browser/locales/en-US/browser/enterprise/enterprise-policies-descriptions.ftl
@@ -6,6 +6,7 @@ policy-AccessConnector2 = Configure the { -enterprise-feature-access-connector }
 policy-AIChatbot = Configure available AI chatbot providers, default provider, and prompt features.
 policy-BlocklistDomainBrowsedTelemetry = Enable and configure security logging/telemetry when { -brand-short-name } blocks a visit to a blocklisted domain.
 policy-ContentAnalysisTelemetry = Enable and configure security logging/telemetry when a DLP rule is triggered.
+policy-DataLossPrevention = Enable and configure built-in data-loss-prevention engine.
 policy-DisableLocalPolicies = Disable all local policy sources (policies.json, Windows GPO and macOS plist).
 policy-DownloadTelemetry = Enable and configure security logging/telemetry when a download is triggered.
 policy-EnterpriseStorageEncryption = Enable enterprise-managed primary password for encrypted storage.

--- a/modules/libpref/init/StaticPrefList.yaml
+++ b/modules/libpref/init/StaticPrefList.yaml
@@ -1322,6 +1322,14 @@
   value: true
   mirror: never
 
+# The rule set (the DLPRules JSON) consulted by the built-in DLP backend.
+# Set by the DataLossPrevention enterprise policy.
+# Empty means no rules.
+- name: browser.contentanalysis.dlp_rules
+  type: String
+  value: ""
+  mirror: never
+
 # On Windows, whether to bring the foreground window to the front when printing
 # to avoid a DLP agent stealing focus and cancelling the print (bug 1980225)
 - name: browser.contentanalysis.print_set_foreground_window

--- a/toolkit/components/contentanalysis/ContentAnalysisRuleParser.cpp
+++ b/toolkit/components/contentanalysis/ContentAnalysisRuleParser.cpp
@@ -58,6 +58,8 @@ bool ActionToAnalysisType(const nsAString& aAction, uint32_t* aOut) {
     *aOut = static_cast<uint32_t>(AnalysisType::eFileAttached);
   } else if (aAction.LowerCaseEqualsLiteral("textpaste")) {
     *aOut = static_cast<uint32_t>(AnalysisType::eBulkDataEntry);
+  } else if (aAction.LowerCaseEqualsLiteral("textcopy")) {
+    *aOut = static_cast<uint32_t>(AnalysisType::eDataCopied);
   } else if (aAction.LowerCaseEqualsLiteral("print")) {
     *aOut = static_cast<uint32_t>(AnalysisType::ePrint);
   } else {
@@ -95,6 +97,10 @@ nsTArray<nsString> ToStringArray(const dom::Sequence<nsString>& aSeq) {
 
 }  // namespace
 
+// Errors here are unexpected because the rules are validated on policy
+// application. Just in case, any errors here are logged and offending rules are
+// skipped so the remaining valid rules still take effect. A total failure to
+// parse any rules is returned as an error.
 nsresult ParseContentAnalysisRules(
     const nsAString& aJSON,
     nsTArray<RefPtr<nsIContentAnalysisRule>>& aOutRules) {
@@ -106,28 +112,45 @@ nsresult ParseContentAnalysisRules(
   nsTArray<RefPtr<nsIContentAnalysisRule>> rules;
   // Most rules will probably be enabled, so set the capacity up front.
   rules.SetCapacity(config.mDLPRules.mRules.Length());
+  uint32_t enabledCount = 0;
   for (const auto& jsonRule : config.mDLPRules.mRules) {
     if (!jsonRule.mEnabled) {
       continue;
     }
+    ++enabledCount;
 
+    // A rule with an unrecognized action or type is skipped (the helpers log
+    // the offending value) so the remaining valid rules still take effect.
     nsTArray<uint32_t> operations;
+    bool operationsOk = true;
     for (const auto& action : jsonRule.mActions) {
       uint32_t op;
       if (!ActionToAnalysisType(action, &op)) {
-        return NS_ERROR_INVALID_ARG;
+        operationsOk = false;
+        break;
       }
       operations.AppendElement(op);
+    }
+    if (!operationsOk) {
+      continue;
     }
 
     uint8_t verdict;
     if (!TypeToVerdict(jsonRule.mType, &verdict)) {
-      return NS_ERROR_INVALID_ARG;
+      continue;
     }
 
     rules.AppendElement(MakeRefPtr<ContentAnalysisRule>(
         jsonRule.mName, std::move(operations), ToStringArray(jsonRule.mDomains),
         ToStringArray(jsonRule.mContentPatterns), verdict, jsonRule.mMessage));
+  }
+
+  // If every configured rule failed to parse, treat it as a total failure so
+  // the caller can fail closed rather than silently enforcing nothing.
+  if (enabledCount > 0 && rules.IsEmpty()) {
+    MOZ_LOG(gContentAnalysisLog, LogLevel::Error,
+            ("All %u enabled DLP rules failed to parse", enabledCount));
+    return NS_ERROR_INVALID_ARG;
   }
 
   aOutRules.AppendElements(std::move(rules));

--- a/toolkit/components/contentanalysis/WasmModuleBackend.cpp
+++ b/toolkit/components/contentanalysis/WasmModuleBackend.cpp
@@ -35,44 +35,19 @@ extern LazyLogModule gContentAnalysisLog;
 
 namespace {
 
-// An example DLP rule set, in the same JSON format as the enterprise DLP
-// rules config. In the future, rules will come from enterprise policy, but
-// for now these rules are hard-coded to allow experimentation. Rule matching
-// (operation, domain, content) happens in the module.
-static constexpr auto kExampleRulesJSON = R"JSON({
-  "DLPRules": {
-    "Rules": [
-      {
-        "Name": "warn-ai-paste",
-        "Enabled": true,
-        "Actions": ["TextPaste", "FileUpload"],
-        "Domains": ["chatgpt.com", "claude.ai", "gemini.google.com"],
-        "Type": "warn",
-        "Message": "Pasting work data into AI services may violate company policy."
-      },
-      {
-        "Name": "block-cloud-uploads",
-        "Enabled": true,
-        "Actions": ["FileUpload"],
-        "Domains": ["drive.google.com", "dropbox.com", "wetransfer.com"],
-        "Type": "block"
-      },
-      {
-        "Name": "block-confidential-content",
-        "Enabled": true,
-        "ContentPatterns": ["\\bCONFIDENTIAL\\b"],
-        "Type": "block",
-        "Message": "Content marked CONFIDENTIAL may not leave the organization."
-      }
-    ]
-  }
-})JSON";
+// The pref carrying the built-in DLP rule set (the DLPRules JSON), set by the
+// DataLossPrevention enterprise policy.
+static constexpr char kDlpRulesPref[] = "browser.contentanalysis.dlp_rules";
 
-static nsTArray<RefPtr<nsIContentAnalysisRule>> BuildExampleRules() {
-  nsTArray<RefPtr<nsIContentAnalysisRule>> rules;
-  MOZ_ALWAYS_SUCCEEDS(ParseContentAnalysisRules(
-      NS_ConvertUTF8toUTF16(kExampleRulesJSON), rules));
-  return rules;
+static nsresult LoadDlpRules(nsTArray<RefPtr<nsIContentAnalysisRule>>& aRules) {
+  nsAutoString rulesJSON;
+  nsresult rv = Preferences::GetString(kDlpRulesPref, rulesJSON);
+  NS_ENSURE_SUCCESS(rv, rv);
+  if (rulesJSON.IsEmpty()) {
+    // No rules configured: nothing to enforce.
+    return NS_OK;
+  }
+  return ParseContentAnalysisRules(rulesJSON, aRules);
 }
 
 // Recover the nsresult from a rejected wasm-runner promise. The runner
@@ -168,7 +143,9 @@ nsresult WasmModuleBackend::Analyze(
     return NS_ERROR_FAILURE;
   }
 
-  nsTArray<RefPtr<nsIContentAnalysisRule>> rules = BuildExampleRules();
+  nsTArray<RefPtr<nsIContentAnalysisRule>> rules;
+  rv = LoadDlpRules(rules);
+  NS_ENSURE_SUCCESS(rv, rv);
 
   nsIContentAnalysisRequest::AnalysisType type =
       nsIContentAnalysisRequest::AnalysisType::eUnspecified;

--- a/toolkit/components/contentanalysis/tests/gtest/TestContentAnalysisRuleParser.cpp
+++ b/toolkit/components/contentanalysis/tests/gtest/TestContentAnalysisRuleParser.cpp
@@ -192,3 +192,94 @@ TEST(ContentAnalysisRuleParser, RejectsMalformedJSON)
   nsTArray<RefPtr<nsIContentAnalysisRule>> rules;
   EXPECT_EQ(Parse("{ not valid json", rules), NS_ERROR_INVALID_ARG);
 }
+
+TEST(ContentAnalysisRuleParser, MapsTextCopyToDataCopied)
+{
+  constexpr const char* kJSON = R"JSON({
+    "DLPRules": { "Rules": [
+      { "Name": "copy", "Enabled": true, "Actions": ["TextCopy"], "Type": "warn" }
+    ] }
+  })JSON";
+
+  nsTArray<RefPtr<nsIContentAnalysisRule>> rules;
+  ASSERT_EQ(Parse(kJSON, rules), NS_OK);
+  ASSERT_EQ(rules.Length(), 1u);
+  nsTArray<uint32_t> ops;
+  ASSERT_EQ(rules[0]->GetOperations(ops), NS_OK);
+  ASSERT_EQ(ops.Length(), 1u);
+  EXPECT_EQ(ops[0], static_cast<uint32_t>(AnalysisType::eDataCopied));
+}
+
+// A rule with an unrecognized action is skipped, but the remaining valid rules
+// still take effect (rather than the whole config being rejected).
+TEST(ContentAnalysisRuleParser, SkipsRuleWithUnknownActionKeepsValid)
+{
+  constexpr const char* kJSON = R"JSON({
+    "DLPRules": { "Rules": [
+      { "Name": "bad", "Enabled": true, "Actions": ["Teleport"], "Type": "block" },
+      { "Name": "good", "Enabled": true, "Actions": ["Print"], "Type": "block" }
+    ] }
+  })JSON";
+
+  nsTArray<RefPtr<nsIContentAnalysisRule>> rules;
+  ASSERT_EQ(Parse(kJSON, rules), NS_OK);
+  ASSERT_EQ(rules.Length(), 1u);
+  nsString name;
+  ASSERT_EQ(rules[0]->GetName(name), NS_OK);
+  EXPECT_TRUE(name.EqualsLiteral("good"));
+}
+
+// Same, but the skipped rule has an unrecognized type.
+TEST(ContentAnalysisRuleParser, SkipsRuleWithUnknownTypeKeepsValid)
+{
+  constexpr const char* kJSON = R"JSON({
+    "DLPRules": { "Rules": [
+      { "Name": "bad", "Enabled": true, "Actions": ["Print"], "Type": "quarantine" },
+      { "Name": "good", "Enabled": true, "Actions": ["Print"], "Type": "warn" }
+    ] }
+  })JSON";
+
+  nsTArray<RefPtr<nsIContentAnalysisRule>> rules;
+  ASSERT_EQ(Parse(kJSON, rules), NS_OK);
+  ASSERT_EQ(rules.Length(), 1u);
+  nsString name;
+  ASSERT_EQ(rules[0]->GetName(name), NS_OK);
+  EXPECT_TRUE(name.EqualsLiteral("good"));
+}
+
+// When every enabled rule is invalid, parsing fails entirely so the caller can
+// fail closed rather than silently enforce nothing.
+TEST(ContentAnalysisRuleParser, RejectsWhenAllRulesInvalid)
+{
+  constexpr const char* kJSON = R"JSON({
+    "DLPRules": { "Rules": [
+      { "Name": "a", "Enabled": true, "Actions": ["Teleport"], "Type": "block" },
+      { "Name": "b", "Enabled": true, "Actions": ["Print"], "Type": "quarantine" }
+    ] }
+  })JSON";
+
+  nsTArray<RefPtr<nsIContentAnalysisRule>> rules;
+  EXPECT_EQ(Parse(kJSON, rules), NS_ERROR_INVALID_ARG);
+  EXPECT_EQ(rules.Length(), 0u);
+}
+
+// ContentPatterns are stored verbatim; regex validity is not checked here (that
+// happens at policy-load time in Policies.sys.mjs).
+TEST(ContentAnalysisRuleParser, ParsesContentPatterns)
+{
+  constexpr const char* kJSON = R"JSON({
+    "DLPRules": { "Rules": [
+      { "Name": "conf", "Enabled": true, "Actions": ["FileUpload"],
+        "Type": "block", "ContentPatterns": ["\\bCONFIDENTIAL\\b", "SECRET"] }
+    ] }
+  })JSON";
+
+  nsTArray<RefPtr<nsIContentAnalysisRule>> rules;
+  ASSERT_EQ(Parse(kJSON, rules), NS_OK);
+  ASSERT_EQ(rules.Length(), 1u);
+  nsTArray<nsString> patterns;
+  ASSERT_EQ(rules[0]->GetContentPatterns(patterns), NS_OK);
+  ASSERT_EQ(patterns.Length(), 2u);
+  EXPECT_TRUE(patterns[0].EqualsLiteral("\\bCONFIDENTIAL\\b"));
+  EXPECT_TRUE(patterns[1].EqualsLiteral("SECRET"));
+}


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2044495 Bug-2042853

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->
Adds the built-in DLP policy:
- Passes the rules from the policy to the built-in backend via a pref
- The built-in backend parses the rules and passes them to the wasm module
- If ContentAnalysis is *Enabled* and DataLossPrevention policies is present, ContentAnalysis policy wins
- Some staging is present for disabling the policies for when live support is added (in work but to be submitted separately for Bug-2058222)
- Also add staging for TextCopy which is not yet supported for interception in Firefox

---

### Testing <!-- OPTIONAL -->

* [x] Added tests
* [x] Manual testing performed

<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
