### PR TITLE
Bug 2056608 - Add live support for policy HTTPSOnlyMode

### DIFF
--- a/browser/components/enterprisepolicies/Policies.sys.mjs
+++ b/browser/components/enterprisepolicies/Policies.sys.mjs
@@ -2781,6 +2781,9 @@ export var Policies = {
           break;
       }
     },
+    onRemove() {
+      lazy.PoliciesUtils.unsetDefaultPref("dom.security.https_only_mode");
+    },
   },
 
   InstallAddonsPermission: {

--- a/browser/components/enterprisepolicies/Policies.sys.mjs
+++ b/browser/components/enterprisepolicies/Policies.sys.mjs
@@ -2781,8 +2781,11 @@ export var Policies = {
           break;
       }
     },
-    onRemove() {
-      lazy.PoliciesUtils.unsetDefaultPref("dom.security.https_only_mode");
+    onRemove(manager, oldParams) {
+      // "allowed" is the default and doesn't touch the pref on apply
+      if (oldParams !== "allowed") {
+        lazy.PoliciesUtils.unsetDefaultPref("dom.security.https_only_mode");
+      }
     },
   },
 

--- a/toolkit/components/enterprisepolicies/tests/browser/live/browser.toml
+++ b/toolkit/components/enterprisepolicies/tests/browser/live/browser.toml
@@ -17,4 +17,6 @@ run-if = [
 
 ["browser_live_policies_restoring_preference_state.js"]
 
+["browser_live_policy_HttpsOnlyMode.js"]
+
 ["browser_live_policy_proxy.js"]

--- a/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_policy_HttpsOnlyMode.js
+++ b/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_policy_HttpsOnlyMode.js
@@ -130,3 +130,34 @@ add_task(async function test_https_only_mode_live_removal() {
     }
   );
 });
+
+// "allowed" is the default and never touches the pref, so removing it
+// must preserve the pref state
+add_task(
+  async function test_https_only_mode_allowed_removal_preserves_pref_state() {
+    // Simulate the pref being locked prior to applying the policy
+    Services.prefs.lockPref(PREF_NAME);
+    checkPref(true, false);
+
+    info("Applying HttpsOnlyMode: allowed");
+    await EnterprisePolicyTesting.setupEngineWithRemotePolicies(
+      {
+        policies: {
+          HttpsOnlyMode: "allowed",
+        },
+      },
+      null
+    );
+
+    // "allowed" is a no-op on the pref.
+    checkPref(true, false);
+
+    info("Removing HttpsOnlyMode");
+    await updatePoliciesLive({});
+
+    // The externally-set lock is preserved since "allowed" never changed it.
+    checkPref(true, false);
+
+    Services.prefs.unlockPref(PREF_NAME);
+  }
+);

--- a/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_policy_HttpsOnlyMode.js
+++ b/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_policy_HttpsOnlyMode.js
@@ -1,0 +1,132 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+const PREF_NAME = "dom.security.https_only_mode";
+
+// Served over http, but has no valid certificate for https, so the HTTPS-Only
+// upgrade fails and the HTTPS-Only error page is shown when the policy is
+// active. Without the policy the http page loads normally.
+// eslint-disable-next-line @microsoft/sdl/no-insecure-url
+const TEST_URL = "http://nocert.example.com";
+
+function waitForPage(browser) {
+  return Promise.race([
+    BrowserTestUtils.waitForErrorPage(browser),
+    BrowserTestUtils.browserLoaded(browser),
+  ]);
+}
+
+async function navigateAndCheckErrorPage(browser, isExpectingErrorPage) {
+  let loaded = waitForPage(browser);
+  BrowserTestUtils.startLoadingURIString(browser, TEST_URL);
+  await loaded;
+
+  await SpecialPowers.spawn(
+    browser,
+    [isExpectingErrorPage],
+    async _expectErrorPage => {
+      const doc = content.document;
+      is(
+        doc.documentURI.startsWith("about:httpsonlyerror") &&
+          doc.body.innerHTML.includes("about-httpsonly-title-alert"),
+        _expectErrorPage,
+        _expectErrorPage
+          ? "Expected the HTTPS-Only error page"
+          : "Expected the page to load over http"
+      );
+    }
+  );
+}
+
+function checkPref(locked, value) {
+  Assert.equal(
+    Services.prefs.prefIsLocked(PREF_NAME),
+    locked,
+    `${PREF_NAME} is ${locked ? "locked" : "unlocked"}`
+  );
+  Assert.strictEqual(
+    Services.prefs.getBoolPref(PREF_NAME),
+    value,
+    `${PREF_NAME} is ${value}`
+  );
+}
+
+// Pushing a new remote policy set and wait for the poller to apply it live
+async function updatePoliciesLive(policies) {
+  const updateApplied = EnterprisePolicyTesting.awaitNextPolicyUpdate();
+  EnterprisePolicyTesting.stubRemotePolicies({ policies });
+  await updateApplied;
+}
+
+// Changing the HttpsOnlyMode value through a live policy update must take
+// effect on the next navigation without a restart.
+add_task(async function test_https_only_mode_live_update() {
+  await BrowserTestUtils.withNewTab(
+    { gBrowser, url: "about:blank" },
+    async browser => {
+      info("Applying HttpsOnlyMode: enabled");
+      await EnterprisePolicyTesting.setupEngineWithRemotePolicies(
+        {
+          policies: {
+            HttpsOnlyMode: "enabled",
+          },
+        },
+        null
+      );
+
+      // "enabled" sets the default value to true without locking it.
+      checkPref(false, true);
+      await navigateAndCheckErrorPage(browser, true);
+
+      info("Live-updating HttpsOnlyMode to disallowed");
+      await updatePoliciesLive({ HttpsOnlyMode: "disallowed" });
+
+      // "disallowed" sets and locks the pref to false.
+      checkPref(true, false);
+      await navigateAndCheckErrorPage(browser, false);
+
+      info("Live-updating HttpsOnlyMode to force_enabled");
+      await updatePoliciesLive({ HttpsOnlyMode: "force_enabled" });
+
+      // "force_enabled" sets and locks the pref to true.
+      checkPref(true, true);
+      await navigateAndCheckErrorPage(browser, true);
+    }
+  );
+});
+
+// Removing HttpsOnlyMode through a live policy update must restore the previous
+// browsing behavior and preference state without a restart.
+add_task(async function test_https_only_mode_live_removal() {
+  await BrowserTestUtils.withNewTab(
+    { gBrowser, url: "about:blank" },
+    async browser => {
+      // The pref defaults to false and is unlocked; the http page loads.
+      checkPref(false, false);
+      await navigateAndCheckErrorPage(browser, false);
+
+      info("Applying HttpsOnlyMode: force_enabled");
+      await EnterprisePolicyTesting.setupEngineWithRemotePolicies(
+        {
+          policies: {
+            HttpsOnlyMode: "force_enabled",
+          },
+        },
+        null
+      );
+
+      // "force_enabled" sets and locks the pref to true.
+      checkPref(true, true);
+      await navigateAndCheckErrorPage(browser, true);
+
+      info("Removing HttpsOnlyMode");
+      await updatePoliciesLive({});
+
+      // The pref is unlocked again and its initial value restored.
+      checkPref(false, false);
+      await navigateAndCheckErrorPage(browser, false);
+    }
+  );
+});


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2056608

Adds an `onRemove` callback to the policy `HTTPSOnlyMode` that unsets the default preference `dom.security.https_only_mode`.

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Testing <!-- OPTIONAL -->

* [X] Added tests
* [X] Manual testing performed

<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
