### PR TITLE
Bug 2056606 - Add live support for policy WebsiteFilter

### DIFF
--- a/browser/components/enterprisepolicies/Policies.sys.mjs
+++ b/browser/components/enterprisepolicies/Policies.sys.mjs
@@ -4344,6 +4344,9 @@ export var Policies = {
     onBeforeUIStartup(manager, param) {
       lazy.WebsiteFilter.init(param.Block || [], param.Exceptions || []);
     },
+    onRemove(_manager, _oldParams) {
+      lazy.WebsiteFilter.uninit();
+    },
   },
 
   WindowsSSO: {

--- a/browser/components/enterprisepolicies/helpers/WebsiteFilter.sys.mjs
+++ b/browser/components/enterprisepolicies/helpers/WebsiteFilter.sys.mjs
@@ -27,6 +27,7 @@ import { AppConstants } from "resource://gre/modules/AppConstants.sys.mjs";
  */
 
 const LIST_LENGTH_LIMIT = 1000;
+const CATEGORY = "content-policy";
 
 const PREF_LOGLEVEL = "browser.policies.loglevel";
 
@@ -47,6 +48,7 @@ ChromeUtils.defineLazyGetter(lazy, "log", () => {
 
 export let WebsiteFilter = {
   _observerAdded: false,
+  _registrar: null,
 
   init(blocklist, exceptionlist) {
     let blockArray = [],
@@ -86,10 +88,14 @@ export let WebsiteFilter = {
       this._exceptionsPatterns = new MatchPatternSet(exceptionArray);
     }
 
-    let registrar = Components.manager.QueryInterface(Ci.nsIComponentRegistrar);
+    if (!this._registrar) {
+      this._registrar = Components.manager.QueryInterface(
+        Ci.nsIComponentRegistrar
+      );
+    }
 
-    if (!registrar.isContractIDRegistered(this.contractID)) {
-      registrar.registerFactory(
+    if (!this._registrar.isContractIDRegistered(this.contractID)) {
+      this._registrar.registerFactory(
         this.classID,
         this.classDescription,
         this.contractID,
@@ -97,7 +103,7 @@ export let WebsiteFilter = {
       );
 
       Services.catMan.addCategoryEntry(
-        "content-policy",
+        CATEGORY,
         this.contractID,
         this.contractID,
         false,
@@ -229,7 +235,7 @@ export let WebsiteFilter = {
       }
     } catch (ex) {
       // Silently fail - telemetry errors should not break website filtering
-      console.error(
+      lazy.log.error(
         `[WebsiteFilter] Blocked domain browsed telemetry recording failed:`,
         ex
       );
@@ -239,7 +245,7 @@ export let WebsiteFilter = {
         );
       } catch (reportEx) {
         // ChromeUtils.reportError may not be available in all contexts
-        console.error(
+        lazy.log.error(
           `[DownloadsTelemetryEnterprise] Could not report error:`,
           reportEx
         );
@@ -282,5 +288,16 @@ export let WebsiteFilter = {
       parsed.hostname = parsed.hostname.replace(/\.+$/, "");
     }
     return parsed.href.toLowerCase();
+  },
+
+  uninit() {
+    this._registrar.unregisterFactory(this.classID, this);
+
+    Services.catMan.deleteCategoryEntry(CATEGORY, this.contractID, false);
+
+    Services.obs.removeObserver(this, "http-on-examine-response");
+    this._observerAdded = false;
+    this._blockPatterns = null;
+    this._exceptionsPatterns = null;
   },
 };

--- a/browser/components/enterprisepolicies/helpers/WebsiteFilter.sys.mjs
+++ b/browser/components/enterprisepolicies/helpers/WebsiteFilter.sys.mjs
@@ -245,7 +245,7 @@ export let WebsiteFilter = {
         );
       } catch (reportEx) {
         // ChromeUtils.reportError may not be available in all contexts
-        lazy.log.error(
+        console.error(
           `[DownloadsTelemetryEnterprise] Could not report error:`,
           reportEx
         );

--- a/toolkit/components/enterprisepolicies/tests/browser/live/browser.toml
+++ b/toolkit/components/enterprisepolicies/tests/browser/live/browser.toml
@@ -18,3 +18,5 @@ run-if = [
 ["browser_live_policies_restoring_preference_state.js"]
 
 ["browser_live_policy_proxy.js"]
+
+["browser_live_policy_WebsiteFilter.js"]

--- a/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_policy_WebsiteFilter.js
+++ b/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_policy_WebsiteFilter.js
@@ -1,0 +1,181 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+const SUPPORT_FILES_PATH =
+  "http://mochi.test:8888/browser/browser/components/enterprisepolicies/tests/browser/";
+const BLOCKED_PAGE = SUPPORT_FILES_PATH + "policy_websitefilter_block.html";
+const EXCEPTION_PAGE =
+  SUPPORT_FILES_PATH + "policy_websitefilter_exception.html";
+const REDIRECT_301 = SUPPORT_FILES_PATH + "301.sjs";
+const REDIRECT_302 = SUPPORT_FILES_PATH + "302.sjs";
+
+const BLOCK_PATTERN = "*://mochi.test/*policy_websitefilter_*";
+const EXCEPTION_PATTERN = "*://mochi.test/*_websitefilter_exception*";
+
+// Checks whether loading |url| ends up on the blockedByPolicy error page.
+async function isBlockedSite(url, isExpectedBlocked) {
+  await BrowserTestUtils.withNewTab("about:blank", async browser => {
+    let loaded = BrowserTestUtils.browserLoaded(browser, false, null, true);
+    BrowserTestUtils.startLoadingURIString(browser, url);
+    await loaded;
+    let blocked = browser.documentURI.spec.startsWith(
+      "about:neterror?e=blockedByPolicy"
+    );
+    is(
+      blocked,
+      isExpectedBlocked,
+      `${url} should ${isExpectedBlocked ? "" : "not "}be blocked by policy`
+    );
+  });
+}
+
+async function removePolicies() {
+  const updateApplied = EnterprisePolicyTesting.awaitNextPolicyUpdate();
+  EnterprisePolicyTesting.stubRemotePolicies({ policies: {} });
+  await updateApplied;
+  Assert.deepEqual(
+    Services.policies.getActivePolicies(),
+    {},
+    "Expected no active policies after removal."
+  );
+}
+
+add_setup(async () => {
+  // Blocking a redirect records enterprise telemetry and would otherwise
+  // submit a Glean ping; disable submission for the duration of this test.
+  await SpecialPowers.pushPrefEnv({
+    set: [
+      ["browser.policies.enterprise.telemetry.testing.disableSubmit", true],
+    ],
+  });
+});
+
+// Applying the policy live blocks the configured pages (including redirects),
+// and removing it live stops blocking them.
+add_task(async function test_apply_then_remove() {
+  await EnterprisePolicyTesting.setupEngineWithRemotePolicies(
+    {
+      policies: {
+        WebsiteFilter: {
+          Block: [BLOCK_PATTERN],
+        },
+      },
+    },
+    null
+  );
+
+  await isBlockedSite(BLOCKED_PAGE, true);
+  await isBlockedSite(REDIRECT_301, true);
+  await isBlockedSite(REDIRECT_302, true);
+
+  await removePolicies();
+
+  await isBlockedSite(BLOCKED_PAGE, false);
+  await isBlockedSite(REDIRECT_301, false);
+  await isBlockedSite(REDIRECT_302, false);
+});
+
+// A live update tears the policy down and re-applies it which
+// includes the removing and re-adding the redirect observer.
+add_task(async function test_update_keeps_blocking_redirects() {
+  await EnterprisePolicyTesting.setupEngineWithRemotePolicies(
+    {
+      policies: {
+        WebsiteFilter: {
+          Block: [BLOCK_PATTERN],
+        },
+      },
+    },
+    null
+  );
+
+  await isBlockedSite(REDIRECT_301, true);
+
+  // Change the parameters (add an unrelated exception) to trigger a
+  // teardown-then-reapply update.
+  const updateApplied = EnterprisePolicyTesting.awaitNextPolicyUpdate();
+  EnterprisePolicyTesting.stubRemotePolicies({
+    policies: {
+      WebsiteFilter: {
+        Block: [BLOCK_PATTERN],
+        Exceptions: ["*://example.com/*"],
+      },
+    },
+  });
+  await updateApplied;
+
+  await isBlockedSite(BLOCKED_PAGE, true);
+  await isBlockedSite(REDIRECT_301, true);
+
+  await removePolicies();
+});
+
+// A live update that changes the Block list drops the old pattern and applies
+// the new one.
+add_task(async function test_update_changes_block_list() {
+  await EnterprisePolicyTesting.setupEngineWithRemotePolicies(
+    {
+      policies: {
+        WebsiteFilter: {
+          Block: ["*://mochi.test/*_block*"],
+        },
+      },
+    },
+    null
+  );
+
+  await isBlockedSite(BLOCKED_PAGE, true);
+  await isBlockedSite(EXCEPTION_PAGE, false);
+
+  const updateApplied = EnterprisePolicyTesting.awaitNextPolicyUpdate();
+  EnterprisePolicyTesting.stubRemotePolicies({
+    policies: {
+      WebsiteFilter: {
+        Block: ["*://mochi.test/*_exception*"],
+      },
+    },
+  });
+  await updateApplied;
+
+  // The old Block pattern no longer matches, the new one does.
+  await isBlockedSite(BLOCKED_PAGE, false);
+  await isBlockedSite(EXCEPTION_PAGE, true);
+
+  await removePolicies();
+});
+
+// A live update that drops the exceptions must not leave any stale ones in place.
+add_task(async function test_update_drops_exceptions() {
+  await EnterprisePolicyTesting.setupEngineWithRemotePolicies(
+    {
+      policies: {
+        WebsiteFilter: {
+          Block: [BLOCK_PATTERN],
+          Exceptions: [EXCEPTION_PATTERN],
+        },
+      },
+    },
+    null
+  );
+
+  await isBlockedSite(BLOCKED_PAGE, true);
+  await isBlockedSite(EXCEPTION_PAGE, false);
+
+  // Drop the exceptions via a live update.
+  const updateApplied = EnterprisePolicyTesting.awaitNextPolicyUpdate();
+  EnterprisePolicyTesting.stubRemotePolicies({
+    policies: {
+      WebsiteFilter: {
+        Block: [BLOCK_PATTERN],
+      },
+    },
+  });
+  await updateApplied;
+
+  await isBlockedSite(BLOCKED_PAGE, true);
+  await isBlockedSite(EXCEPTION_PAGE, true);
+
+  await removePolicies();
+});

--- a/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_policy_WebsiteFilter.js
+++ b/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_policy_WebsiteFilter.js
@@ -21,7 +21,7 @@ async function isBlockedSite(url, isExpectedBlocked) {
     BrowserTestUtils.startLoadingURIString(browser, url);
     await loaded;
     let blocked = browser.documentURI.spec.startsWith(
-      "about:neterror?e=blockedByPolicy"
+      "about:neterror?e=blockedByPolicyEnterprise"
     );
     is(
       blocked,

--- a/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_policy_WebsiteFilter.js
+++ b/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_policy_WebsiteFilter.js
@@ -42,15 +42,8 @@ async function removePolicies() {
   );
 }
 
-add_setup(async () => {
-  // Blocking a redirect records enterprise telemetry and would otherwise
-  // submit a Glean ping; disable submission for the duration of this test.
-  await SpecialPowers.pushPrefEnv({
-    set: [
-      ["browser.policies.enterprise.telemetry.testing.disableSubmit", true],
-    ],
-  });
-});
+// Blocking a redirect records enterprise telemetry into FOG.
+registerCleanupFunction(() => Services.fog.testResetFOG());
 
 // Applying the policy live blocks the configured pages (including redirects),
 // and removing it live stops blocking them.


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2056606

Adds an `onRemove` callback for the `WebsiteFilter` policy that calls `WebsiteFilter.uninit()` method, which tears down anything registered by the `WebsiteFilter.init` method.

---


### Testing <!-- OPTIONAL -->

* [X] Added tests
* [X] Manual testing performed

<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
