### PR TITLE
Bug 2059550 - Fix broken imports in Sync and AIChatbot policies

### DIFF
--- a/browser/components/enterprisepolicies/Policies.sys.mjs
+++ b/browser/components/enterprisepolicies/Policies.sys.mjs
@@ -4267,11 +4267,11 @@ export var Policies = {
   },
 
   Sync: {
-    async onBeforeAddons(manager, param) {
-      await lazy.SyncPolicy.applySettings(manager, param);
+    onBeforeAddons(manager, param) {
+      lazy.SyncPolicy.applySettings(manager, param).then(null, lazy.log.error);
     },
-    async onRemove(manager, _) {
-      await lazy.SyncPolicy.restoreSettings(manager);
+    onRemove(manager, _) {
+      lazy.SyncPolicy.restoreSettings(manager).then(null, lazy.log.error);
     },
   },
 

--- a/browser/components/enterprisepolicies/helpers/AIChatbotPolicies.sys.mjs
+++ b/browser/components/enterprisepolicies/helpers/AIChatbotPolicies.sys.mjs
@@ -2,11 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {
-  setAndLockPref,
-  unsetAndUnlockPref,
-  PoliciesUtils,
-} from "resource:///modules/policies/Policies.sys.mjs";
+import { PoliciesUtils } from "resource://gre/modules/PoliciesHelpers.sys.mjs";
 import {
   CHAT_PROVIDERS_DEFAULT,
   GenAI,
@@ -76,7 +72,7 @@ export const AIChatbotPolicies = {
 
     // If there are no providers, disable the chat sidebar
     if (!providerIds.length) {
-      setAndLockPref("browser.ml.chat.enabled", false);
+      PoliciesUtils.setAndLockPref("browser.ml.chat.enabled", false);
     }
   },
 
@@ -208,6 +204,6 @@ export const AIChatbotPolicies = {
     PoliciesUtils.unsetDefaultPref("browser.ml.chat.prompts.2");
     PoliciesUtils.unsetDefaultPref("browser.ml.chat.prompts.3");
     PoliciesUtils.unsetDefaultPref("browser.ml.chat.shortcuts");
-    unsetAndUnlockPref("browser.ml.chat.enabled");
+    PoliciesUtils.unsetAndUnlockPref("browser.ml.chat.enabled");
   },
 };

--- a/browser/components/enterprisepolicies/helpers/SyncPolicy.sys.mjs
+++ b/browser/components/enterprisepolicies/helpers/SyncPolicy.sys.mjs
@@ -2,17 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this file,
  * You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-import {
-  PREF_LOGLEVEL,
-  setAndLockPref,
-  unsetAndUnlockPref,
-  PoliciesUtils,
-} from "resource:///modules/policies/Policies.sys.mjs";
+import { PREF_LOGLEVEL } from "resource:///modules/policies/Policies.sys.mjs";
 
 import { STATUS_OK as SYNC_STATUS_OK } from "resource://services-sync/constants.sys.mjs";
 
 const lazy = {};
 ChromeUtils.defineESModuleGetters(lazy, {
+  PoliciesUtils: "resource://gre/modules/PoliciesHelpers.sys.mjs",
   Weave: "resource://services-sync/main.sys.mjs",
 });
 
@@ -106,11 +102,11 @@ export const SyncPolicy = {
       const pref = ENGINE_PREFS[type];
       if (isIgnoringUserPreferences) {
         lazy.log.debug(`Setting and locking ${type}: ${pref} : ${value}`);
-        setAndLockPref(pref, value);
+        lazy.PoliciesUtils.setAndLockPref(pref, value);
         continue;
       }
       lazy.log.debug(`Setting ${type}: ${pref} : ${value}`);
-      PoliciesUtils.setDefaultPref(pref, value, false);
+      lazy.PoliciesUtils.setDefaultPref(pref, value, false);
     }
 
     // Only lock the Sync feature if 'Enabled' is configured
@@ -130,7 +126,7 @@ export const SyncPolicy = {
     }
     for (const pref of Object.values(ENGINE_PREFS)) {
       lazy.log.debug(`Unsetting ${pref}`);
-      unsetAndUnlockPref(pref);
+      lazy.PoliciesUtils.unsetAndUnlockPref(pref);
     }
     // We don't have a way yet to restore the pre-policy
     // sync state (Bug 2017719)


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2059550

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

Bug-2048572 moved `PolicyUtils` from `Policies.sys.mjs into `PoliciesHelpers.sys.mjs`. Two policy helpers in the Enterprise repository were not updated to reflect this change in m-c, which resulted in broken policies. The `Sync` policy broke silently due to using `async/await` which prevented the error from ever surfacing.

This PR updates the imports and swaps the `async/await` for a `.then(null, lazy.log.error)`.

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on: Bug-2048572

---

### Testing <!-- OPTIONAL -->

* [ ] Added tests
* [x] Manual testing performed


**Steps to verify changes:**
1. Set a `Sync` and `AIChatbot` policy for your user
2. Navigate to `about:policies`

**Expected result:**

No errors shown for either policy and policies work as expected.