### PR TITLE
Bug 2058850 - Forward update ready notification when browser is available

### DIFF
--- a/testing/enterprise/manifest.toml
+++ b/testing/enterprise/manifest.toml
@@ -113,6 +113,11 @@ run-if = [
   "buildapp == 'browser'", # browser specific: notification
 ]
 
+["test_felt_browser_updates_forward_offline.py"]
+run-if = [
+  "buildapp == 'browser'", # browser specific: notification
+]
+
 ["test_felt_browser_watermark.py"]
 run-if = [
   "buildapp == 'browser'", # browser specific: watermark drawn on a tab

--- a/testing/enterprise/test_felt_browser_updates_forward_offline.py
+++ b/testing/enterprise/test_felt_browser_updates_forward_offline.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import os
+import sys
+
+sys.path.append(os.path.dirname(__file__))
+
+from felt_tests import FeltTests
+
+
+class FeltUpdatesForwardOffline(FeltTests):
+    EXTRA_PREFS = {
+        "network.disable-localhost-when-offline": True,
+        "network.manage-offline-status": False,
+    }
+
+    def set_offline(self, value):
+        self._driver.set_context("chrome")
+        self._driver.execute_script(
+            """
+            Services.io.offline = arguments[0];
+            """,
+            [value],
+        )
+        self._driver.set_context("content")
+
+    def test_felt_updates_forward(self):
+        self.set_offline(True)
+        self.submit_email()
+
+        self._logger.info("Checking offline")
+        self._driver.set_context("chrome")
+        error = self.get_elem(".felt-browser-error-no-network")
+        self._logger.info(f"Checking offline: error={error}")
+        self._wait.until(
+            lambda d: (
+                h.strip()
+                if (h := error.get_attribute("heading"))
+                and "No network connection" in h.strip()
+                else False
+            )
+        )
+        self._logger.info("Checking offline: OK. Going back online")
+        self.set_offline(False)
+
+        self._logger.info("Online, update applied in background before browser starts")
+        self.run_felt_trigger_update()
+
+        self._logger.info("Run SSO and start browser")
+        self.run_felt_base()
+
+        self._logger.info("Connect to launched browser")
+        self.run_felt_browser_started()
+
+        self._logger.info("Verify existence of update notification")
+        self.run_felt_find_browser_notification()
+
+    def run_felt_browser_started(self):
+        self.connect_child_browser()
+        self.open_tab_child("about:support")
+
+    def run_felt_trigger_update(self):
+        self._driver.set_context("chrome")
+        self._driver.execute_script(
+            """
+            Services.obs.notifyObservers(null, "update-downloaded", "applied-service");
+            """
+        )
+        self._driver.set_context("content")
+
+    def run_felt_find_browser_notification(self):
+        self._child_driver.set_context("chrome")
+        notifications = self._child_driver.execute_script(
+            """
+            const { AppMenuNotifications } = ChromeUtils.importESModule("resource://gre/modules/AppMenuNotifications.sys.mjs");
+            return AppMenuNotifications.notifications;
+            """
+        )
+        self._child_driver.set_context("content")
+
+        found_update_ready = False
+        for notification in notifications:
+            if notification["id"] == "update-restart":
+                found_update_ready = True
+                break
+
+        assert found_update_ready, "Found an update-restart notification"

--- a/toolkit/components/enterprise/modules/Updates.sys.mjs
+++ b/toolkit/components/enterprise/modules/Updates.sys.mjs
@@ -133,6 +133,7 @@ export const Updates = {
     this._appUpdater = new lazy.AppUpdater();
     this._updaterCallback = this.appUpdaterCallback.bind(this);
     this._appUpdater.addListener(this._updaterCallback);
+    Services.obs.addObserver(this, "felt-ready");
     Services.obs.addObserver(this, "update-staged");
     Services.obs.addObserver(this, "update-downloaded");
     Services.obs.addObserver(this, "update-error");
@@ -366,6 +367,7 @@ export const Updates = {
   },
 
   unobserve() {
+    Services.obs.removeObserver(this, "felt-ready");
     Services.obs.removeObserver(this, "update-staged");
     Services.obs.removeObserver(this, "update-downloaded");
     Services.obs.removeObserver(this, "update-error");
@@ -375,7 +377,9 @@ export const Updates = {
   sendUpdateReady() {
     try {
       Services.felt?.sendUpdateReady();
+      this._pendingUpdateReady = false;
     } catch (ex) {
+      this._pendingUpdateReady = true;
       if (ex.result === Cr.NS_ERROR_NOT_CONNECTED) {
         lazy.log.warn(
           `FeltUpdates: sendUpdateReady() failed because not connected: no browser ?`
@@ -397,6 +401,15 @@ export const Updates = {
     switch (topic) {
       case "xpcom-shutdown":
         this.unobserve();
+        break;
+      case "felt-ready":
+        lazy.log.warn(
+          "Browser is ready checking for pending update notification"
+        );
+        if (this._pendingUpdateReady) {
+          lazy.log.warn("Informing browser of pending update");
+          this.sendUpdateReady();
+        }
         break;
       case "update-staged":
       case "update-downloaded":


### PR DESCRIPTION
There could be a timing window where we are able to successfully apply an update but the browser is not yet started to show the notification to the user. This could at least repro in bug 2058850 on macOS when starting with network disconnected. Update happens in the background while performing SSO and browser is not yet started when the notification is already ready.

Keep a note when sending an update notification fails and observe "felt-ready" that will be triggered when the browser is started so the update notification can be sent again.

<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2058850

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Testing <!-- OPTIONAL -->

* [x] Added tests

**Steps to verify changes:**
1.Install an "old build with this change"
2. Turn off networking
3. Start FELT
4. Error message about being offline / update check failing
5. Turn on networking
6. Perform SSO
7. Browser launches

**Expected result:**
Update notification visible in hamburger menu

