### PR TITLE
Bug 2043142 - send telemetry for DLP events in enterprise builds

### DIFF
--- a/browser/components/contentanalysis/content/ContentAnalysis.sys.mjs
+++ b/browser/components/contentanalysis/content/ContentAnalysis.sys.mjs
@@ -106,16 +106,6 @@ export const ContentAnalysis = {
   requestTokenToRequestInfo: new Map(),
 
   /**
-   * Telemetry context for warn responses, kept around between the initial
-   * "warn" rule_triggered event and the "dlp-warn-resolved" notification
-   * that reports how the warn was resolved.
-   *
-   * @type {Map<string, {operation: string, url: string,
-   *   analysisType: string, reason: string}>}
-   */
-  _pendingWarnTelemetryInfo: new Map(),
-
-  /**
    * Whether we are resolving warn dialogs because the application is quitting,
    * in which case the resolutions aren't choices the user made.
    *
@@ -203,7 +193,7 @@ export const ContentAnalysis = {
     if (this.isInitialized) {
       this.isInitialized = false;
       this.requestTokenToRequestInfo.clear();
-      this._pendingWarnTelemetryInfo.clear();
+      lazy.ContentAnalysisTelemetry.reset();
       this.userActionToBusyDialogMap.clear();
       this.uninitializeObservers();
     }
@@ -300,8 +290,8 @@ export const ContentAnalysis = {
         // Clear this first so the handler showing the dialog will know not
         // to call respondToWarnDialog() again.
         this.warnDialogRequestTokens = new Set();
-        // Tells _recordWarnResolutionTelemetry() that these resolutions are
-        // not choices the user made.
+        // Tells ContentAnalysisTelemetry.recordWarnResolution() that these
+        // resolutions are not choices the user made.
         this._isRespondingToWarnDialogsForQuit = true;
         try {
           for (let warnDialogRequestToken of requestTokensToCancel) {
@@ -381,7 +371,7 @@ export const ContentAnalysis = {
         }
         this.requestTokenToRequestInfo.delete(response.requestToken);
         this._removeSlowCAMessage(response.userActionId, response.requestToken);
-        this._maybeRecordRuleTriggeredTelemetry(requestInfo, response);
+        lazy.ContentAnalysisTelemetry.recordVerdict(requestInfo, response);
         if (
           requestInfo.resourceNameOrOperationType?.operationType ===
           Ci.nsIContentAnalysisRequest.eDownload
@@ -413,7 +403,11 @@ export const ContentAnalysis = {
             "Got dlp-warn-resolved message but no response object was passed"
           );
         }
-        this._recordWarnResolutionTelemetry(response, aData);
+        lazy.ContentAnalysisTelemetry.recordWarnResolution(
+          response,
+          aData,
+          this._isRespondingToWarnDialogsForQuit
+        );
         break;
       }
     }
@@ -623,169 +617,6 @@ export const ContentAnalysis = {
       }
     }
     return nameOrOperationType;
-  },
-
-  _OPERATION_TYPE_TELEMETRY_STRINGS: {
-    [Ci.nsIContentAnalysisRequest.eClipboard]: "clipboard",
-    [Ci.nsIContentAnalysisRequest.eDroppedText]: "dropped_text",
-    [Ci.nsIContentAnalysisRequest.eOperationPrint]: "print",
-    [Ci.nsIContentAnalysisRequest.eUpload]: "upload",
-    [Ci.nsIContentAnalysisRequest.eDownload]: "download",
-  },
-
-  _ACTION_TELEMETRY_STRINGS: {
-    [Ci.nsIContentAnalysisResponse.eUnspecified]: "unspecified",
-    [Ci.nsIContentAnalysisResponse.eReportOnly]: "report_only",
-    [Ci.nsIContentAnalysisResponse.eBlock]: "block",
-    [Ci.nsIContentAnalysisResponse.eWarn]: "warn",
-    [Ci.nsIContentAnalysisResponse.eAllow]: "allow",
-    // Content analysis uses eCanceled rather than eBlock when the content
-    // should be blocked without showing a block dialog. (an example is
-    // the agent being unreachable while
-    // browser.contentanalysis.default_result is "block")
-    [Ci.nsIContentAnalysisResponse.eCanceled]: "canceled",
-  },
-
-  _CANCEL_ERROR_TELEMETRY_STRINGS: {
-    [Ci.nsIContentAnalysisResponse.eUserInitiated]: "user_initiated",
-    [Ci.nsIContentAnalysisResponse.eNoAgent]: "no_agent",
-    [Ci.nsIContentAnalysisResponse.eInvalidAgentSignature]:
-      "invalid_agent_signature",
-    [Ci.nsIContentAnalysisResponse.eErrorOther]: "error_other",
-    [Ci.nsIContentAnalysisResponse.eOtherRequestInGroupCancelled]:
-      "other_request_in_group_cancelled",
-    [Ci.nsIContentAnalysisResponse.eShutdown]: "shutdown",
-    [Ci.nsIContentAnalysisResponse.eTimeout]: "timeout",
-  },
-
-  // These match the AnalysisConnector enum names in analysis.proto, so the
-  // values line up with the labels of the
-  // content_analysis.request_sent_by_analysis_type counter.
-  _ANALYSIS_TYPE_TELEMETRY_STRINGS: {
-    [Ci.nsIContentAnalysisRequest.eUnspecified]:
-      "ANALYSIS_CONNECTOR_UNSPECIFIED",
-    [Ci.nsIContentAnalysisRequest.eFileDownloaded]: "FILE_DOWNLOADED",
-    [Ci.nsIContentAnalysisRequest.eFileAttached]: "FILE_ATTACHED",
-    [Ci.nsIContentAnalysisRequest.eBulkDataEntry]: "BULK_DATA_ENTRY",
-    [Ci.nsIContentAnalysisRequest.ePrint]: "PRINT",
-    [Ci.nsIContentAnalysisRequest.eFileTransfer]: "FILE_TRANSFER",
-    [Ci.nsIContentAnalysisRequest.eDataCopied]: "DATA_COPIED",
-  },
-
-  // These match the ContentAnalysisRequest::Reason enum names in
-  // analysis.proto, so the values line up with the labels of the
-  // content_analysis.request_sent_by_reason counter.
-  _REASON_TELEMETRY_STRINGS: {
-    [Ci.nsIContentAnalysisRequest.eUnknown]: "UNKNOWN",
-    [Ci.nsIContentAnalysisRequest.eClipboardPaste]: "CLIPBOARD_PASTE",
-    [Ci.nsIContentAnalysisRequest.eDragAndDrop]: "DRAG_AND_DROP",
-    [Ci.nsIContentAnalysisRequest.eFilePickerDialog]: "FILE_PICKER_DIALOG",
-    [Ci.nsIContentAnalysisRequest.ePrintPreviewPrint]: "PRINT_PREVIEW_PRINT",
-    [Ci.nsIContentAnalysisRequest.eSystemDialogPrint]: "SYSTEM_DIALOG_PRINT",
-    [Ci.nsIContentAnalysisRequest.eNormalDownload]: "NORMAL_DOWNLOAD",
-    [Ci.nsIContentAnalysisRequest.eSaveAsDownload]: "SAVE_AS_DOWNLOAD",
-    [Ci.nsIContentAnalysisRequest.eClipboardCopy]: "CLIPBOARD_COPY",
-  },
-
-  /**
-   * Records rule_triggered telemetry for a content analysis response. The
-   * enterprise policy-configured ContentAnalysisTelemetry module decides
-   * whether the event is actually recorded (e.g. it may filter out allow
-   * verdicts).
-   *
-   * @param {object} aRequestInfo The cached request info for this response's
-   *   requestToken (see requestTokenToRequestInfo).
-   * @param {nsIContentAnalysisResponse} aResponse
-   */
-  _maybeRecordRuleTriggeredTelemetry(aRequestInfo, aResponse) {
-    const action =
-      this._ACTION_TELEMETRY_STRINGS[aResponse.action] ??
-      "unknown:" + aResponse.action;
-    const isCancel =
-      aResponse.action === Ci.nsIContentAnalysisResponse.eCanceled;
-    const requestDetails = {
-      operation:
-        this._OPERATION_TYPE_TELEMETRY_STRINGS[
-          aRequestInfo.resourceNameOrOperationType?.operationType
-        ] ??
-        "unknown:" + aRequestInfo.resourceNameOrOperationType?.operationType,
-      url: aRequestInfo.url,
-      analysisType:
-        this._ANALYSIS_TYPE_TELEMETRY_STRINGS[aRequestInfo.analysisType] ??
-        "unknown:" + aRequestInfo.analysisType,
-      reason:
-        this._REASON_TELEMETRY_STRINGS[aRequestInfo.reason] ??
-        "unknown:" + aRequestInfo.reason,
-      ruleName: aResponse.ruleName || "",
-    };
-    if (aResponse.action === Ci.nsIContentAnalysisResponse.eWarn) {
-      // The user hasn't made a choice yet; that's reported separately via
-      // "dlp-warn-resolved" once respondToWarnDialog() is called (either
-      // from this file's warn dialog, or from the downloads panel for
-      // download operations, which don't go through this file at all).
-      this._pendingWarnTelemetryInfo.set(
-        aResponse.requestToken,
-        requestDetails
-      );
-    }
-    // A synthetic response is one Firefox generated itself rather than one an
-    // agent sent. cancelError is only set on those when content analysis
-    // failed (agent unreachable, timed out, ...), in which case the action
-    // reflects browser.contentanalysis.default_result or timeout_result
-    // rather than a verdict about the content. Firefox also synthesizes
-    // responses for reasons that aren't failures, e.g. a URL matching
-    // browser.contentanalysis.deny_url_regex_list, and those leave
-    // cancelError at its eUserInitiated default.
-    const isErrorFallback =
-      aResponse.isSyntheticResponse &&
-      aResponse.cancelError !== Ci.nsIContentAnalysisResponse.eUserInitiated;
-    // Anywhere else cancelError is not meaningful, so report it as unset.
-    const cancelError =
-      isErrorFallback || isCancel
-        ? (this._CANCEL_ERROR_TELEMETRY_STRINGS[aResponse.cancelError] ??
-          "unknown:" + aResponse.cancelError)
-        : "";
-    lazy.ContentAnalysisTelemetry.recordRuleTriggered({
-      ...requestDetails,
-      action,
-      cancelError,
-      type: isErrorFallback ? "error_fallback" : "verdict",
-      isCached: aResponse.isCachedResponse,
-    });
-  },
-
-  /**
-   * Records rule_triggered telemetry reporting how a warn verdict was
-   * resolved (for either the warn dialog shown by this file, or the
-   * downloads panel's own warn UI). Fired from the "dlp-warn-resolved"
-   * notification, which C++ sends whenever respondToWarnDialog() is called,
-   * regardless of caller.
-   *
-   * @param {nsIContentAnalysisResponse} aResponse The resolved response;
-   *   action will be eAllow or eBlock, never eWarn.
-   * @param {string} aData The notification's data: "cancel" if the warn was
-   *   resolved because the request was cancelled rather than because the user
-   *   made a choice. See nsIContentAnalysis.respondToWarnDialog().
-   */
-  _recordWarnResolutionTelemetry(aResponse, aData) {
-    const pendingInfo = this._pendingWarnTelemetryInfo.get(
-      aResponse.requestToken
-    );
-    if (!pendingInfo) {
-      return;
-    }
-    this._pendingWarnTelemetryInfo.delete(aResponse.requestToken);
-    const action =
-      this._ACTION_TELEMETRY_STRINGS[aResponse.action] ??
-      "unknown:" + aResponse.action;
-    lazy.ContentAnalysisTelemetry.recordRuleTriggered({
-      ...pendingInfo,
-      action,
-      type:
-        aData === "cancel" || this._isRespondingToWarnDialogsForQuit
-          ? "warn_cancel"
-          : "warn_resolution",
-    });
   },
 
   /**

--- a/browser/components/contentanalysis/content/ContentAnalysis.sys.mjs
+++ b/browser/components/contentanalysis/content/ContentAnalysis.sys.mjs
@@ -367,9 +367,10 @@ export const ContentAnalysis = {
           );
         }
 
-        let windowAndResourceNameOrOperationType =
-          this.requestTokenToRequestInfo.get(response.requestToken);
-        if (!windowAndResourceNameOrOperationType) {
+        let requestInfo = this.requestTokenToRequestInfo.get(
+          response.requestToken
+        );
+        if (!requestInfo) {
           // We may get multiple responses, for example, if we are blocked or
           // canceled after receiving our verdict because we were part of a
           // multipart transaction.  Just ignore that.
@@ -380,13 +381,10 @@ export const ContentAnalysis = {
         }
         this.requestTokenToRequestInfo.delete(response.requestToken);
         this._removeSlowCAMessage(response.userActionId, response.requestToken);
-        this._maybeRecordRuleTriggeredTelemetry(
-          windowAndResourceNameOrOperationType,
-          response
-        );
+        this._maybeRecordRuleTriggeredTelemetry(requestInfo, response);
         if (
-          windowAndResourceNameOrOperationType.resourceNameOrOperationType
-            ?.operationType === Ci.nsIContentAnalysisRequest.eDownload
+          requestInfo.resourceNameOrOperationType?.operationType ===
+          Ci.nsIContentAnalysisRequest.eDownload
         ) {
           // Don't show warn/block/error dialogs for downloads; they're shown
           // inside the downloads panel.
@@ -397,8 +395,8 @@ export const ContentAnalysis = {
         // Don't show dialog if this is a cached response
         if (!response?.isCachedResponse) {
           await this._showCAResult(
-            windowAndResourceNameOrOperationType.resourceNameOrOperationType,
-            windowAndResourceNameOrOperationType.browsingContext,
+            requestInfo.resourceNameOrOperationType,
+            requestInfo.browsingContext,
             response.requestToken,
             response.userActionId,
             responseResult,

--- a/browser/components/contentanalysis/content/ContentAnalysis.sys.mjs
+++ b/browser/components/contentanalysis/content/ContentAnalysis.sys.mjs
@@ -718,6 +718,7 @@ export const ContentAnalysis = {
       reason:
         this._REASON_TELEMETRY_STRINGS[aRequestInfo.reason] ??
         "unknown:" + aRequestInfo.reason,
+      ruleName: aResponse.ruleName || "",
     };
     if (aResponse.action === Ci.nsIContentAnalysisResponse.eWarn) {
       // The user hasn't made a choice yet; that's reported separately via

--- a/browser/components/contentanalysis/content/ContentAnalysis.sys.mjs
+++ b/browser/components/contentanalysis/content/ContentAnalysis.sys.mjs
@@ -19,6 +19,8 @@ let internalContentAnalysisService = undefined;
 ChromeUtils.defineESModuleGetters(lazy, {
   BrowserWindowTracker: "resource:///modules/BrowserWindowTracker.sys.mjs",
   clearTimeout: "resource://gre/modules/Timer.sys.mjs",
+  ContentAnalysisTelemetry:
+    "moz-src:///browser/components/contentanalysis/content/ContentAnalysisTelemetry.sys.mjs",
   PanelMultiView:
     "moz-src:///browser/components/customizableui/PanelMultiView.sys.mjs",
   setTimeout: "resource://gre/modules/Timer.sys.mjs",
@@ -104,6 +106,24 @@ export const ContentAnalysis = {
   requestTokenToRequestInfo: new Map(),
 
   /**
+   * Telemetry context for warn responses, kept around between the initial
+   * "warn" rule_triggered event and the "dlp-warn-resolved" notification
+   * that reports how the warn was resolved.
+   *
+   * @type {Map<string, {operation: string, url: string,
+   *   analysisType: string, reason: string}>}
+   */
+  _pendingWarnTelemetryInfo: new Map(),
+
+  /**
+   * Whether we are resolving warn dialogs because the application is quitting,
+   * in which case the resolutions aren't choices the user made.
+   *
+   * @type {boolean}
+   */
+  _isRespondingToWarnDialogsForQuit: false,
+
+  /**
    * @type {Set<string>}
    */
   warnDialogRequestTokens: new Set(),
@@ -183,6 +203,7 @@ export const ContentAnalysis = {
     if (this.isInitialized) {
       this.isInitialized = false;
       this.requestTokenToRequestInfo.clear();
+      this._pendingWarnTelemetryInfo.clear();
       this.userActionToBusyDialogMap.clear();
       this.uninitializeObservers();
     }
@@ -194,6 +215,7 @@ export const ContentAnalysis = {
   initializeObservers() {
     Services.obs.addObserver(this, "dlp-request-made");
     Services.obs.addObserver(this, "dlp-response");
+    Services.obs.addObserver(this, "dlp-warn-resolved");
     Services.obs.addObserver(this, "quit-application");
     Services.obs.addObserver(this, "quit-application-granted");
     Services.obs.addObserver(this, "quit-application-requested");
@@ -205,13 +227,14 @@ export const ContentAnalysis = {
   uninitializeObservers() {
     Services.obs.removeObserver(this, "dlp-request-made");
     Services.obs.removeObserver(this, "dlp-response");
+    Services.obs.removeObserver(this, "dlp-warn-resolved");
     Services.obs.removeObserver(this, "quit-application");
     Services.obs.removeObserver(this, "quit-application-granted");
     Services.obs.removeObserver(this, "quit-application-requested");
   },
 
   // nsIObserver
-  async observe(aSubj, aTopic, _aData) {
+  async observe(aSubj, aTopic, aData) {
     switch (aTopic) {
       case "quit-application-requested": {
         if (aSubj.data) {
@@ -277,11 +300,18 @@ export const ContentAnalysis = {
         // Clear this first so the handler showing the dialog will know not
         // to call respondToWarnDialog() again.
         this.warnDialogRequestTokens = new Set();
-        for (let warnDialogRequestToken of requestTokensToCancel) {
-          this.contentAnalysis.respondToWarnDialog(
-            warnDialogRequestToken,
-            false
-          );
+        // Tells _recordWarnResolutionTelemetry() that these resolutions are
+        // not choices the user made.
+        this._isRespondingToWarnDialogsForQuit = true;
+        try {
+          for (let warnDialogRequestToken of requestTokensToCancel) {
+            this.contentAnalysis.respondToWarnDialog(
+              warnDialogRequestToken,
+              false
+            );
+          }
+        } finally {
+          this._isRespondingToWarnDialogsForQuit = false;
         }
         break;
       }
@@ -316,6 +346,9 @@ export const ContentAnalysis = {
           this.requestTokenToRequestInfo.set(request.requestToken, {
             browsingContext,
             resourceNameOrOperationType,
+            url: request.url?.spec ?? "",
+            analysisType: request.analysisType,
+            reason: request.reason,
           });
           this._queueSlowCAMessage(
             request,
@@ -347,6 +380,10 @@ export const ContentAnalysis = {
         }
         this.requestTokenToRequestInfo.delete(response.requestToken);
         this._removeSlowCAMessage(response.userActionId, response.requestToken);
+        this._maybeRecordRuleTriggeredTelemetry(
+          windowAndResourceNameOrOperationType,
+          response
+        );
         if (
           windowAndResourceNameOrOperationType.resourceNameOrOperationType
             ?.operationType === Ci.nsIContentAnalysisRequest.eDownload
@@ -369,6 +406,16 @@ export const ContentAnalysis = {
             response.cancelError
           );
         }
+        break;
+      }
+      case "dlp-warn-resolved": {
+        const response = aSubj.QueryInterface(Ci.nsIContentAnalysisResponse);
+        if (!response) {
+          throw new Error(
+            "Got dlp-warn-resolved message but no response object was passed"
+          );
+        }
+        this._recordWarnResolutionTelemetry(response, aData);
         break;
       }
     }
@@ -578,6 +625,168 @@ export const ContentAnalysis = {
       }
     }
     return nameOrOperationType;
+  },
+
+  _OPERATION_TYPE_TELEMETRY_STRINGS: {
+    [Ci.nsIContentAnalysisRequest.eClipboard]: "clipboard",
+    [Ci.nsIContentAnalysisRequest.eDroppedText]: "dropped_text",
+    [Ci.nsIContentAnalysisRequest.eOperationPrint]: "print",
+    [Ci.nsIContentAnalysisRequest.eUpload]: "upload",
+    [Ci.nsIContentAnalysisRequest.eDownload]: "download",
+  },
+
+  _ACTION_TELEMETRY_STRINGS: {
+    [Ci.nsIContentAnalysisResponse.eUnspecified]: "unspecified",
+    [Ci.nsIContentAnalysisResponse.eReportOnly]: "report_only",
+    [Ci.nsIContentAnalysisResponse.eBlock]: "block",
+    [Ci.nsIContentAnalysisResponse.eWarn]: "warn",
+    [Ci.nsIContentAnalysisResponse.eAllow]: "allow",
+    // Content analysis uses eCanceled rather than eBlock when the content
+    // should be blocked without showing a block dialog. (an example is
+    // the agent being unreachable while
+    // browser.contentanalysis.default_result is "block")
+    [Ci.nsIContentAnalysisResponse.eCanceled]: "canceled",
+  },
+
+  _CANCEL_ERROR_TELEMETRY_STRINGS: {
+    [Ci.nsIContentAnalysisResponse.eUserInitiated]: "user_initiated",
+    [Ci.nsIContentAnalysisResponse.eNoAgent]: "no_agent",
+    [Ci.nsIContentAnalysisResponse.eInvalidAgentSignature]:
+      "invalid_agent_signature",
+    [Ci.nsIContentAnalysisResponse.eErrorOther]: "error_other",
+    [Ci.nsIContentAnalysisResponse.eOtherRequestInGroupCancelled]:
+      "other_request_in_group_cancelled",
+    [Ci.nsIContentAnalysisResponse.eShutdown]: "shutdown",
+    [Ci.nsIContentAnalysisResponse.eTimeout]: "timeout",
+  },
+
+  // These match the AnalysisConnector enum names in analysis.proto, so the
+  // values line up with the labels of the
+  // content_analysis.request_sent_by_analysis_type counter.
+  _ANALYSIS_TYPE_TELEMETRY_STRINGS: {
+    [Ci.nsIContentAnalysisRequest.eUnspecified]:
+      "ANALYSIS_CONNECTOR_UNSPECIFIED",
+    [Ci.nsIContentAnalysisRequest.eFileDownloaded]: "FILE_DOWNLOADED",
+    [Ci.nsIContentAnalysisRequest.eFileAttached]: "FILE_ATTACHED",
+    [Ci.nsIContentAnalysisRequest.eBulkDataEntry]: "BULK_DATA_ENTRY",
+    [Ci.nsIContentAnalysisRequest.ePrint]: "PRINT",
+    [Ci.nsIContentAnalysisRequest.eFileTransfer]: "FILE_TRANSFER",
+    [Ci.nsIContentAnalysisRequest.eDataCopied]: "DATA_COPIED",
+  },
+
+  // These match the ContentAnalysisRequest::Reason enum names in
+  // analysis.proto, so the values line up with the labels of the
+  // content_analysis.request_sent_by_reason counter.
+  _REASON_TELEMETRY_STRINGS: {
+    [Ci.nsIContentAnalysisRequest.eUnknown]: "UNKNOWN",
+    [Ci.nsIContentAnalysisRequest.eClipboardPaste]: "CLIPBOARD_PASTE",
+    [Ci.nsIContentAnalysisRequest.eDragAndDrop]: "DRAG_AND_DROP",
+    [Ci.nsIContentAnalysisRequest.eFilePickerDialog]: "FILE_PICKER_DIALOG",
+    [Ci.nsIContentAnalysisRequest.ePrintPreviewPrint]: "PRINT_PREVIEW_PRINT",
+    [Ci.nsIContentAnalysisRequest.eSystemDialogPrint]: "SYSTEM_DIALOG_PRINT",
+    [Ci.nsIContentAnalysisRequest.eNormalDownload]: "NORMAL_DOWNLOAD",
+    [Ci.nsIContentAnalysisRequest.eSaveAsDownload]: "SAVE_AS_DOWNLOAD",
+    [Ci.nsIContentAnalysisRequest.eClipboardCopy]: "CLIPBOARD_COPY",
+  },
+
+  /**
+   * Records rule_triggered telemetry for a content analysis response. The
+   * enterprise policy-configured ContentAnalysisTelemetry module decides
+   * whether the event is actually recorded (e.g. it may filter out allow
+   * verdicts).
+   *
+   * @param {object} aRequestInfo The cached request info for this response's
+   *   requestToken (see requestTokenToRequestInfo).
+   * @param {nsIContentAnalysisResponse} aResponse
+   */
+  _maybeRecordRuleTriggeredTelemetry(aRequestInfo, aResponse) {
+    const action =
+      this._ACTION_TELEMETRY_STRINGS[aResponse.action] ??
+      "unknown:" + aResponse.action;
+    const isCancel =
+      aResponse.action === Ci.nsIContentAnalysisResponse.eCanceled;
+    const requestDetails = {
+      operation:
+        this._OPERATION_TYPE_TELEMETRY_STRINGS[
+          aRequestInfo.resourceNameOrOperationType?.operationType
+        ] ??
+        "unknown:" + aRequestInfo.resourceNameOrOperationType?.operationType,
+      url: aRequestInfo.url,
+      analysisType:
+        this._ANALYSIS_TYPE_TELEMETRY_STRINGS[aRequestInfo.analysisType] ??
+        "unknown:" + aRequestInfo.analysisType,
+      reason:
+        this._REASON_TELEMETRY_STRINGS[aRequestInfo.reason] ??
+        "unknown:" + aRequestInfo.reason,
+    };
+    if (aResponse.action === Ci.nsIContentAnalysisResponse.eWarn) {
+      // The user hasn't made a choice yet; that's reported separately via
+      // "dlp-warn-resolved" once respondToWarnDialog() is called (either
+      // from this file's warn dialog, or from the downloads panel for
+      // download operations, which don't go through this file at all).
+      this._pendingWarnTelemetryInfo.set(
+        aResponse.requestToken,
+        requestDetails
+      );
+    }
+    // A synthetic response is one Firefox generated itself rather than one an
+    // agent sent. cancelError is only set on those when content analysis
+    // failed (agent unreachable, timed out, ...), in which case the action
+    // reflects browser.contentanalysis.default_result or timeout_result
+    // rather than a verdict about the content. Firefox also synthesizes
+    // responses for reasons that aren't failures, e.g. a URL matching
+    // browser.contentanalysis.deny_url_regex_list, and those leave
+    // cancelError at its eUserInitiated default.
+    const isErrorFallback =
+      aResponse.isSyntheticResponse &&
+      aResponse.cancelError !== Ci.nsIContentAnalysisResponse.eUserInitiated;
+    // Anywhere else cancelError is not meaningful, so report it as unset.
+    const cancelError =
+      isErrorFallback || isCancel
+        ? (this._CANCEL_ERROR_TELEMETRY_STRINGS[aResponse.cancelError] ??
+          "unknown:" + aResponse.cancelError)
+        : "";
+    lazy.ContentAnalysisTelemetry.recordRuleTriggered({
+      ...requestDetails,
+      action,
+      cancelError,
+      type: isErrorFallback ? "error_fallback" : "verdict",
+      isCached: aResponse.isCachedResponse,
+    });
+  },
+
+  /**
+   * Records rule_triggered telemetry reporting how a warn verdict was
+   * resolved (for either the warn dialog shown by this file, or the
+   * downloads panel's own warn UI). Fired from the "dlp-warn-resolved"
+   * notification, which C++ sends whenever respondToWarnDialog() is called,
+   * regardless of caller.
+   *
+   * @param {nsIContentAnalysisResponse} aResponse The resolved response;
+   *   action will be eAllow or eBlock, never eWarn.
+   * @param {string} aData The notification's data: "cancel" if the warn was
+   *   resolved because the request was cancelled rather than because the user
+   *   made a choice. See nsIContentAnalysis.respondToWarnDialog().
+   */
+  _recordWarnResolutionTelemetry(aResponse, aData) {
+    const pendingInfo = this._pendingWarnTelemetryInfo.get(
+      aResponse.requestToken
+    );
+    if (!pendingInfo) {
+      return;
+    }
+    this._pendingWarnTelemetryInfo.delete(aResponse.requestToken);
+    const action =
+      this._ACTION_TELEMETRY_STRINGS[aResponse.action] ??
+      "unknown:" + aResponse.action;
+    lazy.ContentAnalysisTelemetry.recordRuleTriggered({
+      ...pendingInfo,
+      action,
+      type:
+        aData === "cancel" || this._isRespondingToWarnDialogsForQuit
+          ? "warn_cancel"
+          : "warn_resolution",
+    });
   },
 
   /**

--- a/browser/components/contentanalysis/content/ContentAnalysisTelemetry.enterprise.sys.mjs
+++ b/browser/components/contentanalysis/content/ContentAnalysisTelemetry.enterprise.sys.mjs
@@ -171,6 +171,8 @@ export const ContentAnalysisTelemetryEnterprise = {
    *   "canceled" actions, e.g. "no_agent" or "timeout".
    * @param {boolean} [details.isCached] - Whether the verdict was reused from
    *   an identical earlier request instead of being analyzed again.
+   * @param {string} [details.ruleName] - The name of the rule that produced
+   *   the verdict, if any.
    */
   recordRuleTriggered({
     operation,
@@ -181,6 +183,7 @@ export const ContentAnalysisTelemetryEnterprise = {
     reason,
     cancelError,
     isCached,
+    ruleName,
   }) {
     if (!this._isEnabled()) {
       return;
@@ -204,6 +207,7 @@ export const ContentAnalysisTelemetryEnterprise = {
         reason: reason || "",
         cancel_error: cancelError || "",
         is_cached: !!isCached,
+        rule_name: ruleName || "",
       });
 
       // Allow tests to disable submission to inspect recorded telemetry

--- a/browser/components/contentanalysis/content/ContentAnalysisTelemetry.enterprise.sys.mjs
+++ b/browser/components/contentanalysis/content/ContentAnalysisTelemetry.enterprise.sys.mjs
@@ -151,8 +151,188 @@ export const ContentAnalysisTelemetryEnterprise = {
    */
   _ALWAYS_RECORDED_TYPES: ["warn_resolution", "warn_cancel", "error_fallback"],
 
+  _OPERATION_TYPE_TELEMETRY_STRINGS: {
+    [Ci.nsIContentAnalysisRequest.eClipboard]: "clipboard",
+    [Ci.nsIContentAnalysisRequest.eDroppedText]: "dropped_text",
+    [Ci.nsIContentAnalysisRequest.eOperationPrint]: "print",
+    [Ci.nsIContentAnalysisRequest.eUpload]: "upload",
+    [Ci.nsIContentAnalysisRequest.eDownload]: "download",
+  },
+
+  _ACTION_TELEMETRY_STRINGS: {
+    [Ci.nsIContentAnalysisResponse.eUnspecified]: "unspecified",
+    [Ci.nsIContentAnalysisResponse.eReportOnly]: "report_only",
+    [Ci.nsIContentAnalysisResponse.eBlock]: "block",
+    [Ci.nsIContentAnalysisResponse.eWarn]: "warn",
+    [Ci.nsIContentAnalysisResponse.eAllow]: "allow",
+    // Content analysis uses eCanceled rather than eBlock when the content
+    // should be blocked without showing a block dialog. (an example is
+    // the agent being unreachable while
+    // browser.contentanalysis.default_result is "block")
+    [Ci.nsIContentAnalysisResponse.eCanceled]: "canceled",
+  },
+
+  _CANCEL_ERROR_TELEMETRY_STRINGS: {
+    [Ci.nsIContentAnalysisResponse.eUserInitiated]: "user_initiated",
+    [Ci.nsIContentAnalysisResponse.eNoAgent]: "no_agent",
+    [Ci.nsIContentAnalysisResponse.eInvalidAgentSignature]:
+      "invalid_agent_signature",
+    [Ci.nsIContentAnalysisResponse.eErrorOther]: "error_other",
+    [Ci.nsIContentAnalysisResponse.eOtherRequestInGroupCancelled]:
+      "other_request_in_group_cancelled",
+    [Ci.nsIContentAnalysisResponse.eShutdown]: "shutdown",
+    [Ci.nsIContentAnalysisResponse.eTimeout]: "timeout",
+  },
+
+  // These match the AnalysisConnector enum names in analysis.proto, so the
+  // values line up with the labels of the
+  // content_analysis.request_sent_by_analysis_type counter.
+  _ANALYSIS_TYPE_TELEMETRY_STRINGS: {
+    [Ci.nsIContentAnalysisRequest.eUnspecified]:
+      "ANALYSIS_CONNECTOR_UNSPECIFIED",
+    [Ci.nsIContentAnalysisRequest.eFileDownloaded]: "FILE_DOWNLOADED",
+    [Ci.nsIContentAnalysisRequest.eFileAttached]: "FILE_ATTACHED",
+    [Ci.nsIContentAnalysisRequest.eBulkDataEntry]: "BULK_DATA_ENTRY",
+    [Ci.nsIContentAnalysisRequest.ePrint]: "PRINT",
+    [Ci.nsIContentAnalysisRequest.eFileTransfer]: "FILE_TRANSFER",
+    [Ci.nsIContentAnalysisRequest.eDataCopied]: "DATA_COPIED",
+  },
+
+  // These match the ContentAnalysisRequest::Reason enum names in
+  // analysis.proto, so the values line up with the labels of the
+  // content_analysis.request_sent_by_reason counter.
+  _REASON_TELEMETRY_STRINGS: {
+    [Ci.nsIContentAnalysisRequest.eUnknown]: "UNKNOWN",
+    [Ci.nsIContentAnalysisRequest.eClipboardPaste]: "CLIPBOARD_PASTE",
+    [Ci.nsIContentAnalysisRequest.eDragAndDrop]: "DRAG_AND_DROP",
+    [Ci.nsIContentAnalysisRequest.eFilePickerDialog]: "FILE_PICKER_DIALOG",
+    [Ci.nsIContentAnalysisRequest.ePrintPreviewPrint]: "PRINT_PREVIEW_PRINT",
+    [Ci.nsIContentAnalysisRequest.eSystemDialogPrint]: "SYSTEM_DIALOG_PRINT",
+    [Ci.nsIContentAnalysisRequest.eNormalDownload]: "NORMAL_DOWNLOAD",
+    [Ci.nsIContentAnalysisRequest.eSaveAsDownload]: "SAVE_AS_DOWNLOAD",
+    [Ci.nsIContentAnalysisRequest.eClipboardCopy]: "CLIPBOARD_COPY",
+  },
+
   /**
-   * Records a telemetry event for a content analysis (DLP) decision.
+   * Telemetry context for warn responses, kept around between the initial
+   * "warn" rule_triggered event and the "dlp-warn-resolved" notification
+   * that reports how the warn was resolved.
+   *
+   * @type {Map<string, {operation: string, url: string,
+   *   analysisType: string, reason: string, ruleName: string}>}
+   */
+  _pendingWarnTelemetryInfo: new Map(),
+
+  /**
+   * Forgets any in-flight telemetry state. Called when ContentAnalysis is
+   * uninitialized (e.g. content analysis becoming inactive, or shutdown).
+   */
+  reset() {
+    this._pendingWarnTelemetryInfo.clear();
+  },
+
+  /**
+   * Records rule_triggered telemetry for a content analysis response.
+   *
+   * @param {object} aRequestInfo The cached request info for this response's
+   *   requestToken (see ContentAnalysis.requestTokenToRequestInfo).
+   * @param {nsIContentAnalysisResponse} aResponse
+   */
+  recordVerdict(aRequestInfo, aResponse) {
+    const action =
+      this._ACTION_TELEMETRY_STRINGS[aResponse.action] ??
+      "unknown:" + aResponse.action;
+    const isCancel =
+      aResponse.action === Ci.nsIContentAnalysisResponse.eCanceled;
+    const requestDetails = {
+      operation:
+        this._OPERATION_TYPE_TELEMETRY_STRINGS[
+          aRequestInfo.resourceNameOrOperationType?.operationType
+        ] ??
+        "unknown:" + aRequestInfo.resourceNameOrOperationType?.operationType,
+      url: aRequestInfo.url,
+      analysisType:
+        this._ANALYSIS_TYPE_TELEMETRY_STRINGS[aRequestInfo.analysisType] ??
+        "unknown:" + aRequestInfo.analysisType,
+      reason:
+        this._REASON_TELEMETRY_STRINGS[aRequestInfo.reason] ??
+        "unknown:" + aRequestInfo.reason,
+      ruleName: aResponse.ruleName || "",
+    };
+    if (aResponse.action === Ci.nsIContentAnalysisResponse.eWarn) {
+      // The user hasn't made a choice yet; that's reported separately via
+      // recordWarnResolution() once respondToWarnDialog() is called (either
+      // from the warn dialog in ContentAnalysis.sys.mjs, or from the
+      // downloads panel for download operations, which doesn't go through
+      // that file at all).
+      this._pendingWarnTelemetryInfo.set(
+        aResponse.requestToken,
+        requestDetails
+      );
+    }
+    // A synthetic response is one Firefox generated itself rather than one an
+    // agent sent. cancelError is only set on those when content analysis
+    // failed (agent unreachable, timed out, ...), in which case the action
+    // reflects browser.contentanalysis.default_result or timeout_result
+    // rather than a verdict about the content. Firefox also synthesizes
+    // responses for reasons that aren't failures, e.g. a URL matching
+    // browser.contentanalysis.deny_url_regex_list, and those leave
+    // cancelError at its eUserInitiated default.
+    const isErrorFallback =
+      aResponse.isSyntheticResponse &&
+      aResponse.cancelError !== Ci.nsIContentAnalysisResponse.eUserInitiated;
+    // Anywhere else cancelError is not meaningful, so report it as unset.
+    const cancelError =
+      isErrorFallback || isCancel
+        ? (this._CANCEL_ERROR_TELEMETRY_STRINGS[aResponse.cancelError] ??
+          "unknown:" + aResponse.cancelError)
+        : "";
+    this._record({
+      ...requestDetails,
+      action,
+      cancelError,
+      type: isErrorFallback ? "error_fallback" : "verdict",
+      isCached: aResponse.isCachedResponse,
+    });
+  },
+
+  /**
+   * Records rule_triggered telemetry reporting how a warn verdict was
+   * resolved (for either the warn dialog shown by ContentAnalysis.sys.mjs, or
+   * the downloads panel's own warn UI). Called whenever
+   * nsIContentAnalysis.respondToWarnDialog() is called, regardless of caller.
+   *
+   * @param {nsIContentAnalysisResponse} aResponse The resolved response;
+   *   action will be eAllow or eBlock, never eWarn.
+   * @param {string} aData The notification's data: "cancel" if the warn was
+   *   resolved because the request was cancelled rather than because the user
+   *   made a choice. See nsIContentAnalysis.respondToWarnDialog().
+   * @param {boolean} aIsQuitting Whether the warn is being resolved because
+   *   the application is quitting, in which case it's not a choice the user
+   *   made even if aData isn't "cancel".
+   */
+  recordWarnResolution(aResponse, aData, aIsQuitting) {
+    const pendingInfo = this._pendingWarnTelemetryInfo.get(
+      aResponse.requestToken
+    );
+    if (!pendingInfo) {
+      return;
+    }
+    this._pendingWarnTelemetryInfo.delete(aResponse.requestToken);
+    const action =
+      this._ACTION_TELEMETRY_STRINGS[aResponse.action] ??
+      "unknown:" + aResponse.action;
+    this._record({
+      ...pendingInfo,
+      action,
+      type:
+        aData === "cancel" || aIsQuitting ? "warn_cancel" : "warn_resolution",
+    });
+  },
+
+  /**
+   * Records a telemetry event for a content analysis (DLP) decision. Use
+   * recordVerdict()/recordWarnResolution() instead of calling this directly.
    *
    * @param {object} details
    * @param {string} details.operation - The user action performed.
@@ -174,7 +354,7 @@ export const ContentAnalysisTelemetryEnterprise = {
    * @param {string} [details.ruleName] - The name of the rule that produced
    *   the verdict, if any.
    */
-  recordRuleTriggered({
+  _record({
     operation,
     url,
     action,

--- a/browser/components/contentanalysis/content/ContentAnalysisTelemetry.enterprise.sys.mjs
+++ b/browser/components/contentanalysis/content/ContentAnalysisTelemetry.enterprise.sys.mjs
@@ -1,0 +1,227 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Enterprise Content Analysis (DLP) Telemetry Implementation
+ *
+ * This module is only included in MOZ_ENTERPRISE builds and provides
+ * security telemetry when content analysis makes a decision about a
+ * user action.
+ *
+ * ENTERPRISE POLICY CONFIGURATION:
+ * ================================
+ *
+ * The telemetry collection can be configured via enterprise policy. In the
+ * enterprise policies.json file:
+ *
+ * {
+ *   "policies": {
+ *     "ContentAnalysisTelemetry": {
+ *       "Enabled": true,
+ *       "UrlLogging": "full",
+ *       "RecordEvents": "nonAllow"
+ *     }
+ *   }
+ * }
+ *
+ * Configuration Options:
+ * - Enabled (boolean): Enable/disable content analysis telemetry collection
+ * - UrlLogging (string): URL logging level with values:
+ *   - "full" (default): Collect the complete URL
+ *   - "domain": Collect only the hostname portion of the URL
+ *   - "none": Do not collect any URL information
+ * - RecordEvents (string): Which outcomes to record, with values:
+ *   - "nonAllow" (default): Record everything except verdicts that silently
+ *     allowed the operation the user asked for. Report-only verdicts are
+ *     recorded, since reporting is the only thing they ask for.
+ *   - "all": Also record verdicts that allowed the operation
+ */
+
+export const ContentAnalysisTelemetryEnterprise = {
+  /**
+   * Checks if content analysis telemetry is enabled via enterprise policy.
+   *
+   * @returns {boolean} True if telemetry should be collected
+   */
+  _isEnabled() {
+    return Services.prefs.getBoolPref(
+      "browser.contentanalysis.enterprise.telemetry.enabled",
+      true
+    );
+  },
+
+  /**
+   * Gets the configured URL logging level from enterprise policy preferences.
+   *
+   * @returns {string} One of: "full", "domain", "none"
+   */
+  _getUrlLoggingPolicy() {
+    const urlLogging = Services.prefs.getCharPref(
+      "browser.contentanalysis.enterprise.telemetry.urlLogging",
+      "full"
+    );
+
+    if (["full", "domain", "none"].includes(urlLogging)) {
+      return urlLogging;
+    }
+
+    return "full";
+  },
+
+  /**
+   * Gets the configured outcome-filtering policy from enterprise policy
+   * preferences.
+   *
+   * @returns {string} One of: "all", "nonAllow"
+   */
+  _getRecordEventsPolicy() {
+    const recordEvents = Services.prefs.getCharPref(
+      "browser.contentanalysis.enterprise.telemetry.recordEvents",
+      "nonAllow"
+    );
+
+    if (["all", "nonAllow"].includes(recordEvents)) {
+      return recordEvents;
+    }
+
+    return "nonAllow";
+  },
+
+  /**
+   * Processes a URL based on the configured logging policy.
+   *
+   * @param {string} url - The original URL
+   * @returns {string} Processed URL, hostname, or empty string based on policy
+   */
+  _processUrl(url) {
+    if (!url) {
+      return "";
+    }
+
+    switch (this._getUrlLoggingPolicy()) {
+      case "none":
+        return "";
+
+      case "domain":
+        try {
+          return new URL(url).hostname || "";
+        } catch (ex) {
+          return "";
+        }
+
+      case "full":
+      default:
+        return url;
+    }
+  },
+
+  /**
+   * Determines whether an event for the given action should be recorded,
+   * based on the configured RecordEvents policy.
+   *
+   * @param {string} action - e.g. "block", "warn", "canceled", or "allow"
+   * @returns {boolean} True if this action should be recorded
+   */
+  _shouldRecordAction(action) {
+    if (this._getRecordEventsPolicy() === "all") {
+      return true;
+    }
+    return action !== "allow";
+  },
+
+  /**
+   * Determines which DLP backend produced the verdict.
+   *
+   * @returns {boolean} true if the in-process WASM engine was used, false
+   *   if an external agent was used.
+   */
+  _isBuiltinEngine() {
+    return Services.prefs.getBoolPref(
+      "browser.contentanalysis.use_wasm_backend",
+      false
+    );
+  },
+
+  /**
+   * Event types that are recorded whenever telemetry is enabled, regardless
+   * of the RecordEvents policy. "warn_resolution" and "warn_cancel" follow up
+   * on a warn that was already reportable, and "error_fallback" means content
+   * analysis itself failed, which is always reportable.
+   */
+  _ALWAYS_RECORDED_TYPES: ["warn_resolution", "warn_cancel", "error_fallback"],
+
+  /**
+   * Records a telemetry event for a content analysis (DLP) decision.
+   *
+   * @param {object} details
+   * @param {string} details.operation - The user action performed.
+   * @param {string} details.url - The URL of the content the action was
+   *   performed on.
+   * @param {string} details.action - What content analysis decided to do,
+   *   e.g. "block", "warn", "canceled", or "allow".
+   * @param {string} details.type - "verdict", "error_fallback",
+   *   "warn_resolution", or "warn_cancel". See _ALWAYS_RECORDED_TYPES.
+   * @param {string} details.analysisType - The request's analysisType as an
+   *   AnalysisConnector enum name from analysis.proto, e.g. "FILE_ATTACHED".
+   * @param {string} details.reason - The request's reason as a
+   *   ContentAnalysisRequest::Reason enum name from analysis.proto, e.g.
+   *   "CLIPBOARD_PASTE".
+   * @param {string} [details.cancelError] - Why the request was canceled, for
+   *   "canceled" actions, e.g. "no_agent" or "timeout".
+   * @param {boolean} [details.isCached] - Whether the verdict was reused from
+   *   an identical earlier request instead of being analyzed again.
+   */
+  recordRuleTriggered({
+    operation,
+    url,
+    action,
+    type,
+    analysisType,
+    reason,
+    cancelError,
+    isCached,
+  }) {
+    if (!this._isEnabled()) {
+      return;
+    }
+
+    if (
+      !this._ALWAYS_RECORDED_TYPES.includes(type) &&
+      !this._shouldRecordAction(action)
+    ) {
+      return;
+    }
+
+    try {
+      Glean.contentAnalysis.ruleTriggered.record({
+        operation,
+        url: this._processUrl(url),
+        action,
+        type,
+        is_builtin: this._isBuiltinEngine(),
+        analysis_type: analysisType || "",
+        reason: reason || "",
+        cancel_error: cancelError || "",
+        is_cached: !!isCached,
+      });
+
+      // Allow tests to disable submission to inspect recorded telemetry
+      if (
+        !Services.prefs.getBoolPref(
+          "browser.contentanalysis.enterprise.telemetry.testing.disableSubmit",
+          false
+        )
+      ) {
+        GleanPings.enterprise.submit();
+      }
+    } catch (ex) {
+      // Report but otherwise swallow the failure - telemetry errors should not
+      // break content analysis.
+      console.error(
+        `[ContentAnalysisTelemetryEnterprise] Rule-triggered telemetry recording failed:`,
+        ex
+      );
+    }
+  },
+};

--- a/browser/components/contentanalysis/content/ContentAnalysisTelemetry.enterprise.sys.mjs
+++ b/browser/components/contentanalysis/content/ContentAnalysisTelemetry.enterprise.sys.mjs
@@ -19,8 +19,7 @@
  *   "policies": {
  *     "ContentAnalysisTelemetry": {
  *       "Enabled": true,
- *       "UrlLogging": "full",
- *       "RecordEvents": "nonAllow"
+ *       "UrlLogging": "full"
  *     }
  *   }
  * }
@@ -31,11 +30,9 @@
  *   - "full" (default): Collect the complete URL
  *   - "domain": Collect only the hostname portion of the URL
  *   - "none": Do not collect any URL information
- * - RecordEvents (string): Which outcomes to record, with values:
- *   - "nonAllow" (default): Record everything except verdicts that silently
- *     allowed the operation the user asked for. Report-only verdicts are
- *     recorded, since reporting is the only thing they ask for.
- *   - "all": Also record verdicts that allowed the operation
+ *
+ * Verdicts that silently allowed the operation the user asked for aren't
+ * recorded.
  */
 
 export const ContentAnalysisTelemetryEnterprise = {
@@ -70,25 +67,6 @@ export const ContentAnalysisTelemetryEnterprise = {
   },
 
   /**
-   * Gets the configured outcome-filtering policy from enterprise policy
-   * preferences.
-   *
-   * @returns {string} One of: "all", "nonAllow"
-   */
-  _getRecordEventsPolicy() {
-    const recordEvents = Services.prefs.getCharPref(
-      "browser.contentanalysis.enterprise.telemetry.recordEvents",
-      "nonAllow"
-    );
-
-    if (["all", "nonAllow"].includes(recordEvents)) {
-      return recordEvents;
-    }
-
-    return "nonAllow";
-  },
-
-  /**
    * Processes a URL based on the configured logging policy.
    *
    * @param {string} url - The original URL
@@ -117,16 +95,14 @@ export const ContentAnalysisTelemetryEnterprise = {
   },
 
   /**
-   * Determines whether an event for the given action should be recorded,
-   * based on the configured RecordEvents policy.
+   * Determines whether an event for the given action should be recorded.
+   * Verdicts that silently allowed the operation the user asked for aren't
+   * recorded, since they aren't relevant to a DLP audit.
    *
    * @param {string} action - e.g. "block", "warn", "canceled", or "allow"
    * @returns {boolean} True if this action should be recorded
    */
   _shouldRecordAction(action) {
-    if (this._getRecordEventsPolicy() === "all") {
-      return true;
-    }
     return action !== "allow";
   },
 
@@ -144,10 +120,11 @@ export const ContentAnalysisTelemetryEnterprise = {
   },
 
   /**
-   * Event types that are recorded whenever telemetry is enabled, regardless
-   * of the RecordEvents policy. "warn_resolution" and "warn_cancel" follow up
-   * on a warn that was already reportable, and "error_fallback" means content
-   * analysis itself failed, which is always reportable.
+   * Event types that are recorded whenever telemetry is enabled, even if
+   * their action is "allow" (see _shouldRecordAction). "warn_resolution" and
+   * "warn_cancel" follow up on a warn that was already reportable, and
+   * "error_fallback" means content analysis itself failed, which is always
+   * reportable.
    */
   _ALWAYS_RECORDED_TYPES: ["warn_resolution", "warn_cancel", "error_fallback"],
 

--- a/browser/components/contentanalysis/content/ContentAnalysisTelemetry.sys.mjs
+++ b/browser/components/contentanalysis/content/ContentAnalysisTelemetry.sys.mjs
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * Shim module for Content Analysis Telemetry.
+ *
+ * This module provides a stable import path for content analysis (DLP)
+ * telemetry functionality. The actual implementation is conditionally
+ * provided at build time:
+ * - In MOZ_ENTERPRISE builds: Full enterprise telemetry implementation
+ * - In regular builds: No-op implementation (enterprise code completely absent)
+ */
+
+let ContentAnalysisTelemetryImpl;
+
+try {
+  const { ContentAnalysisTelemetryEnterprise } = ChromeUtils.importESModule(
+    "moz-src:///browser/components/contentanalysis/content/ContentAnalysisTelemetry.enterprise.sys.mjs"
+  );
+  ContentAnalysisTelemetryImpl = ContentAnalysisTelemetryEnterprise;
+} catch (ex) {
+  console.warn(
+    "[ContentAnalysisTelemetry] Enterprise implementation not available, using no-op shim. Error:",
+    ex.message
+  );
+  ContentAnalysisTelemetryImpl = {
+    recordRuleTriggered: () => {},
+  };
+}
+
+export const ContentAnalysisTelemetry = ContentAnalysisTelemetryImpl;

--- a/browser/components/contentanalysis/content/ContentAnalysisTelemetry.sys.mjs
+++ b/browser/components/contentanalysis/content/ContentAnalysisTelemetry.sys.mjs
@@ -12,21 +12,24 @@
  * - In regular builds: No-op implementation (enterprise code completely absent)
  */
 
-let ContentAnalysisTelemetryImpl;
+import { AppConstants } from "resource://gre/modules/AppConstants.sys.mjs";
 
-try {
-  const { ContentAnalysisTelemetryEnterprise } = ChromeUtils.importESModule(
-    "moz-src:///browser/components/contentanalysis/content/ContentAnalysisTelemetry.enterprise.sys.mjs"
-  );
-  ContentAnalysisTelemetryImpl = ContentAnalysisTelemetryEnterprise;
-} catch (ex) {
-  console.warn(
-    "[ContentAnalysisTelemetry] Enterprise implementation not available, using no-op shim. Error:",
-    ex.message
-  );
-  ContentAnalysisTelemetryImpl = {
-    recordRuleTriggered: () => {},
-  };
+let ContentAnalysisTelemetryImpl = {
+  recordRuleTriggered: () => {},
+};
+
+if (AppConstants.MOZ_ENTERPRISE) {
+  try {
+    const { ContentAnalysisTelemetryEnterprise } = ChromeUtils.importESModule(
+      "moz-src:///browser/components/contentanalysis/content/ContentAnalysisTelemetry.enterprise.sys.mjs"
+    );
+    ContentAnalysisTelemetryImpl = ContentAnalysisTelemetryEnterprise;
+  } catch (ex) {
+    console.error(
+      "[ContentAnalysisTelemetry] Enterprise implementation not available, using no-op shim. Error:",
+      ex.message
+    );
+  }
 }
 
 export const ContentAnalysisTelemetry = ContentAnalysisTelemetryImpl;

--- a/browser/components/contentanalysis/content/ContentAnalysisTelemetry.sys.mjs
+++ b/browser/components/contentanalysis/content/ContentAnalysisTelemetry.sys.mjs
@@ -15,7 +15,9 @@
 import { AppConstants } from "resource://gre/modules/AppConstants.sys.mjs";
 
 let ContentAnalysisTelemetryImpl = {
-  recordRuleTriggered: () => {},
+  recordVerdict: () => {},
+  recordWarnResolution: () => {},
+  reset: () => {},
 };
 
 if (AppConstants.MOZ_ENTERPRISE) {

--- a/browser/components/contentanalysis/moz.build
+++ b/browser/components/contentanalysis/moz.build
@@ -7,4 +7,10 @@ with Files("**"):
 
 MOZ_SRC_FILES += [
     "content/ContentAnalysis.sys.mjs",
+    "content/ContentAnalysisTelemetry.sys.mjs",
 ]
+
+if CONFIG["MOZ_ENTERPRISE"]:
+    MOZ_SRC_FILES += ["content/ContentAnalysisTelemetry.enterprise.sys.mjs"]
+
+XPCSHELL_TESTS_MANIFESTS += ["test/unit/xpcshell.toml"]

--- a/browser/components/contentanalysis/test/unit/head.js
+++ b/browser/components/contentanalysis/test/unit/head.js
@@ -1,0 +1,8 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+add_setup(async function test_common_initialize() {
+  do_get_profile();
+  // Initialize FOG for Glean telemetry testing
+  Services.fog.initializeFOG();
+});

--- a/browser/components/contentanalysis/test/unit/test_ContentAnalysisTelemetry_enterprise.js
+++ b/browser/components/contentanalysis/test/unit/test_ContentAnalysisTelemetry_enterprise.js
@@ -43,12 +43,12 @@ const BASE_DETAILS = {
  * Records one event and returns the extras of everything recorded, or null if
  * nothing was recorded.
  *
- * @param {object} details Passed through to recordRuleTriggered().
+ * @param {object} details Passed through to _record().
  * @returns {object[]|null}
  */
 function recordAndGetExtras(details) {
   Services.fog.testResetFOG();
-  ContentAnalysisTelemetryEnterprise.recordRuleTriggered(details);
+  ContentAnalysisTelemetryEnterprise._record(details);
   const events = Glean.contentAnalysis.ruleTriggered.testGetValue("enterprise");
   return events ? events.map(event => event.extra) : null;
 }

--- a/browser/components/contentanalysis/test/unit/test_ContentAnalysisTelemetry_enterprise.js
+++ b/browser/components/contentanalysis/test/unit/test_ContentAnalysisTelemetry_enterprise.js
@@ -187,6 +187,34 @@ add_task(async function test_record_rule_triggered() {
     "false",
     "is_cached should be false when not passed"
   );
+  Assert.equal(
+    extras[0].rule_name,
+    "",
+    "rule_name should be empty when not passed"
+  );
+});
+
+add_task(async function test_rule_name_is_reported_for_either_engine() {
+  const details = { ...BASE_DETAILS, ruleName: "block-confidential-content" };
+
+  // External agent (the default; browser.contentanalysis.use_wasm_backend
+  // defaults to false).
+  let extras = recordAndGetExtras(details);
+  Assert.equal(extras[0].is_builtin, "false");
+  Assert.equal(extras[0].rule_name, "block-confidential-content");
+
+  Services.prefs.setBoolPref("browser.contentanalysis.use_wasm_backend", true);
+  try {
+    extras = recordAndGetExtras(details);
+    Assert.equal(extras[0].is_builtin, "true");
+    Assert.equal(
+      extras[0].rule_name,
+      "block-confidential-content",
+      "rule_name should be reported for the built-in engine too"
+    );
+  } finally {
+    Services.prefs.clearUserPref("browser.contentanalysis.use_wasm_backend");
+  }
 });
 
 add_task(async function test_optional_keys_are_recorded() {

--- a/browser/components/contentanalysis/test/unit/test_ContentAnalysisTelemetry_enterprise.js
+++ b/browser/components/contentanalysis/test/unit/test_ContentAnalysisTelemetry_enterprise.js
@@ -1,0 +1,282 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+/**
+ * Tests for Enterprise Content Analysis (DLP) Telemetry functionality.
+ * These tests only run in MOZ_ENTERPRISE builds.
+ */
+
+const { ContentAnalysisTelemetryEnterprise } = ChromeUtils.importESModule(
+  "moz-src:///browser/components/contentanalysis/content/ContentAnalysisTelemetry.enterprise.sys.mjs"
+);
+
+const ENABLED_PREF = "browser.contentanalysis.enterprise.telemetry.enabled";
+const URL_LOGGING_PREF =
+  "browser.contentanalysis.enterprise.telemetry.urlLogging";
+const RECORD_EVENTS_PREF =
+  "browser.contentanalysis.enterprise.telemetry.recordEvents";
+const DISABLE_SUBMIT_PREF =
+  "browser.contentanalysis.enterprise.telemetry.testing.disableSubmit";
+
+add_setup(function () {
+  // Every task below wants submission disabled so it can inspect recorded
+  // telemetry without it being cleared by GleanPings.enterprise.submit().
+  Services.prefs.setBoolPref(DISABLE_SUBMIT_PREF, true);
+  registerCleanupFunction(() => {
+    Services.prefs.clearUserPref(DISABLE_SUBMIT_PREF);
+    Services.prefs.clearUserPref(ENABLED_PREF);
+    Services.prefs.clearUserPref(URL_LOGGING_PREF);
+    Services.prefs.clearUserPref(RECORD_EVENTS_PREF);
+  });
+});
+
+const BASE_DETAILS = {
+  operation: "upload",
+  url: "https://example.com/secret.docx",
+  action: "block",
+  type: "verdict",
+  analysisType: "FILE_ATTACHED",
+  reason: "FILE_PICKER_DIALOG",
+};
+
+/**
+ * Records one event and returns the extras of everything recorded, or null if
+ * nothing was recorded.
+ *
+ * @param {object} details Passed through to recordRuleTriggered().
+ * @returns {object[]|null}
+ */
+function recordAndGetExtras(details) {
+  Services.fog.testResetFOG();
+  ContentAnalysisTelemetryEnterprise.recordRuleTriggered(details);
+  const events = Glean.contentAnalysis.ruleTriggered.testGetValue("enterprise");
+  return events ? events.map(event => event.extra) : null;
+}
+
+add_task(async function test_url_processing_policies() {
+  const testCases = [
+    {
+      input: "https://example.com/path/to/file.pdf?param=value#fragment",
+      policy: "full",
+      expected: "https://example.com/path/to/file.pdf?param=value#fragment",
+    },
+    {
+      input: "https://example.com/path/to/file.pdf?param=value#fragment",
+      policy: "domain",
+      expected: "example.com",
+    },
+    {
+      input: "https://example.com/path/to/file.pdf?param=value#fragment",
+      policy: "none",
+      expected: "",
+    },
+    {
+      // An unrecognized policy value falls back to "full".
+      input: "https://example.com/path/to/file.pdf?param=value#fragment",
+      policy: "bogus",
+      expected: "https://example.com/path/to/file.pdf?param=value#fragment",
+    },
+    {
+      input: "invalid-url",
+      policy: "full",
+      expected: "invalid-url",
+    },
+    {
+      input: "invalid-url",
+      policy: "domain",
+      expected: "",
+    },
+    {
+      input: null,
+      policy: "full",
+      expected: "",
+    },
+    {
+      input: "",
+      policy: "domain",
+      expected: "",
+    },
+  ];
+
+  for (const testCase of testCases) {
+    Services.prefs.setCharPref(URL_LOGGING_PREF, testCase.policy);
+
+    Assert.strictEqual(
+      ContentAnalysisTelemetryEnterprise._processUrl(testCase.input),
+      testCase.expected,
+      `URL processing failed for input: ${testCase.input}, policy: ${testCase.policy}`
+    );
+
+    // The same policy should apply to what actually gets recorded.
+    const extras = recordAndGetExtras({ ...BASE_DETAILS, url: testCase.input });
+    Assert.equal(
+      extras[0].url,
+      testCase.expected,
+      `recorded url should honor the ${testCase.policy} policy`
+    );
+  }
+
+  Services.prefs.clearUserPref(URL_LOGGING_PREF);
+});
+
+add_task(async function test_should_record_action() {
+  const testCases = [
+    { action: "block", policy: "nonAllow", expected: true },
+    { action: "warn", policy: "nonAllow", expected: true },
+    { action: "canceled", policy: "nonAllow", expected: true },
+    // Recording is the whole point of a report-only verdict.
+    { action: "report_only", policy: "nonAllow", expected: true },
+    // Unrecognized actions are recorded rather than silently dropped.
+    { action: "unknown:1234", policy: "nonAllow", expected: true },
+    { action: "allow", policy: "nonAllow", expected: false },
+    { action: "block", policy: "all", expected: true },
+    { action: "warn", policy: "all", expected: true },
+    { action: "canceled", policy: "all", expected: true },
+    { action: "allow", policy: "all", expected: true },
+    { action: "report_only", policy: "all", expected: true },
+    // An unrecognized policy value falls back to "nonAllow".
+    { action: "block", policy: "bogus", expected: true },
+    { action: "allow", policy: "bogus", expected: false },
+  ];
+
+  for (const testCase of testCases) {
+    Services.prefs.setCharPref(RECORD_EVENTS_PREF, testCase.policy);
+
+    Assert.strictEqual(
+      ContentAnalysisTelemetryEnterprise._shouldRecordAction(testCase.action),
+      testCase.expected,
+      `_shouldRecordAction failed for action: ${testCase.action}, policy: ${testCase.policy}`
+    );
+
+    const extras = recordAndGetExtras({
+      ...BASE_DETAILS,
+      action: testCase.action,
+    });
+    Assert.equal(
+      extras !== null,
+      testCase.expected,
+      `recording a ${testCase.action} verdict under the ${testCase.policy} policy`
+    );
+  }
+
+  Services.prefs.clearUserPref(RECORD_EVENTS_PREF);
+});
+
+add_task(async function test_record_rule_triggered() {
+  const extras = recordAndGetExtras(BASE_DETAILS);
+  Assert.ok(extras, "Should have recorded events");
+  Assert.equal(extras.length, 1, "Should record exactly one event");
+
+  Assert.equal(extras[0].operation, "upload");
+  Assert.equal(extras[0].url, "https://example.com/secret.docx");
+  Assert.equal(extras[0].action, "block");
+  Assert.equal(extras[0].type, "verdict");
+  Assert.ok(
+    extras[0].is_builtin === "true" || extras[0].is_builtin === "false",
+    "is_builtin should be a boolean"
+  );
+  Assert.equal(extras[0].analysis_type, "FILE_ATTACHED");
+  Assert.equal(extras[0].reason, "FILE_PICKER_DIALOG");
+  Assert.equal(
+    extras[0].cancel_error,
+    "",
+    "cancel_error should be empty when not passed"
+  );
+  Assert.equal(
+    extras[0].is_cached,
+    "false",
+    "is_cached should be false when not passed"
+  );
+});
+
+add_task(async function test_optional_keys_are_recorded() {
+  const extras = recordAndGetExtras({
+    ...BASE_DETAILS,
+    action: "canceled",
+    cancelError: "timeout",
+    isCached: true,
+  });
+  Assert.ok(extras, "Should have recorded events");
+  Assert.equal(extras[0].action, "canceled");
+  Assert.equal(extras[0].cancel_error, "timeout");
+  Assert.equal(extras[0].is_cached, "true");
+});
+
+add_task(async function test_disabled_does_not_record() {
+  Services.prefs.setBoolPref(ENABLED_PREF, false);
+  try {
+    Assert.equal(
+      recordAndGetExtras(BASE_DETAILS),
+      null,
+      "Should not record when disabled"
+    );
+    // Not even the types that bypass the RecordEvents filter.
+    Assert.equal(
+      recordAndGetExtras({
+        ...BASE_DETAILS,
+        action: "canceled",
+        type: "error_fallback",
+        cancelError: "no_agent",
+      }),
+      null,
+      "Should not record error fallbacks when disabled"
+    );
+  } finally {
+    Services.prefs.clearUserPref(ENABLED_PREF);
+  }
+});
+
+add_task(async function test_always_recorded_types_bypass_outcome_filter() {
+  // Each of these has an action that RecordEvents=nonAllow would otherwise
+  // filter out.
+  const testCases = [
+    {
+      what: "an error fallback that allowed the operation",
+      details: { action: "allow", type: "error_fallback" },
+    },
+    {
+      what: "a warn the user resolved by allowing",
+      details: { action: "allow", type: "warn_resolution" },
+    },
+    {
+      what: "a warn resolved by the request being canceled",
+      details: { action: "allow", type: "warn_cancel" },
+    },
+  ];
+
+  Services.prefs.setCharPref(RECORD_EVENTS_PREF, "nonAllow");
+  try {
+    for (const testCase of testCases) {
+      const extras = recordAndGetExtras({
+        ...BASE_DETAILS,
+        ...testCase.details,
+      });
+      Assert.ok(extras, `should record ${testCase.what}`);
+      Assert.equal(extras[0].action, testCase.details.action);
+      Assert.equal(extras[0].type, testCase.details.type);
+    }
+  } finally {
+    Services.prefs.clearUserPref(RECORD_EVENTS_PREF);
+  }
+});
+
+add_task(async function test_error_fallback_block_is_recorded() {
+  // The common agent-failure case: browser.contentanalysis.default_result is
+  // "block", so content analysis reports a canceled action rather than a
+  // block. This must be recorded under the default policy.
+  Services.prefs.setCharPref(RECORD_EVENTS_PREF, "nonAllow");
+  try {
+    const extras = recordAndGetExtras({
+      ...BASE_DETAILS,
+      action: "canceled",
+      type: "error_fallback",
+      cancelError: "no_agent",
+    });
+    Assert.ok(extras, "should record a canceled error fallback");
+    Assert.equal(extras[0].action, "canceled");
+    Assert.equal(extras[0].type, "error_fallback");
+    Assert.equal(extras[0].cancel_error, "no_agent");
+  } finally {
+    Services.prefs.clearUserPref(RECORD_EVENTS_PREF);
+  }
+});

--- a/browser/components/contentanalysis/test/unit/test_ContentAnalysisTelemetry_enterprise.js
+++ b/browser/components/contentanalysis/test/unit/test_ContentAnalysisTelemetry_enterprise.js
@@ -13,8 +13,6 @@ const { ContentAnalysisTelemetryEnterprise } = ChromeUtils.importESModule(
 const ENABLED_PREF = "browser.contentanalysis.enterprise.telemetry.enabled";
 const URL_LOGGING_PREF =
   "browser.contentanalysis.enterprise.telemetry.urlLogging";
-const RECORD_EVENTS_PREF =
-  "browser.contentanalysis.enterprise.telemetry.recordEvents";
 const DISABLE_SUBMIT_PREF =
   "browser.contentanalysis.enterprise.telemetry.testing.disableSubmit";
 
@@ -26,7 +24,6 @@ add_setup(function () {
     Services.prefs.clearUserPref(DISABLE_SUBMIT_PREF);
     Services.prefs.clearUserPref(ENABLED_PREF);
     Services.prefs.clearUserPref(URL_LOGGING_PREF);
-    Services.prefs.clearUserPref(RECORD_EVENTS_PREF);
   });
 });
 
@@ -121,31 +118,21 @@ add_task(async function test_url_processing_policies() {
 
 add_task(async function test_should_record_action() {
   const testCases = [
-    { action: "block", policy: "nonAllow", expected: true },
-    { action: "warn", policy: "nonAllow", expected: true },
-    { action: "canceled", policy: "nonAllow", expected: true },
+    { action: "block", expected: true },
+    { action: "warn", expected: true },
+    { action: "canceled", expected: true },
     // Recording is the whole point of a report-only verdict.
-    { action: "report_only", policy: "nonAllow", expected: true },
+    { action: "report_only", expected: true },
     // Unrecognized actions are recorded rather than silently dropped.
-    { action: "unknown:1234", policy: "nonAllow", expected: true },
-    { action: "allow", policy: "nonAllow", expected: false },
-    { action: "block", policy: "all", expected: true },
-    { action: "warn", policy: "all", expected: true },
-    { action: "canceled", policy: "all", expected: true },
-    { action: "allow", policy: "all", expected: true },
-    { action: "report_only", policy: "all", expected: true },
-    // An unrecognized policy value falls back to "nonAllow".
-    { action: "block", policy: "bogus", expected: true },
-    { action: "allow", policy: "bogus", expected: false },
+    { action: "unknown:1234", expected: true },
+    { action: "allow", expected: false },
   ];
 
   for (const testCase of testCases) {
-    Services.prefs.setCharPref(RECORD_EVENTS_PREF, testCase.policy);
-
     Assert.strictEqual(
       ContentAnalysisTelemetryEnterprise._shouldRecordAction(testCase.action),
       testCase.expected,
-      `_shouldRecordAction failed for action: ${testCase.action}, policy: ${testCase.policy}`
+      `_shouldRecordAction failed for action: ${testCase.action}`
     );
 
     const extras = recordAndGetExtras({
@@ -155,11 +142,9 @@ add_task(async function test_should_record_action() {
     Assert.equal(
       extras !== null,
       testCase.expected,
-      `recording a ${testCase.action} verdict under the ${testCase.policy} policy`
+      `recording a ${testCase.action} verdict`
     );
   }
-
-  Services.prefs.clearUserPref(RECORD_EVENTS_PREF);
 });
 
 add_task(async function test_record_rule_triggered() {
@@ -238,7 +223,7 @@ add_task(async function test_disabled_does_not_record() {
       null,
       "Should not record when disabled"
     );
-    // Not even the types that bypass the RecordEvents filter.
+    // Not even the types that bypass the "allow" outcome filter.
     Assert.equal(
       recordAndGetExtras({
         ...BASE_DETAILS,
@@ -255,8 +240,8 @@ add_task(async function test_disabled_does_not_record() {
 });
 
 add_task(async function test_always_recorded_types_bypass_outcome_filter() {
-  // Each of these has an action that RecordEvents=nonAllow would otherwise
-  // filter out.
+  // Each of these has an action ("allow") that would otherwise be filtered
+  // out.
   const testCases = [
     {
       what: "an error fallback that allowed the operation",
@@ -272,39 +257,29 @@ add_task(async function test_always_recorded_types_bypass_outcome_filter() {
     },
   ];
 
-  Services.prefs.setCharPref(RECORD_EVENTS_PREF, "nonAllow");
-  try {
-    for (const testCase of testCases) {
-      const extras = recordAndGetExtras({
-        ...BASE_DETAILS,
-        ...testCase.details,
-      });
-      Assert.ok(extras, `should record ${testCase.what}`);
-      Assert.equal(extras[0].action, testCase.details.action);
-      Assert.equal(extras[0].type, testCase.details.type);
-    }
-  } finally {
-    Services.prefs.clearUserPref(RECORD_EVENTS_PREF);
+  for (const testCase of testCases) {
+    const extras = recordAndGetExtras({
+      ...BASE_DETAILS,
+      ...testCase.details,
+    });
+    Assert.ok(extras, `should record ${testCase.what}`);
+    Assert.equal(extras[0].action, testCase.details.action);
+    Assert.equal(extras[0].type, testCase.details.type);
   }
 });
 
 add_task(async function test_error_fallback_block_is_recorded() {
   // The common agent-failure case: browser.contentanalysis.default_result is
   // "block", so content analysis reports a canceled action rather than a
-  // block. This must be recorded under the default policy.
-  Services.prefs.setCharPref(RECORD_EVENTS_PREF, "nonAllow");
-  try {
-    const extras = recordAndGetExtras({
-      ...BASE_DETAILS,
-      action: "canceled",
-      type: "error_fallback",
-      cancelError: "no_agent",
-    });
-    Assert.ok(extras, "should record a canceled error fallback");
-    Assert.equal(extras[0].action, "canceled");
-    Assert.equal(extras[0].type, "error_fallback");
-    Assert.equal(extras[0].cancel_error, "no_agent");
-  } finally {
-    Services.prefs.clearUserPref(RECORD_EVENTS_PREF);
-  }
+  // block. This must be recorded.
+  const extras = recordAndGetExtras({
+    ...BASE_DETAILS,
+    action: "canceled",
+    type: "error_fallback",
+    cancelError: "no_agent",
+  });
+  Assert.ok(extras, "should record a canceled error fallback");
+  Assert.equal(extras[0].action, "canceled");
+  Assert.equal(extras[0].type, "error_fallback");
+  Assert.equal(extras[0].cancel_error, "no_agent");
 });

--- a/browser/components/contentanalysis/test/unit/test_ContentAnalysis_telemetry_mapping.js
+++ b/browser/components/contentanalysis/test/unit/test_ContentAnalysis_telemetry_mapping.js
@@ -2,16 +2,16 @@
    http://creativecommons.org/publicdomain/zero/1.0/ */
 
 /**
- * Tests how ContentAnalysis.sys.mjs turns nsIContentAnalysisResponses into
- * rule_triggered telemetry, in particular the cases that are hard to produce
+ * Tests how ContentAnalysisTelemetryEnterprise turns nsIContentAnalysisResponses
+ * into rule_triggered telemetry, in particular the cases that are hard to produce
  * from a browser test: responses Firefox synthesized because content analysis
  * itself failed, and warn verdicts resolved by the request being canceled.
  *
  * Only run in MOZ_ENTERPRISE builds.
  */
 
-const { ContentAnalysis } = ChromeUtils.importESModule(
-  "moz-src:///browser/components/contentanalysis/content/ContentAnalysis.sys.mjs"
+const { ContentAnalysisTelemetryEnterprise } = ChromeUtils.importESModule(
+  "moz-src:///browser/components/contentanalysis/content/ContentAnalysisTelemetry.enterprise.sys.mjs"
 );
 
 const RECORD_EVENTS_PREF =
@@ -64,7 +64,7 @@ function getRecordedExtras() {
 
 function recordResponseAndGetExtras(properties) {
   Services.fog.testResetFOG();
-  ContentAnalysis._maybeRecordRuleTriggeredTelemetry(
+  ContentAnalysisTelemetryEnterprise.recordVerdict(
     REQUEST_INFO,
     makeResponse(properties)
   );
@@ -98,16 +98,17 @@ add_task(async function test_rule_name_is_forwarded_from_response() {
 
 add_task(async function test_rule_name_carries_into_warn_resolution() {
   Services.fog.testResetFOG();
-  ContentAnalysis._maybeRecordRuleTriggeredTelemetry(
+  ContentAnalysisTelemetryEnterprise.recordVerdict(
     REQUEST_INFO,
     makeResponse({
       action: Ci.nsIContentAnalysisResponse.eWarn,
       ruleName: "warn-ai-paste",
     })
   );
-  ContentAnalysis._recordWarnResolutionTelemetry(
+  ContentAnalysisTelemetryEnterprise.recordWarnResolution(
     makeResponse({ action: Ci.nsIContentAnalysisResponse.eAllow }),
-    "user"
+    "user",
+    /* aIsQuitting */ false
   );
   const extras = getRecordedExtras();
   Assert.equal(extras[0].rule_name, "warn-ai-paste");
@@ -143,7 +144,7 @@ add_task(async function test_action_names() {
     );
   }
   // Clear the pending warn state the eWarn case above left behind.
-  ContentAnalysis._pendingWarnTelemetryInfo.clear();
+  ContentAnalysisTelemetryEnterprise.reset();
 });
 
 add_task(async function test_agent_failure_is_an_error_fallback() {
@@ -224,21 +225,24 @@ add_task(async function test_cached_response_is_recorded() {
  *
  * @param {boolean} aAllowContent What the warn was resolved to.
  * @param {string} aData The "dlp-warn-resolved" notification's data.
+ * @param {boolean} [aIsQuitting] Whether the warn is being resolved because
+ *   the application is quitting.
  * @returns {object[]}
  */
-function recordWarnAndResolution(aAllowContent, aData) {
+function recordWarnAndResolution(aAllowContent, aData, aIsQuitting = false) {
   Services.fog.testResetFOG();
-  ContentAnalysis._maybeRecordRuleTriggeredTelemetry(
+  ContentAnalysisTelemetryEnterprise.recordVerdict(
     REQUEST_INFO,
     makeResponse({ action: Ci.nsIContentAnalysisResponse.eWarn })
   );
-  ContentAnalysis._recordWarnResolutionTelemetry(
+  ContentAnalysisTelemetryEnterprise.recordWarnResolution(
     makeResponse({
       action: aAllowContent
         ? Ci.nsIContentAnalysisResponse.eAllow
         : Ci.nsIContentAnalysisResponse.eBlock,
     }),
-    aData
+    aData,
+    aIsQuitting
   );
   return getRecordedExtras();
 }
@@ -271,23 +275,18 @@ add_task(async function test_warn_resolved_by_cancel() {
 add_task(async function test_warn_resolved_during_quit() {
   // Quitting resolves warn dialogs from the front-end rather than from
   // cancelAllRequests(), so the notification's data says "user".
-  ContentAnalysis._isRespondingToWarnDialogsForQuit = true;
-  let extras;
-  try {
-    extras = recordWarnAndResolution(false, "user");
-  } finally {
-    ContentAnalysis._isRespondingToWarnDialogsForQuit = false;
-  }
+  const extras = recordWarnAndResolution(false, "user", /* aIsQuitting */ true);
   Assert.equal(extras.length, 2, "should record the warn and its resolution");
   Assert.equal(extras[1].type, "warn_cancel");
 });
 
 add_task(async function test_unknown_resolution_is_ignored() {
   Services.fog.testResetFOG();
-  ContentAnalysis._pendingWarnTelemetryInfo.clear();
-  ContentAnalysis._recordWarnResolutionTelemetry(
+  ContentAnalysisTelemetryEnterprise.reset();
+  ContentAnalysisTelemetryEnterprise.recordWarnResolution(
     makeResponse({ action: Ci.nsIContentAnalysisResponse.eAllow }),
-    "user"
+    "user",
+    /* aIsQuitting */ false
   );
   Assert.equal(
     getRecordedExtras(),

--- a/browser/components/contentanalysis/test/unit/test_ContentAnalysis_telemetry_mapping.js
+++ b/browser/components/contentanalysis/test/unit/test_ContentAnalysis_telemetry_mapping.js
@@ -52,6 +52,7 @@ function makeResponse(properties) {
     cancelError: Ci.nsIContentAnalysisResponse.eUserInitiated,
     isSyntheticResponse: false,
     isCachedResponse: false,
+    ruleName: "",
     ...properties,
   };
 }
@@ -82,6 +83,39 @@ add_task(async function test_request_details_are_mapped_to_enum_names() {
   Assert.equal(extras[0].type, "verdict");
   Assert.equal(extras[0].cancel_error, "");
   Assert.equal(extras[0].is_cached, "false");
+  Assert.equal(extras[0].rule_name, "");
+});
+
+add_task(async function test_rule_name_is_forwarded_from_response() {
+  // Reported regardless of which engine produced the response (the default
+  // here is an external agent; browser.contentanalysis.use_wasm_backend
+  // defaults to false).
+  const extras = recordResponseAndGetExtras({
+    ruleName: "block-confidential-content",
+  });
+  Assert.equal(extras[0].rule_name, "block-confidential-content");
+});
+
+add_task(async function test_rule_name_carries_into_warn_resolution() {
+  Services.fog.testResetFOG();
+  ContentAnalysis._maybeRecordRuleTriggeredTelemetry(
+    REQUEST_INFO,
+    makeResponse({
+      action: Ci.nsIContentAnalysisResponse.eWarn,
+      ruleName: "warn-ai-paste",
+    })
+  );
+  ContentAnalysis._recordWarnResolutionTelemetry(
+    makeResponse({ action: Ci.nsIContentAnalysisResponse.eAllow }),
+    "user"
+  );
+  const extras = getRecordedExtras();
+  Assert.equal(extras[0].rule_name, "warn-ai-paste");
+  Assert.equal(
+    extras[1].rule_name,
+    "warn-ai-paste",
+    "the resolution should report the rule that caused the original warn"
+  );
 });
 
 add_task(async function test_action_names() {

--- a/browser/components/contentanalysis/test/unit/test_ContentAnalysis_telemetry_mapping.js
+++ b/browser/components/contentanalysis/test/unit/test_ContentAnalysis_telemetry_mapping.js
@@ -14,19 +14,13 @@ const { ContentAnalysisTelemetryEnterprise } = ChromeUtils.importESModule(
   "moz-src:///browser/components/contentanalysis/content/ContentAnalysisTelemetry.enterprise.sys.mjs"
 );
 
-const RECORD_EVENTS_PREF =
-  "browser.contentanalysis.enterprise.telemetry.recordEvents";
 const DISABLE_SUBMIT_PREF =
   "browser.contentanalysis.enterprise.telemetry.testing.disableSubmit";
 
 add_setup(function () {
   Services.prefs.setBoolPref(DISABLE_SUBMIT_PREF, true);
-  // Be explicit that these tests run under the default filtering policy, so
-  // they show that these events survive it.
-  Services.prefs.setCharPref(RECORD_EVENTS_PREF, "nonAllow");
   registerCleanupFunction(() => {
     Services.prefs.clearUserPref(DISABLE_SUBMIT_PREF);
-    Services.prefs.clearUserPref(RECORD_EVENTS_PREF);
   });
 });
 
@@ -134,7 +128,7 @@ add_task(async function test_action_names() {
     },
   ];
   for (const testCase of testCases) {
-    // None of these is an allow, so all are recorded under the default policy.
+    // None of these is an allow, so all are recorded.
     const extras = recordResponseAndGetExtras({ action: testCase.action });
     Assert.ok(extras, `should have recorded a ${testCase.expected} action`);
     Assert.equal(
@@ -156,10 +150,7 @@ add_task(async function test_agent_failure_is_an_error_fallback() {
     cancelError: Ci.nsIContentAnalysisResponse.eNoAgent,
     isSyntheticResponse: true,
   });
-  Assert.ok(
-    extras,
-    "an agent failure should be recorded under the default policy"
-  );
+  Assert.ok(extras, "an agent failure should be recorded");
   Assert.equal(extras[0].action, "canceled");
   Assert.equal(extras[0].type, "error_fallback");
   Assert.equal(extras[0].cancel_error, "no_agent");
@@ -168,7 +159,7 @@ add_task(async function test_agent_failure_is_an_error_fallback() {
 add_task(async function test_agent_timeout_allow_fallback() {
   // The same, but with a default result of "allow": the action is an allow
   // Firefox chose rather than a verdict, so it's still an error fallback and
-  // is recorded despite the default policy filtering allows out.
+  // is recorded despite allow verdicts normally being filtered out.
   const extras = recordResponseAndGetExtras({
     action: Ci.nsIContentAnalysisResponse.eAllow,
     cancelError: Ci.nsIContentAnalysisResponse.eTimeout,

--- a/browser/components/contentanalysis/test/unit/test_ContentAnalysis_telemetry_mapping.js
+++ b/browser/components/contentanalysis/test/unit/test_ContentAnalysis_telemetry_mapping.js
@@ -1,0 +1,263 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+/**
+ * Tests how ContentAnalysis.sys.mjs turns nsIContentAnalysisResponses into
+ * rule_triggered telemetry, in particular the cases that are hard to produce
+ * from a browser test: responses Firefox synthesized because content analysis
+ * itself failed, and warn verdicts resolved by the request being canceled.
+ *
+ * Only run in MOZ_ENTERPRISE builds.
+ */
+
+const { ContentAnalysis } = ChromeUtils.importESModule(
+  "moz-src:///browser/components/contentanalysis/content/ContentAnalysis.sys.mjs"
+);
+
+const RECORD_EVENTS_PREF =
+  "browser.contentanalysis.enterprise.telemetry.recordEvents";
+const DISABLE_SUBMIT_PREF =
+  "browser.contentanalysis.enterprise.telemetry.testing.disableSubmit";
+
+add_setup(function () {
+  Services.prefs.setBoolPref(DISABLE_SUBMIT_PREF, true);
+  // Be explicit that these tests run under the default filtering policy, so
+  // they show that these events survive it.
+  Services.prefs.setCharPref(RECORD_EVENTS_PREF, "nonAllow");
+  registerCleanupFunction(() => {
+    Services.prefs.clearUserPref(DISABLE_SUBMIT_PREF);
+    Services.prefs.clearUserPref(RECORD_EVENTS_PREF);
+  });
+});
+
+const REQUEST_INFO = {
+  resourceNameOrOperationType: {
+    operationType: Ci.nsIContentAnalysisRequest.eUpload,
+    name: "secret.docx",
+  },
+  url: "https://example.com/upload",
+  analysisType: Ci.nsIContentAnalysisRequest.eFileAttached,
+  reason: Ci.nsIContentAnalysisRequest.eFilePickerDialog,
+};
+
+/**
+ * @param {object} properties Overrides for the response's properties.
+ * @returns {object} A stand-in for an nsIContentAnalysisResponse, which is
+ *   enough for the telemetry code since it only reads these properties.
+ */
+function makeResponse(properties) {
+  return {
+    requestToken: "test-token",
+    action: Ci.nsIContentAnalysisResponse.eBlock,
+    cancelError: Ci.nsIContentAnalysisResponse.eUserInitiated,
+    isSyntheticResponse: false,
+    isCachedResponse: false,
+    ...properties,
+  };
+}
+
+function getRecordedExtras() {
+  const events = Glean.contentAnalysis.ruleTriggered.testGetValue("enterprise");
+  return events ? events.map(event => event.extra) : null;
+}
+
+function recordResponseAndGetExtras(properties) {
+  Services.fog.testResetFOG();
+  ContentAnalysis._maybeRecordRuleTriggeredTelemetry(
+    REQUEST_INFO,
+    makeResponse(properties)
+  );
+  return getRecordedExtras();
+}
+
+add_task(async function test_request_details_are_mapped_to_enum_names() {
+  const extras = recordResponseAndGetExtras({});
+  Assert.ok(extras, "should have recorded an event");
+  Assert.equal(extras.length, 1, "should record exactly one event");
+  Assert.equal(extras[0].operation, "upload");
+  Assert.equal(extras[0].url, "https://example.com/upload");
+  Assert.equal(extras[0].analysis_type, "FILE_ATTACHED");
+  Assert.equal(extras[0].reason, "FILE_PICKER_DIALOG");
+  Assert.equal(extras[0].action, "block");
+  Assert.equal(extras[0].type, "verdict");
+  Assert.equal(extras[0].cancel_error, "");
+  Assert.equal(extras[0].is_cached, "false");
+});
+
+add_task(async function test_action_names() {
+  const testCases = [
+    { action: Ci.nsIContentAnalysisResponse.eBlock, expected: "block" },
+    { action: Ci.nsIContentAnalysisResponse.eWarn, expected: "warn" },
+    { action: Ci.nsIContentAnalysisResponse.eCanceled, expected: "canceled" },
+    {
+      action: Ci.nsIContentAnalysisResponse.eReportOnly,
+      expected: "report_only",
+    },
+    {
+      action: Ci.nsIContentAnalysisResponse.eUnspecified,
+      expected: "unspecified",
+    },
+  ];
+  for (const testCase of testCases) {
+    // None of these is an allow, so all are recorded under the default policy.
+    const extras = recordResponseAndGetExtras({ action: testCase.action });
+    Assert.ok(extras, `should have recorded a ${testCase.expected} action`);
+    Assert.equal(
+      extras[0].action,
+      testCase.expected,
+      `action ${testCase.action} should be reported as ${testCase.expected}`
+    );
+  }
+  // Clear the pending warn state the eWarn case above left behind.
+  ContentAnalysis._pendingWarnTelemetryInfo.clear();
+});
+
+add_task(async function test_agent_failure_is_an_error_fallback() {
+  // What content analysis reports when the agent can't be reached and
+  // browser.contentanalysis.default_result is "block" (the default): a
+  // synthesized cancel rather than a block.
+  const extras = recordResponseAndGetExtras({
+    action: Ci.nsIContentAnalysisResponse.eCanceled,
+    cancelError: Ci.nsIContentAnalysisResponse.eNoAgent,
+    isSyntheticResponse: true,
+  });
+  Assert.ok(
+    extras,
+    "an agent failure should be recorded under the default policy"
+  );
+  Assert.equal(extras[0].action, "canceled");
+  Assert.equal(extras[0].type, "error_fallback");
+  Assert.equal(extras[0].cancel_error, "no_agent");
+});
+
+add_task(async function test_agent_timeout_allow_fallback() {
+  // The same, but with a default result of "allow": the action is an allow
+  // Firefox chose rather than a verdict, so it's still an error fallback and
+  // is recorded despite the default policy filtering allows out.
+  const extras = recordResponseAndGetExtras({
+    action: Ci.nsIContentAnalysisResponse.eAllow,
+    cancelError: Ci.nsIContentAnalysisResponse.eTimeout,
+    isSyntheticResponse: true,
+  });
+  Assert.ok(extras, "a timeout fallback should be recorded");
+  Assert.equal(extras[0].action, "allow");
+  Assert.equal(extras[0].type, "error_fallback");
+  Assert.equal(extras[0].cancel_error, "timeout");
+});
+
+add_task(async function test_user_cancel_is_a_verdict() {
+  const extras = recordResponseAndGetExtras({
+    action: Ci.nsIContentAnalysisResponse.eCanceled,
+    cancelError: Ci.nsIContentAnalysisResponse.eUserInitiated,
+    isSyntheticResponse: true,
+  });
+  Assert.ok(extras, "a user cancel should be recorded");
+  Assert.equal(extras[0].action, "canceled");
+  Assert.equal(
+    extras[0].type,
+    "verdict",
+    "the user canceling is not a content analysis failure"
+  );
+  Assert.equal(extras[0].cancel_error, "user_initiated");
+});
+
+add_task(async function test_synthetic_block_is_a_verdict() {
+  // For example a URL matching browser.contentanalysis.deny_url_regex_list.
+  const extras = recordResponseAndGetExtras({
+    action: Ci.nsIContentAnalysisResponse.eBlock,
+    isSyntheticResponse: true,
+  });
+  Assert.ok(extras, "a synthetic block should be recorded");
+  Assert.equal(extras[0].action, "block");
+  Assert.equal(extras[0].type, "verdict");
+  Assert.equal(
+    extras[0].cancel_error,
+    "",
+    "cancel_error should be unset for a response that wasn't canceled"
+  );
+});
+
+add_task(async function test_cached_response_is_recorded() {
+  const extras = recordResponseAndGetExtras({ isCachedResponse: true });
+  Assert.ok(extras, "a cached verdict should still be recorded");
+  Assert.equal(extras[0].action, "block");
+  Assert.equal(extras[0].is_cached, "true");
+});
+
+/**
+ * Records a warn verdict and then resolves it, returning the extras of both
+ * events.
+ *
+ * @param {boolean} aAllowContent What the warn was resolved to.
+ * @param {string} aData The "dlp-warn-resolved" notification's data.
+ * @returns {object[]}
+ */
+function recordWarnAndResolution(aAllowContent, aData) {
+  Services.fog.testResetFOG();
+  ContentAnalysis._maybeRecordRuleTriggeredTelemetry(
+    REQUEST_INFO,
+    makeResponse({ action: Ci.nsIContentAnalysisResponse.eWarn })
+  );
+  ContentAnalysis._recordWarnResolutionTelemetry(
+    makeResponse({
+      action: aAllowContent
+        ? Ci.nsIContentAnalysisResponse.eAllow
+        : Ci.nsIContentAnalysisResponse.eBlock,
+    }),
+    aData
+  );
+  return getRecordedExtras();
+}
+
+add_task(async function test_warn_resolution() {
+  const extras = recordWarnAndResolution(true, "user");
+  Assert.equal(extras.length, 2, "should record the warn and its resolution");
+  Assert.equal(extras[0].action, "warn");
+  Assert.equal(extras[0].type, "verdict");
+  Assert.equal(extras[1].action, "allow");
+  Assert.equal(extras[1].type, "warn_resolution");
+  Assert.equal(
+    extras[1].reason,
+    "FILE_PICKER_DIALOG",
+    "the resolution should carry the original request's details"
+  );
+});
+
+add_task(async function test_warn_resolved_by_cancel() {
+  const extras = recordWarnAndResolution(false, "cancel");
+  Assert.equal(extras.length, 2, "should record the warn and its resolution");
+  Assert.equal(extras[1].action, "block");
+  Assert.equal(
+    extras[1].type,
+    "warn_cancel",
+    "a canceled warn should not look like a choice the user made"
+  );
+});
+
+add_task(async function test_warn_resolved_during_quit() {
+  // Quitting resolves warn dialogs from the front-end rather than from
+  // cancelAllRequests(), so the notification's data says "user".
+  ContentAnalysis._isRespondingToWarnDialogsForQuit = true;
+  let extras;
+  try {
+    extras = recordWarnAndResolution(false, "user");
+  } finally {
+    ContentAnalysis._isRespondingToWarnDialogsForQuit = false;
+  }
+  Assert.equal(extras.length, 2, "should record the warn and its resolution");
+  Assert.equal(extras[1].type, "warn_cancel");
+});
+
+add_task(async function test_unknown_resolution_is_ignored() {
+  Services.fog.testResetFOG();
+  ContentAnalysis._pendingWarnTelemetryInfo.clear();
+  ContentAnalysis._recordWarnResolutionTelemetry(
+    makeResponse({ action: Ci.nsIContentAnalysisResponse.eAllow }),
+    "user"
+  );
+  Assert.equal(
+    getRecordedExtras(),
+    null,
+    "a resolution for a warn we never recorded should be ignored"
+  );
+});

--- a/browser/components/contentanalysis/test/unit/xpcshell.toml
+++ b/browser/components/contentanalysis/test/unit/xpcshell.toml
@@ -1,0 +1,9 @@
+[DEFAULT]
+head = "head.js"
+firefox-appdir = "browser"
+
+["test_ContentAnalysisTelemetry_enterprise.js"]
+run-if = ["enterprise"]
+
+["test_ContentAnalysis_telemetry_mapping.js"]
+run-if = ["enterprise"]

--- a/browser/components/enterprisepolicies/Policies.sys.mjs
+++ b/browser/components/enterprisepolicies/Policies.sys.mjs
@@ -1095,16 +1095,6 @@ export var Policies = {
             param.UrlLogging
           );
         }
-
-        if (
-          typeof param.RecordEvents === "string" &&
-          ["all", "nonAllow"].includes(param.RecordEvents)
-        ) {
-          lazy.PoliciesUtils.setAndLockPref(
-            "browser.contentanalysis.enterprise.telemetry.recordEvents",
-            param.RecordEvents
-          );
-        }
       }
     },
     onRemove(_manager, _oldParams) {
@@ -1113,9 +1103,6 @@ export var Policies = {
       );
       lazy.PoliciesUtils.unsetAndUnlockPref(
         "browser.contentanalysis.enterprise.telemetry.urlLogging"
-      );
-      lazy.PoliciesUtils.unsetAndUnlockPref(
-        "browser.contentanalysis.enterprise.telemetry.recordEvents"
       );
     },
   },

--- a/browser/components/enterprisepolicies/Policies.sys.mjs
+++ b/browser/components/enterprisepolicies/Policies.sys.mjs
@@ -1107,24 +1107,16 @@ export var Policies = {
         }
       }
     },
-    onRemove(manager, oldParams) {
-      if (oldParams && typeof oldParams === "object") {
-        if ("Enabled" in oldParams) {
-          lazy.PoliciesUtils.unsetAndUnlockPref(
-            "browser.contentanalysis.enterprise.telemetry.enabled"
-          );
-        }
-        if ("UrlLogging" in oldParams) {
-          lazy.PoliciesUtils.unsetAndUnlockPref(
-            "browser.contentanalysis.enterprise.telemetry.urlLogging"
-          );
-        }
-        if ("RecordEvents" in oldParams) {
-          lazy.PoliciesUtils.unsetAndUnlockPref(
-            "browser.contentanalysis.enterprise.telemetry.recordEvents"
-          );
-        }
-      }
+    onRemove(_manager, _oldParams) {
+      lazy.PoliciesUtils.unsetAndUnlockPref(
+        "browser.contentanalysis.enterprise.telemetry.enabled"
+      );
+      lazy.PoliciesUtils.unsetAndUnlockPref(
+        "browser.contentanalysis.enterprise.telemetry.urlLogging"
+      );
+      lazy.PoliciesUtils.unsetAndUnlockPref(
+        "browser.contentanalysis.enterprise.telemetry.recordEvents"
+      );
     },
   },
 

--- a/browser/components/enterprisepolicies/Policies.sys.mjs
+++ b/browser/components/enterprisepolicies/Policies.sys.mjs
@@ -1076,6 +1076,58 @@ export var Policies = {
     },
   },
 
+  ContentAnalysisTelemetry: {
+    onBeforeAddons(manager, param) {
+      if (param && typeof param === "object") {
+        if (typeof param.Enabled === "boolean") {
+          lazy.PoliciesUtils.setAndLockPref(
+            "browser.contentanalysis.enterprise.telemetry.enabled",
+            param.Enabled
+          );
+        }
+
+        if (
+          typeof param.UrlLogging === "string" &&
+          ["full", "domain", "none"].includes(param.UrlLogging)
+        ) {
+          lazy.PoliciesUtils.setAndLockPref(
+            "browser.contentanalysis.enterprise.telemetry.urlLogging",
+            param.UrlLogging
+          );
+        }
+
+        if (
+          typeof param.RecordEvents === "string" &&
+          ["all", "nonAllow"].includes(param.RecordEvents)
+        ) {
+          lazy.PoliciesUtils.setAndLockPref(
+            "browser.contentanalysis.enterprise.telemetry.recordEvents",
+            param.RecordEvents
+          );
+        }
+      }
+    },
+    onRemove(manager, oldParams) {
+      if (oldParams && typeof oldParams === "object") {
+        if ("Enabled" in oldParams) {
+          lazy.PoliciesUtils.unsetAndUnlockPref(
+            "browser.contentanalysis.enterprise.telemetry.enabled"
+          );
+        }
+        if ("UrlLogging" in oldParams) {
+          lazy.PoliciesUtils.unsetAndUnlockPref(
+            "browser.contentanalysis.enterprise.telemetry.urlLogging"
+          );
+        }
+        if ("RecordEvents" in oldParams) {
+          lazy.PoliciesUtils.unsetAndUnlockPref(
+            "browser.contentanalysis.enterprise.telemetry.recordEvents"
+          );
+        }
+      }
+    },
+  },
+
   Cookies: {
     onBeforeUIStartup(manager, param) {
       lazy.addAllowDenyPermissions("cookie", param.Allow, param.Block);

--- a/browser/components/enterprisepolicies/schemas/policies-schema.json
+++ b/browser/components/enterprisepolicies/schemas/policies-schema.json
@@ -814,8 +814,7 @@
       "examples": [
         {
           "Enabled": true,
-          "UrlLogging": "domain",
-          "RecordEvents": "all"
+          "UrlLogging": "domain"
         }
       ],
       "properties": {
@@ -825,10 +824,6 @@
         "UrlLogging": {
           "type": "string",
           "enum": ["full", "domain", "none"]
-        },
-        "RecordEvents": {
-          "type": "string",
-          "enum": ["all", "nonAllow"]
         }
       }
     },

--- a/browser/components/enterprisepolicies/schemas/policies-schema.json
+++ b/browser/components/enterprisepolicies/schemas/policies-schema.json
@@ -807,6 +807,32 @@
       }
     },
 
+    "ContentAnalysisTelemetry": {
+      "type": "object",
+      "x-category": "Cloud reporting",
+      "description": "Enable and configure security logging/telemetry when a DLP rule is triggered.",
+      "examples": [
+        {
+          "Enabled": true,
+          "UrlLogging": "domain",
+          "RecordEvents": "all"
+        }
+      ],
+      "properties": {
+        "Enabled": {
+          "type": "boolean"
+        },
+        "UrlLogging": {
+          "type": "string",
+          "enum": ["full", "domain", "none"]
+        },
+        "RecordEvents": {
+          "type": "string",
+          "enum": ["all", "nonAllow"]
+        }
+      }
+    },
+
     "Cookies": {
       "type": "object",
       "x-category": "Network security",

--- a/browser/components/enterprisepolicies/tests/xpcshell/test_simple_pref_policies.js
+++ b/browser/components/enterprisepolicies/tests/xpcshell/test_simple_pref_policies.js
@@ -1421,6 +1421,36 @@ const POLICIES_TESTS = [
       MOZ_CRASHREPORTER_POLICY_AUTO_SUBMIT: "",
     },
   },
+
+  // POLICY: ContentAnalysisTelemetry
+  {
+    policies: {
+      ContentAnalysisTelemetry: {
+        Enabled: true,
+        UrlLogging: "domain",
+        RecordEvents: "all",
+      },
+    },
+    lockedPrefs: {
+      "browser.contentanalysis.enterprise.telemetry.enabled": true,
+      "browser.contentanalysis.enterprise.telemetry.urlLogging": "domain",
+      "browser.contentanalysis.enterprise.telemetry.recordEvents": "all",
+    },
+  },
+  {
+    policies: {
+      ContentAnalysisTelemetry: {
+        Enabled: false,
+        UrlLogging: "none",
+        RecordEvents: "nonAllow",
+      },
+    },
+    lockedPrefs: {
+      "browser.contentanalysis.enterprise.telemetry.enabled": false,
+      "browser.contentanalysis.enterprise.telemetry.urlLogging": "none",
+      "browser.contentanalysis.enterprise.telemetry.recordEvents": "nonAllow",
+    },
+  },
 ];
 
 add_task(async function test_policy_simple_prefs() {

--- a/browser/components/enterprisepolicies/tests/xpcshell/test_simple_pref_policies.js
+++ b/browser/components/enterprisepolicies/tests/xpcshell/test_simple_pref_policies.js
@@ -1428,13 +1428,11 @@ const POLICIES_TESTS = [
       ContentAnalysisTelemetry: {
         Enabled: true,
         UrlLogging: "domain",
-        RecordEvents: "all",
       },
     },
     lockedPrefs: {
       "browser.contentanalysis.enterprise.telemetry.enabled": true,
       "browser.contentanalysis.enterprise.telemetry.urlLogging": "domain",
-      "browser.contentanalysis.enterprise.telemetry.recordEvents": "all",
     },
   },
   {
@@ -1442,13 +1440,11 @@ const POLICIES_TESTS = [
       ContentAnalysisTelemetry: {
         Enabled: false,
         UrlLogging: "none",
-        RecordEvents: "nonAllow",
       },
     },
     lockedPrefs: {
       "browser.contentanalysis.enterprise.telemetry.enabled": false,
       "browser.contentanalysis.enterprise.telemetry.urlLogging": "none",
-      "browser.contentanalysis.enterprise.telemetry.recordEvents": "nonAllow",
     },
   },
 ];

--- a/browser/locales/en-US/browser/enterprise/enterprise-policies-descriptions.ftl
+++ b/browser/locales/en-US/browser/enterprise/enterprise-policies-descriptions.ftl
@@ -5,6 +5,7 @@
 policy-AccessConnector2 = Configure the { -enterprise-feature-access-connector } for proxying web traffic.
 policy-AIChatbot = Configure available AI chatbot providers, default provider, and prompt features.
 policy-BlocklistDomainBrowsedTelemetry = Enable and configure security logging/telemetry when { -brand-short-name } blocks a visit to a blocklisted domain.
+policy-ContentAnalysisTelemetry = Enable and configure security logging/telemetry when a DLP rule is triggered.
 policy-DisableLocalPolicies = Disable all local policy sources (policies.json, Windows GPO and macOS plist).
 policy-DownloadTelemetry = Enable and configure security logging/telemetry when a download is triggered.
 policy-EnterpriseStorageEncryption = Enable enterprise-managed primary password for encrypted storage.

--- a/toolkit/components/contentanalysis/ContentAnalysis.cpp
+++ b/toolkit/components/contentanalysis/ContentAnalysis.cpp
@@ -453,10 +453,12 @@ nsresult ContentAnalysisRequest::GetFileDigest(const nsAString& aFilePath,
 
 ContentAnalysisResponse::ContentAnalysisResponse(
     Action aAction, const nsACString& aRequestToken,
-    const nsACString& aUserActionId, bool aIsSynthetic)
+    const nsACString& aUserActionId, bool aIsSynthetic,
+    const nsAString& aRuleName)
     : mAction(aAction),
       mRequestToken(aRequestToken),
       mUserActionId(aUserActionId),
+      mRuleName(aRuleName),
       mIsSyntheticResponse(aIsSynthetic) {
   MOZ_ASSERT(mAction != Action::eUnspecified);
 }
@@ -482,6 +484,12 @@ ContentAnalysisResponse::GetAction(Action* aAction) {
 NS_IMETHODIMP
 ContentAnalysisResponse::GetCancelError(CancelError* aCancelError) {
   *aCancelError = mCancelError;
+  return NS_OK;
+}
+
+NS_IMETHODIMP
+ContentAnalysisResponse::GetRuleName(nsAString& aRuleName) {
+  aRuleName = mRuleName;
   return NS_OK;
 }
 

--- a/toolkit/components/contentanalysis/ContentAnalysis.cpp
+++ b/toolkit/components/contentanalysis/ContentAnalysis.cpp
@@ -2421,7 +2421,7 @@ ContentAnalysis::CancelAllRequests(bool aForbidFutureRequests) {
         "Responding to warn dialog (from CancelAllRequests) for "
         "request %s",
         requestToken.get());
-    RespondToWarnDialog(requestToken, false);
+    RespondToWarnDialogInternal(requestToken, false, /* aFromCancel */ true);
   }
   return NS_OK;
 }
@@ -2429,6 +2429,12 @@ ContentAnalysis::CancelAllRequests(bool aForbidFutureRequests) {
 NS_IMETHODIMP
 ContentAnalysis::RespondToWarnDialog(const nsACString& aRequestToken,
                                      bool aAllowContent) {
+  return RespondToWarnDialogInternal(aRequestToken, aAllowContent,
+                                     /* aFromCancel */ false);
+}
+
+nsresult ContentAnalysis::RespondToWarnDialogInternal(
+    const nsACString& aRequestToken, bool aAllowContent, bool aFromCancel) {
   MOZ_ASSERT(NS_IsMainThread());
   nsCString token(aRequestToken);
   LOGD("Content analysis getting warn response %d for request %s",
@@ -2443,6 +2449,17 @@ ContentAnalysis::RespondToWarnDialog(const nsACString& aRequestToken,
   }
 
   entry->mResponse->ResolveWarnAction(aAllowContent);
+
+  // Let observers (e.g. telemetry) know what the user chose in response to
+  // the warn dialog, since IssueResponse() below does not fire another
+  // "dlp-response" notification for the resolved action.
+  if (nsCOMPtr<nsIObserverService> obsServ =
+          mozilla::services::GetObserverService()) {
+    obsServ->NotifyObservers(
+        static_cast<nsIContentAnalysisResponse*>(entry->mResponse.get()),
+        "dlp-warn-resolved", aFromCancel ? u"cancel" : u"user");
+  }
+
   if (entry->mWasTimeout) {
     LOGD(
         "Warn response was for a previous timeout, inserting into "

--- a/toolkit/components/contentanalysis/ContentAnalysis.h
+++ b/toolkit/components/contentanalysis/ContentAnalysis.h
@@ -304,6 +304,13 @@ class ContentAnalysis final : public nsIContentAnalysis,
       ContentAnalysisResponse* aResponse, nsCString&& aUserActionId,
       bool aAutoAcknowledge);
 
+  // Implementation of RespondToWarnDialog(). aFromCancel indicates that the
+  // response is not the user's choice but the result of the request being
+  // cancelled (for example at shutdown), which observers of
+  // "dlp-warn-resolved" are told about via the notification's data.
+  nsresult RespondToWarnDialogInternal(const nsACString& aRequestToken,
+                                       bool aAllowContent, bool aFromCancel);
+
   // Destroy the service.  Happens during xpcom-shutdown-threads.
   void Close();
 

--- a/toolkit/components/contentanalysis/ContentAnalysis.h
+++ b/toolkit/components/contentanalysis/ContentAnalysis.h
@@ -480,7 +480,8 @@ class ContentAnalysisResponse final : public nsIContentAnalysisResponse,
   virtual ~ContentAnalysisResponse() = default;
   ContentAnalysisResponse(Action aAction, const nsACString& aRequestToken,
                           const nsACString& aUserActionId,
-                          bool aIsSynthetic = false);
+                          bool aIsSynthetic = false,
+                          const nsAString& aRuleName = u""_ns);
 
   // Use MakeRefPtr as factory.
   template <typename T, typename... Args>
@@ -498,6 +499,9 @@ class ContentAnalysisResponse final : public nsIContentAnalysisResponse,
   // If mAction is eCanceled, this is the error explaining why the request was
   // canceled, or eUserInitiated if the user canceled it.
   CancelError mCancelError = CancelError::eUserInitiated;
+
+  // The name of the rule that determined mAction, or empty if none did.
+  nsString mRuleName;
 
   // ContentAnalysis (or, more precisely, its Client object) must outlive
   // the transaction.

--- a/toolkit/components/contentanalysis/ContentAnalysisBackend.cpp
+++ b/toolkit/components/contentanalysis/ContentAnalysisBackend.cpp
@@ -228,6 +228,7 @@ ContentAnalysisBackend::ConvertResponseFromProtobuf(
     const nsCString& aUserActionId) {
   ContentAnalysisResponse::Action action =
       ContentAnalysisResponse::Action::eUnspecified;
+  nsString ruleName;
   for (const auto& result : aResponse.results()) {
     if (!result.has_status() ||
         result.status() !=
@@ -236,8 +237,12 @@ ContentAnalysisBackend::ConvertResponseFromProtobuf(
     }
     // The action values increase with severity, so the max is the most severe.
     for (const auto& rule : result.triggered_rules()) {
-      action = static_cast<ContentAnalysisResponse::Action>(std::max(
-          static_cast<uint32_t>(action), static_cast<uint32_t>(rule.action())));
+      if (static_cast<uint32_t>(rule.action()) >
+          static_cast<uint32_t>(action)) {
+        action = static_cast<ContentAnalysisResponse::Action>(rule.action());
+        ruleName = NS_ConvertUTF8toUTF16(rule.rule_name().data(),
+                                         rule.rule_name().size());
+      }
     }
   }
 
@@ -251,7 +256,8 @@ ContentAnalysisBackend::ConvertResponseFromProtobuf(
   requestTokenStr.Assign(requestToken.data(), requestToken.size());
 
   return MakeRefPtr<ContentAnalysisResponse>(action, requestTokenStr,
-                                             aUserActionId)
+                                             aUserActionId,
+                                             /* aIsSynthetic */ false, ruleName)
       .forget();
 }
 

--- a/toolkit/components/contentanalysis/metrics.yaml
+++ b/toolkit/components/contentanalysis/metrics.yaml
@@ -294,3 +294,89 @@ content_analysis:
       - gstoll@mozilla.com
       - haftandilian@mozilla.com
       - dparks@mozilla.com
+#ifdef MOZ_ENTERPRISE
+  rule_triggered:
+    type: event
+    description: Recorded when content analysis (DLP) makes a decision
+     about a user action (paste, upload, download, print, etc), subject
+     to the ContentAnalysisTelemetry enterprise policy's filtering.
+     Only collected when MOZ_ENTERPRISE is defined and enabled.
+    bugs:
+      - https://bugzil.la/2043142
+    data_reviews:
+      - https://bugzil.la/TBD
+    data_sensitivity:
+      - highly_sensitive
+    expires: never
+    notification_emails:
+      - gstoll@mozilla.com
+      - jmendez@mozilla.com
+      - enterprise-telemetry@mozilla.org
+    send_in_pings:
+      - enterprise
+    extra_keys:
+      operation:
+        description: >
+          The user action that triggered content analysis (e.g. "clipboard",
+          "dropped_text", "print", "upload", "download").
+        type: string
+      url:
+        description: >
+          The URL of the page/content the action was performed on. Full
+          URL, hostname only, or omitted (empty string) depending on the
+          ContentAnalysisTelemetry policy's UrlLogging setting.
+        type: string
+      action:
+        description: >
+          The DLP verdict: "block", "warn", "allow", "report_only", or
+          "canceled". "canceled" means the operation did not proceed but no
+          block dialog was shown, which is what content analysis reports when
+          a request fails while browser.contentanalysis.default_result is
+          "block", and when the user cancels the operation themselves; see
+          the cancel_error extra key to tell those apart.
+        type: string
+      type:
+        description: >
+          One of "verdict" (a genuine DLP verdict), "error_fallback" (Firefox
+          fell back to the configured default result because content analysis
+          itself failed, e.g. the agent was unreachable or timed out),
+          "warn_resolution" (a report of what the user chose to do after a
+          "warn" verdict), or "warn_cancel" (a "warn" verdict was resolved
+          because the request was canceled, e.g. at shutdown, rather than
+          because the user chose something). For the last two, see the action
+          extra key for the allow/block the warn was resolved to.
+        type: string
+      is_builtin:
+        description: >
+          Whether the in-process WASM engine (true) or an external agent
+          (false) produced the verdict.
+        type: boolean
+      analysis_type:
+        description: >
+          The analysisType of the request, which corresponds to a value in
+          the AnalysisConnector enum in analysis.proto (e.g.
+          "FILE_DOWNLOADED", "FILE_ATTACHED", "BULK_DATA_ENTRY"). Matches
+          the labels used by content_analysis.request_sent_by_analysis_type.
+        type: string
+      reason:
+        description: >
+          The reason the request was created, which corresponds to a value
+          in the ContentAnalysisRequest::Reason enum in analysis.proto (e.g.
+          "CLIPBOARD_PASTE", "DRAG_AND_DROP"). Matches the labels used by
+          content_analysis.request_sent_by_reason.
+        type: string
+      cancel_error:
+        description: >
+          Why the request was canceled or why content analysis failed, for
+          "canceled" actions and "error_fallback" events: one of
+          "user_initiated", "no_agent", "invalid_agent_signature",
+          "error_other", "other_request_in_group_cancelled", "shutdown", or
+          "timeout". Empty string otherwise, where content analysis does not
+          define it.
+        type: string
+      is_cached:
+        description: >
+          Whether this verdict was reused from an identical request that was
+          analyzed earlier, rather than being sent for analysis again.
+        type: boolean
+#endif

--- a/toolkit/components/contentanalysis/metrics.yaml
+++ b/toolkit/components/contentanalysis/metrics.yaml
@@ -352,6 +352,12 @@ content_analysis:
           Whether the in-process WASM engine (true) or an external agent
           (false) produced the verdict.
         type: boolean
+      rule_name:
+        description: >
+          The name of the rule that determined the verdict, as reported by
+          whatever produced it. Empty string if nothing reported one,
+          e.g. no rule matched.
+        type: string
       analysis_type:
         description: >
           The analysisType of the request, which corresponds to a value in

--- a/toolkit/components/contentanalysis/metrics.yaml
+++ b/toolkit/components/contentanalysis/metrics.yaml
@@ -318,7 +318,8 @@ content_analysis:
       operation:
         description: >
           The user action that triggered content analysis (e.g. "clipboard",
-          "dropped_text", "print", "upload", "download").
+          "dropped_text", "print", "upload", "download"). It corresponds to a value
+          in the nsIContentAnalysisRequest::OperationType enum.
         type: string
       url:
         description: >

--- a/toolkit/components/contentanalysis/nsIContentAnalysis.idl
+++ b/toolkit/components/contentanalysis/nsIContentAnalysis.idl
@@ -418,6 +418,12 @@ interface nsIContentAnalysis : nsISupports
   /**
    * Indicates that the user has responded to a WARN dialog. aAllowContent represents
    * whether the user wants to allow the request to go through.
+   *
+   * This fires a "dlp-warn-resolved" observer notification with the
+   * resolved nsIContentAnalysisResponse (action will be either eAllow or eBlock)
+   * as the subject, and "user" as the data. (cancelAllRequests() resolves any
+   * outstanding warn dialogs the same way, but passes "cancel" as the data,
+   * since the resolution does not represent a choice the user made.)
    */
   void respondToWarnDialog(in ACString aRequestToken, in boolean aAllowContent);
 

--- a/toolkit/components/contentanalysis/nsIContentAnalysis.idl
+++ b/toolkit/components/contentanalysis/nsIContentAnalysis.idl
@@ -81,6 +81,11 @@ interface nsIContentAnalysisResponse : nsIContentAnalysisResult
   // or eUserInitiated if the user canceled it.
   [infallible] readonly attribute nsIContentAnalysisResponse_CancelError cancelError;
 
+  // The name of the rule that determined `action` (the rule's config "Name";
+  // see nsIContentAnalysisRule.name). Empty if nothing reported one,
+  // e.g. this is a synthetic response Firefox produced itself.
+  readonly attribute AString ruleName;
+
   // Identifier for the corresponding nsIContentAnalysisRequest
   readonly attribute ACString requestToken;
   readonly attribute ACString userActionId;

--- a/toolkit/components/contentanalysis/tests/browser/browser.toml
+++ b/toolkit/components/contentanalysis/tests/browser/browser.toml
@@ -99,6 +99,9 @@ skip-if = [
 
 ["browser_content_analysis_quit_confirmation_dialog.js"]
 
+["browser_content_analysis_rule_triggered_telemetry.js"]
+skip-if = ["!enterprise"]
+
 ["browser_download_content_analysis.js"]
 support-files = [
   "file_to_download.unknownextension",

--- a/toolkit/components/contentanalysis/tests/browser/browser_content_analysis_rule_triggered_telemetry.js
+++ b/toolkit/components/contentanalysis/tests/browser/browser_content_analysis_rule_triggered_telemetry.js
@@ -115,26 +115,13 @@ add_task(async function testBlockVerdictRecordsTelemetryByDefault() {
   is(events[0].extra.is_cached, "false");
 });
 
-add_task(async function testAllowVerdictDoesNotRecordTelemetryByDefault() {
+add_task(async function testAllowVerdictDoesNotRecordTelemetry() {
   const events = await pasteAndGetTelemetryEvents({ allow: true });
   is(
     events,
     null,
-    "should not record rule_triggered telemetry for an allow verdict when RecordEvents is nonAllow (default)"
+    "should not record rule_triggered telemetry for an allow verdict"
   );
-});
-
-add_task(async function testAllowVerdictRecordsTelemetryWhenPolicyIsAll() {
-  await SpecialPowers.pushPrefEnv({
-    set: [["browser.contentanalysis.enterprise.telemetry.recordEvents", "all"]],
-  });
-  const events = await pasteAndGetTelemetryEvents({ allow: true });
-  ok(
-    events,
-    "should record rule_triggered telemetry for an allow verdict when RecordEvents is all"
-  );
-  is(events[0].extra.action, "allow");
-  await SpecialPowers.popPrefEnv();
 });
 
 add_task(async function testUrlLoggingPolicyNone() {

--- a/toolkit/components/contentanalysis/tests/browser/browser_content_analysis_rule_triggered_telemetry.js
+++ b/toolkit/components/contentanalysis/tests/browser/browser_content_analysis_rule_triggered_telemetry.js
@@ -1,0 +1,289 @@
+/* Any copyright is dedicated to the Public Domain.
+   http://creativecommons.org/publicdomain/zero/1.0/ */
+
+// This test only runs in MOZ_ENTERPRISE builds (see browser.toml), since
+// the content_analysis.rule_triggered Glean event and the
+// ContentAnalysisTelemetry enterprise policy prefs it's gated by don't
+// exist otherwise.
+
+let mockCA = makeMockContentAnalysis();
+
+add_setup(async function test_setup() {
+  mockCA = await mockContentAnalysisService(mockCA);
+  // Each recordRuleTriggered() call submits the "enterprise" ping
+  // immediately, which clears its buffered events. Disable that here so
+  // testGetValue() can see every event recorded during a test, including
+  // cases (like a warn verdict followed by its resolution) where more than
+  // one event is recorded per test.
+  await SpecialPowers.pushPrefEnv({
+    set: [
+      [
+        "browser.contentanalysis.enterprise.telemetry.testing.disableSubmit",
+        true,
+      ],
+    ],
+  });
+});
+
+const testPage =
+  "<body style='margin: 0'><input id='input' type='text'></body>";
+
+const CLIPBOARD_TEXT_STRING = "Just some text";
+
+const TEST_PAGE_URL =
+  "https://example.com/browser/toolkit/components/contentanalysis/tests/browser/";
+
+function setClipboardData(clipboardString) {
+  const trans = Cc["@mozilla.org/widget/transferable;1"].createInstance(
+    Ci.nsITransferable
+  );
+  trans.init(null);
+  trans.addDataFlavor("text/plain");
+  const str = Cc["@mozilla.org/supports-string;1"].createInstance(
+    Ci.nsISupportsString
+  );
+  str.data = clipboardString;
+  trans.setTransferData("text/plain", str);
+
+  Services.clipboard.setData(trans, null, Ci.nsIClipboard.kGlobalClipboard);
+}
+
+async function pasteAndGetTelemetryEvents({ allow, useDataUrl = true }) {
+  mockCA.setupForTest(allow, /* waitForEvent */ false, /* showDialogs */ true);
+  Services.fog.testResetFOG();
+
+  let tab = BrowserTestUtils.addTab(gBrowser);
+  let browser = gBrowser.getBrowserForTab(tab);
+  gBrowser.selectedTab = tab;
+  await BrowserTestUtils.loadURIString({
+    browser: tab.linkedBrowser,
+    uriString: useDataUrl
+      ? "data:text/html," + escape(testPage)
+      : TEST_PAGE_URL,
+  });
+  await SimpleTest.promiseFocus(browser);
+
+  setClipboardData(CLIPBOARD_TEXT_STRING);
+
+  await SpecialPowers.spawn(
+    browser,
+    [testPage, useDataUrl],
+    (html, isDataUrl) => {
+      if (!isDataUrl) {
+        content.document.body.innerHTML = html;
+      }
+      content.document.getElementById("input").value = "";
+      content.document.getElementById("input").focus();
+    }
+  );
+
+  let blockDialogPromise;
+  if (!allow) {
+    blockDialogPromise = BrowserTestUtils.promiseAlertDialogOpen();
+  }
+
+  await BrowserTestUtils.synthesizeKey("v", { accelKey: true }, browser);
+  if (!allow) {
+    let win = await blockDialogPromise;
+    win.document.querySelector("dialog").getButton("accept").click();
+  }
+
+  BrowserTestUtils.removeTab(tab);
+
+  return Glean.contentAnalysis.ruleTriggered.testGetValue("enterprise");
+}
+
+add_task(async function testBlockVerdictRecordsTelemetryByDefault() {
+  const events = await pasteAndGetTelemetryEvents({ allow: false });
+  ok(events, "should have recorded rule_triggered telemetry for a block");
+  is(events.length, 1, "should record exactly one event");
+  is(events[0].extra.operation, "clipboard");
+  is(events[0].extra.action, "block");
+  is(events[0].extra.type, "verdict");
+  is(events[0].extra.analysis_type, "BULK_DATA_ENTRY");
+  is(events[0].extra.reason, "CLIPBOARD_PASTE");
+  is(
+    events[0].extra.is_builtin,
+    "false",
+    "is_builtin should be false since these tests use an external agent"
+  );
+  is(
+    events[0].extra.cancel_error,
+    "",
+    "cancel_error should be unset for a verdict from an agent"
+  );
+  is(events[0].extra.is_cached, "false");
+});
+
+add_task(async function testAllowVerdictDoesNotRecordTelemetryByDefault() {
+  const events = await pasteAndGetTelemetryEvents({ allow: true });
+  is(
+    events,
+    null,
+    "should not record rule_triggered telemetry for an allow verdict when RecordEvents is nonAllow (default)"
+  );
+});
+
+add_task(async function testAllowVerdictRecordsTelemetryWhenPolicyIsAll() {
+  await SpecialPowers.pushPrefEnv({
+    set: [["browser.contentanalysis.enterprise.telemetry.recordEvents", "all"]],
+  });
+  const events = await pasteAndGetTelemetryEvents({ allow: true });
+  ok(
+    events,
+    "should record rule_triggered telemetry for an allow verdict when RecordEvents is all"
+  );
+  is(events[0].extra.action, "allow");
+  await SpecialPowers.popPrefEnv();
+});
+
+add_task(async function testUrlLoggingPolicyNone() {
+  await SpecialPowers.pushPrefEnv({
+    set: [["browser.contentanalysis.enterprise.telemetry.urlLogging", "none"]],
+  });
+  const events = await pasteAndGetTelemetryEvents({
+    allow: false,
+    useDataUrl: false,
+  });
+  ok(events, "should have recorded rule_triggered telemetry");
+  is(events[0].extra.url, "", "url should be empty when UrlLogging is none");
+  await SpecialPowers.popPrefEnv();
+});
+
+add_task(async function testUrlLoggingPolicyDomain() {
+  await SpecialPowers.pushPrefEnv({
+    set: [
+      ["browser.contentanalysis.enterprise.telemetry.urlLogging", "domain"],
+    ],
+  });
+  const events = await pasteAndGetTelemetryEvents({
+    allow: false,
+    useDataUrl: false,
+  });
+  ok(events, "should have recorded rule_triggered telemetry");
+  is(
+    events[0].extra.url,
+    "example.com",
+    "url should be reduced to the hostname when UrlLogging is domain"
+  );
+  await SpecialPowers.popPrefEnv();
+});
+
+add_task(async function testUrlLoggingPolicyFullUrl() {
+  await SpecialPowers.pushPrefEnv({
+    set: [["browser.contentanalysis.enterprise.telemetry.urlLogging", "full"]],
+  });
+  const events = await pasteAndGetTelemetryEvents({
+    allow: false,
+    useDataUrl: false,
+  });
+  ok(events, "should have recorded rule_triggered telemetry");
+  is(events[0].extra.url, TEST_PAGE_URL);
+  await SpecialPowers.popPrefEnv();
+});
+
+async function pasteAndGetWarnResolutionEvents({ allowAfterWarn }) {
+  mockCA.setupForTest("warn", /* waitForEvent */ false, /* showDialogs */ true);
+  Services.fog.testResetFOG();
+
+  let tab = BrowserTestUtils.addTab(gBrowser);
+  let browser = gBrowser.getBrowserForTab(tab);
+  gBrowser.selectedTab = tab;
+  await BrowserTestUtils.loadURIString({
+    browser: tab.linkedBrowser,
+    uriString: "data:text/html," + escape(testPage),
+  });
+  await SimpleTest.promiseFocus(browser);
+
+  setClipboardData(CLIPBOARD_TEXT_STRING);
+
+  await SpecialPowers.spawn(browser, [], () => {
+    content.document.getElementById("input").value = "";
+    content.document.getElementById("input").focus();
+  });
+
+  let warnDialogPromise = BrowserTestUtils.promiseAlertDialogOpen();
+  // Deliberately not awaited here: a warn verdict doesn't resolve the paste
+  // until respondToWarnDialog() is called, and synthesizeKey() doesn't
+  // resolve until the paste it triggered has been handled. Awaiting it
+  // before answering the dialog deadlocks the test.
+  let keyPromise = BrowserTestUtils.synthesizeKey(
+    "v",
+    { accelKey: true },
+    browser
+  );
+  let win = await warnDialogPromise;
+  win.document
+    .querySelector("dialog")
+    .getButton(allowAfterWarn ? "accept" : "cancel")
+    .click();
+  await keyPromise;
+
+  // respondToWarnDialog() resolves asynchronously (it goes through the
+  // "dlp-warn-resolved" notification), so wait for the second event
+  // instead of assuming it's recorded by the time the click returns.
+  await TestUtils.waitForCondition(() => {
+    const events =
+      Glean.contentAnalysis.ruleTriggered.testGetValue("enterprise");
+    return events && events.length >= 2;
+  }, "waiting for warn_resolution telemetry to be recorded");
+
+  BrowserTestUtils.removeTab(tab);
+
+  return Glean.contentAnalysis.ruleTriggered.testGetValue("enterprise");
+}
+
+add_task(async function testWarnThenAllowRecordsResolutionTelemetry() {
+  const events = await pasteAndGetWarnResolutionEvents({
+    allowAfterWarn: true,
+  });
+  ok(events, "should have recorded rule_triggered telemetry");
+  is(events.length, 2, "should record the warn trigger and its resolution");
+  is(events[0].extra.action, "warn", "first event reports the warn verdict");
+  is(events[0].extra.type, "verdict", "first event is the verdict");
+  is(events[1].extra.action, "allow", "second event reports the user's choice");
+  is(
+    events[1].extra.type,
+    "warn_resolution",
+    "second event is the warn resolution"
+  );
+  is(events[1].extra.operation, "clipboard");
+  is(
+    events[1].extra.analysis_type,
+    "BULK_DATA_ENTRY",
+    "the resolution event carries the original request's analysis_type"
+  );
+  is(
+    events[1].extra.reason,
+    "CLIPBOARD_PASTE",
+    "the resolution event carries the original request's reason"
+  );
+});
+
+add_task(async function testWarnThenBlockRecordsResolutionTelemetry() {
+  const events = await pasteAndGetWarnResolutionEvents({
+    allowAfterWarn: false,
+  });
+  ok(events, "should have recorded rule_triggered telemetry");
+  is(events.length, 2, "should record the warn trigger and its resolution");
+  is(events[0].extra.action, "warn", "first event reports the warn verdict");
+  is(events[1].extra.action, "block", "second event reports the user's choice");
+  is(
+    events[1].extra.type,
+    "warn_resolution",
+    "second event is the warn resolution"
+  );
+});
+
+add_task(async function testTelemetryDisabledEntirely() {
+  await SpecialPowers.pushPrefEnv({
+    set: [["browser.contentanalysis.enterprise.telemetry.enabled", false]],
+  });
+  const events = await pasteAndGetTelemetryEvents({ allow: false });
+  is(
+    events,
+    null,
+    "should not record any rule_triggered telemetry when the policy disables it"
+  );
+  await SpecialPowers.popPrefEnv();
+});

--- a/toolkit/components/contentanalysis/tests/browser/browser_content_analysis_rule_triggered_telemetry.js
+++ b/toolkit/components/contentanalysis/tests/browser/browser_content_analysis_rule_triggered_telemetry.js
@@ -10,8 +10,8 @@ let mockCA = makeMockContentAnalysis();
 
 add_setup(async function test_setup() {
   mockCA = await mockContentAnalysisService(mockCA);
-  // Each recordRuleTriggered() call submits the "enterprise" ping
-  // immediately, which clears its buffered events. Disable that here so
+  // Each recorded event submits the "enterprise" ping immediately, which
+  // clears its buffered events. Disable that here so
   // testGetValue() can see every event recorded during a test, including
   // cases (like a warn verdict followed by its resolution) where more than
   // one event is recorded per test.

--- a/toolkit/components/contentanalysis/tests/browser/head.js
+++ b/toolkit/components/contentanalysis/tests/browser/head.js
@@ -142,7 +142,14 @@ function makeMockContentAnalysis() {
     /**
      * Sets up the mock CA service
      *
-     * @param {boolean} shouldAllowRequest Whether requests should be allowed.
+     * @param {boolean|string} shouldAllowRequest Whether requests should be
+     *                               allowed (true), blocked (false), or
+     *                               made to return a warn verdict
+     *                               (the string "warn"). For "warn",
+     *                               respondToWarnDialog() must be called
+     *                               (typically indirectly, by interacting
+     *                               with the warn dialog UI) before the
+     *                               request will resolve.
      * @param {boolean} waitForEvent If this is true, a response will not be
      *                               returned until an event is dispatched by the
      *                               test. Helpful for testing timing scenarios.
@@ -180,13 +187,14 @@ function makeMockContentAnalysis() {
       this.agentCancelCalls = 0;
       this.cancelledUserActions = [];
       this.cancelledRequestTokens = [];
+      this.pendingWarnResponses = new Map();
     },
 
     getAction() {
-      if (this.shouldAllowRequest === undefined) {
-        this.shouldAllowRequest = true;
+      if (this.shouldAllowRequest === "warn") {
+        return Ci.nsIContentAnalysisResponse.eWarn;
       }
-      return this.shouldAllowRequest
+      return (this.shouldAllowRequest ?? true)
         ? Ci.nsIContentAnalysisResponse.eAllow
         : Ci.nsIContentAnalysisResponse.eBlock;
     },
@@ -303,8 +311,38 @@ function makeMockContentAnalysis() {
         if (this.showDialogs) {
           Services.obs.notifyObservers(response, "dlp-response");
         }
-        callback.contentResult(response);
+        if (response.action === Ci.nsIContentAnalysisResponse.eWarn) {
+          // As in the real content analysis service, a warn verdict doesn't
+          // resolve the request until respondToWarnDialog() is called.
+          this.pendingWarnResponses.set(request.requestToken, {
+            response,
+            callback,
+          });
+        } else {
+          callback.contentResult(response);
+        }
       }, 0);
+    },
+
+    respondToWarnDialog(aRequestToken, aAllowContent) {
+      let entry = this.pendingWarnResponses.get(aRequestToken);
+      if (!entry) {
+        return;
+      }
+      this.pendingWarnResponses.delete(aRequestToken);
+      let resolvedResponse = this.realCAService.makeResponseForTest(
+        aAllowContent
+          ? Ci.nsIContentAnalysisResponse.eAllow
+          : Ci.nsIContentAnalysisResponse.eBlock,
+        aRequestToken,
+        entry.response.userActionId
+      );
+      Services.obs.notifyObservers(
+        resolvedResponse,
+        "dlp-warn-resolved",
+        "user"
+      );
+      entry.callback.contentResult(resolvedResponse);
     },
 
     cancelAllRequests() {


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2043142

Add a telemetry event whenever a DLP result is returned (only in Enterprise builds). Also allows configuring via policy:
- whether to report full URLs, just the domain, or nothing
- whether to send an event for every DLP result, or only ones that are not "allow". (per our existing telemetry, around 99.9% of requests return "allow" results, so this would greatly cut down on recorded events)

---

### Testing

* [x] Added tests