### PR TITLE
Bug 2060545 - Prepare for more locales

### DIFF
--- a/browser/locales/enterprise-l10n-changesets.json
+++ b/browser/locales/enterprise-l10n-changesets.json
@@ -1,5 +1,93 @@
 {
+    "de": {
+        "pin": false,
+        "platforms": [
+            "linux64",
+            "linux64-enterprise",
+            "linux64-aarch64",
+            "linux64-aarch64-enterprise",
+            "linux64-aarch64-devedition",
+            "linux64-devedition",
+            "macosx64",
+            "macosx64-enterprise",
+            "macosx64-devedition",
+            "win32",
+            "win32-devedition",
+            "win64",
+            "win64-enterprise",
+            "win64-aarch64",
+            "win64-aarch64-devedition",
+            "win64-devedition"
+        ],
+        "revision": "d02e9a686ee0454f6bb41bf67fc09a16a14c9541"
+    },
+    "es": {
+        "pin": false,
+        "platforms": [
+            "linux64",
+            "linux64-enterprise",
+            "linux64-aarch64",
+            "linux64-aarch64-enterprise",
+            "linux64-aarch64-devedition",
+            "linux64-devedition",
+            "macosx64",
+            "macosx64-enterprise",
+            "macosx64-devedition",
+            "win32",
+            "win32-devedition",
+            "win64",
+            "win64-enterprise",
+            "win64-aarch64",
+            "win64-aarch64-devedition",
+            "win64-devedition"
+        ],
+        "revision": "d02e9a686ee0454f6bb41bf67fc09a16a14c9541"
+    },
     "fr": {
+        "pin": false,
+        "platforms": [
+            "linux64",
+            "linux64-enterprise",
+            "linux64-aarch64",
+            "linux64-aarch64-enterprise",
+            "linux64-aarch64-devedition",
+            "linux64-devedition",
+            "macosx64",
+            "macosx64-enterprise",
+            "macosx64-devedition",
+            "win32",
+            "win32-devedition",
+            "win64",
+            "win64-enterprise",
+            "win64-aarch64",
+            "win64-aarch64-devedition",
+            "win64-devedition"
+        ],
+        "revision": "d02e9a686ee0454f6bb41bf67fc09a16a14c9541"
+    },
+    "it": {
+        "pin": false,
+        "platforms": [
+            "linux64",
+            "linux64-enterprise",
+            "linux64-aarch64",
+            "linux64-aarch64-enterprise",
+            "linux64-aarch64-devedition",
+            "linux64-devedition",
+            "macosx64",
+            "macosx64-enterprise",
+            "macosx64-devedition",
+            "win32",
+            "win32-devedition",
+            "win64",
+            "win64-enterprise",
+            "win64-aarch64",
+            "win64-aarch64-devedition",
+            "win64-devedition"
+        ],
+        "revision": "d02e9a686ee0454f6bb41bf67fc09a16a14c9541"
+    },
+    "nl": {
         "pin": false,
         "platforms": [
             "linux64",


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2060545

It was reported that more locales can be useful in some contexts (demo). This change adds production of locales data on CI. They will be later picked by repacks definition once Bug-2060543 is fixed and repack repos are updated to request more locales.

To make sure things are not broken when this happens (there is no per-branch repacks, it would be too many configurations to manage), let's land this change that makes sure the data is there at CI time.