### PR TITLE
Bug 2058222 - Add live support for ContentAnalysis and DataLossPrevention policies

### DIFF
--- a/browser/components/contentanalysis/content/ContentAnalysis.sys.mjs
+++ b/browser/components/contentanalysis/content/ContentAnalysis.sys.mjs
@@ -160,11 +160,11 @@ export const ContentAnalysis = {
    * @param {Window} window - The window to monitor
    */
   initialize(window) {
-    if (!this.contentAnalysis.isActive) {
-      this.uninitialize();
-      return;
-    }
-    let doc = window.document;
+    // Register unconditionally (not gated on isActive): Content Analysis can be
+    // turned on or off at runtime by an enterprise-policy update, so the
+    // observers must already be listening when a later update activates it. The
+    // observers are process-global and registered once; the handlers no-op when
+    // nothing is pending. Teardown happens on quit-application.
     if (!this.isInitialized) {
       this.isInitialized = true;
       this.initializeObservers();
@@ -177,16 +177,41 @@ export const ContentAnalysis = {
       });
     }
 
-    // Do this even if initialized so the icon shows up on new windows, not just the
-    // first one.
-    for (let indicator of doc.getElementsByClassName(
-      "content-analysis-indicator"
-    )) {
-      doc.l10n.setAttributes(indicator, "content-analysis-indicator-tooltip", {
-        agentName: lazy.agentName,
-      });
+    // Reflect the current active state in this window's indicator. Done for
+    // every window (not just the first) so the icon shows up on new windows,
+    // and re-run for all windows on a policy update (see observe()).
+    this.updateWindowContentAnalysisState(window);
+  },
+
+  /**
+   * Show or hide the Content Analysis indicator in a window to match the
+   * service's current active state.
+   *
+   * @param {Window} window - The window to update
+   */
+  updateWindowContentAnalysisState(window) {
+    let doc = window.document;
+    // Check the enabled pref before touching this.contentAnalysis so an
+    // unrelated policy update doesn't construct the service (and its backend)
+    // for a profile that never turns Content Analysis on. isActive still
+    // requires the pref, so this short-circuit changes nothing when active.
+    let isActive =
+      Services.prefs.getBoolPref("browser.contentanalysis.enabled", false) &&
+      this.contentAnalysis.isActive;
+    if (isActive) {
+      for (let indicator of doc.getElementsByClassName(
+        "content-analysis-indicator"
+      )) {
+        doc.l10n.setAttributes(
+          indicator,
+          "content-analysis-indicator-tooltip",
+          { agentName: lazy.agentName }
+        );
+      }
+      doc.documentElement.setAttribute("contentanalysisactive", "true");
+    } else {
+      doc.documentElement.removeAttribute("contentanalysisactive");
     }
-    doc.documentElement.setAttribute("contentanalysisactive", "true");
   },
 
   async uninitialize() {
@@ -209,6 +234,7 @@ export const ContentAnalysis = {
     Services.obs.addObserver(this, "quit-application");
     Services.obs.addObserver(this, "quit-application-granted");
     Services.obs.addObserver(this, "quit-application-requested");
+    Services.obs.addObserver(this, "EnterprisePolicies:PolicyUpdatesApplied");
   },
 
   /**
@@ -221,6 +247,10 @@ export const ContentAnalysis = {
     Services.obs.removeObserver(this, "quit-application");
     Services.obs.removeObserver(this, "quit-application-granted");
     Services.obs.removeObserver(this, "quit-application-requested");
+    Services.obs.removeObserver(
+      this,
+      "EnterprisePolicies:PolicyUpdatesApplied"
+    );
   },
 
   // nsIObserver
@@ -307,6 +337,14 @@ export const ContentAnalysis = {
       }
       case "quit-application": {
         this.uninitialize();
+        break;
+      }
+      // An enterprise-policy update may have activated or deactivated Content
+      // Analysis; refresh every window's indicator to match the new state.
+      case "EnterprisePolicies:PolicyUpdatesApplied": {
+        for (let window of lazy.BrowserWindowTracker.orderedWindows) {
+          this.updateWindowContentAnalysisState(window);
+        }
         break;
       }
       case "dlp-request-made":

--- a/browser/components/enterprisepolicies/Policies.sys.mjs
+++ b/browser/components/enterprisepolicies/Policies.sys.mjs
@@ -915,6 +915,9 @@ export var Policies = {
       // arbitrate consistently, including on live policy updates.
       lazy.ContentAnalysisPolicies.reconcileContentAnalysis(manager);
     },
+    onRemove(manager) {
+      lazy.ContentAnalysisPolicies.reconcileContentAnalysis(manager);
+    },
   },
 
   ContentAnalysisTelemetry: {
@@ -1218,6 +1221,9 @@ export var Policies = {
       ).errors) {
         lazy.log.error(error);
       }
+      lazy.ContentAnalysisPolicies.reconcileContentAnalysis(manager);
+    },
+    onRemove(manager) {
       lazy.ContentAnalysisPolicies.reconcileContentAnalysis(manager);
     },
   },

--- a/browser/components/enterprisepolicies/helpers/ContentAnalysisPolicies.sys.mjs
+++ b/browser/components/enterprisepolicies/helpers/ContentAnalysisPolicies.sys.mjs
@@ -53,11 +53,53 @@ const CA_PLAIN_TEXT_POINTS = [
   ["DragAndDrop", "drag_and_drop"],
 ];
 
+// Every browser.contentanalysis.* pref either provider may set, apart from the
+// per-interception-point ones handled alongside these below.
+const CA_SHARED_PREFS = [
+  "enabled",
+  "use_wasm_backend",
+  "wasm_module_extension_require_signature",
+  "default_result",
+  "timeout_result",
+  "dlp_rules",
+  "allow_url_regex_list",
+  "deny_url_regex_list",
+  "agent_timeout",
+  "show_blocked_result",
+  "bypass_for_same_tab_operations",
+  "agent_name",
+  "pipe_path_name",
+  "client_signature",
+  "max_connections",
+  "is_per_user",
+];
+
+// Return every shared pref to its built-in default, unlocked.
+function releaseContentAnalysisPrefs() {
+  for (let suffix of CA_SHARED_PREFS) {
+    lazy.PoliciesUtils.unsetAndUnlockPref(caPrefName(suffix));
+  }
+  for (let [, suffix] of CA_INTERCEPTION_POINTS) {
+    lazy.PoliciesUtils.unsetAndUnlockPref(
+      caPrefName(`interception_point.${suffix}.enabled`)
+    );
+  }
+  for (let [, suffix] of CA_PLAIN_TEXT_POINTS) {
+    lazy.PoliciesUtils.unsetAndUnlockPref(
+      caPrefName(`interception_point.${suffix}.plain_text_only`)
+    );
+  }
+}
+
 export const ContentAnalysisPolicies = {
   reconcileContentAnalysis(manager) {
     let active = manager.getActivePolicies() ?? {};
     let caParam = active.ContentAnalysis;
     let dlpParam = active.DataLossPrevention;
+
+    // Release every shared pref before applying the winner's configuration.
+    // (Avoid stale prefs during a switch)
+    releaseContentAnalysisPrefs();
 
     // The external agent is authoritative only when it is actually enabled; a
     // ContentAnalysis block that does not enable an agent doesn't suppress
@@ -66,9 +108,14 @@ export const ContentAnalysisPolicies = {
       applyExternalContentAnalysis(caParam);
     } else if (dlpParam) {
       applyBuiltinDlp(dlpParam);
-    } else {
-      disableContentAnalysis(caParam);
+    } else if (caParam) {
+      // Match previous behavior of locking all prefs when policy present
+      // and Enabled=false
+      activelyDisableContentAnalysis(caParam);
     }
+    // Else, neither provider is configured: the release above is the whole job.
+
+    markContentAnalysisPolicyControlled(!!caParam || !!dlpParam);
   },
 
   // Validate DLP rules' ContentPatterns as regular expressions (a JS-regex
@@ -110,8 +157,6 @@ function applyExternalContentAnalysis(caParam) {
   );
 
   applyContentAnalysisConfig(caParam);
-  lazy.PoliciesUtils.unsetAndUnlockPref(caPrefName("dlp_rules"));
-  markContentAnalysisPolicyControlled();
 }
 
 // Apply prefs for setting up the built-in DLP provider.
@@ -122,16 +167,6 @@ function applyBuiltinDlp(dlpParam) {
     caPrefName("wasm_module_extension_require_signature"),
     true
   );
-
-  // The external agent isn't running, so these prefs are released.
-  for (let suffix of [
-    "pipe_path_name",
-    "client_signature",
-    "max_connections",
-    "is_per_user",
-  ]) {
-    lazy.PoliciesUtils.unsetAndUnlockPref(caPrefName(suffix));
-  }
 
   // Built-in DLP policy does not have an explicit deny list, but encodes
   // domain deny behavior in the DLP rules for processing by the engine.
@@ -209,47 +244,11 @@ function applyBuiltinDlp(dlpParam) {
     caPrefName("dlp_rules"),
     JSON.stringify({ DLPRules: { Rules: rules } })
   );
-
-  markContentAnalysisPolicyControlled();
 }
 
-// Turn both providers off. A still-present (disabled) ContentAnalysis policy
-// keeps its config locked with the service disabled to match previous behavior.
-function disableContentAnalysis(caParam) {
-  if (!caParam) {
-    for (let suffix of [
-      "enabled",
-      "use_wasm_backend",
-      "wasm_module_extension_require_signature",
-      "default_result",
-      "timeout_result",
-      "dlp_rules",
-      "allow_url_regex_list",
-      "deny_url_regex_list",
-      "agent_timeout",
-      "show_blocked_result",
-      "bypass_for_same_tab_operations",
-      "agent_name",
-      "pipe_path_name",
-      "client_signature",
-      "max_connections",
-      "is_per_user",
-    ]) {
-      lazy.PoliciesUtils.unsetAndUnlockPref(caPrefName(suffix));
-    }
-    for (let [, suffix] of CA_INTERCEPTION_POINTS) {
-      lazy.PoliciesUtils.unsetAndUnlockPref(
-        caPrefName(`interception_point.${suffix}.enabled`)
-      );
-    }
-    for (let [, suffix] of CA_PLAIN_TEXT_POINTS) {
-      lazy.PoliciesUtils.unsetAndUnlockPref(
-        caPrefName(`interception_point.${suffix}.plain_text_only`)
-      );
-    }
-    return;
-  }
-
+// A ContentAnalysis policy that is present but not enabled: keep its config
+// locked with the service disabled, to match previous behavior.
+function activelyDisableContentAnalysis(caParam) {
   lazy.PoliciesUtils.setAndLockPref(caPrefName("enabled"), false);
   lazy.PoliciesUtils.setAndLockPref(caPrefName("use_wasm_backend"), false);
   lazy.PoliciesUtils.setAndLockPref(
@@ -257,10 +256,6 @@ function disableContentAnalysis(caParam) {
     true
   );
   applyContentAnalysisConfig(caParam);
-  lazy.PoliciesUtils.unsetAndUnlockPref(caPrefName("dlp_rules"));
-  if ("Enabled" in caParam) {
-    markContentAnalysisPolicyControlled();
-  }
 }
 
 // Set and lock the Content Analysis prefs for an active ContentAnalysis policy.
@@ -379,9 +374,9 @@ function applyContentAnalysisConfig(caParam) {
 
 // Ensure the Content Analysis service exists (so it can observe policy updates)
 // and mark it as controlled by enterprise policy.
-function markContentAnalysisPolicyControlled() {
+function markContentAnalysisPolicyControlled(isControlled) {
   let ca = Cc["@mozilla.org/contentanalysis;1"].getService(
     Ci.nsIContentAnalysis
   );
-  ca.isSetByEnterprisePolicy = true;
+  ca.isSetByEnterprisePolicy = isControlled;
 }

--- a/browser/components/enterprisepolicies/tests/browser/browser_policy_data_loss_prevention.js
+++ b/browser/components/enterprisepolicies/tests/browser/browser_policy_data_loss_prevention.js
@@ -24,6 +24,30 @@ function getSerializedRules() {
   return json ? JSON.parse(json).DLPRules.Rules : [];
 }
 
+function assertInterceptionPoints(expectedOn, message) {
+  for (let point of INTERCEPTION_POINTS) {
+    is(
+      Services.prefs.getBoolPref(
+        `${CA_PREFIX}interception_point.${point}.enabled`,
+        false
+      ),
+      expectedOn.includes(point),
+      `${message}: interception_point.${point}.enabled`
+    );
+  }
+}
+
+function dlpRule(name, actions, extra = {}) {
+  return {
+    Name: name,
+    Enabled: true,
+    Actions: actions,
+    Domains: ["example.com"],
+    Type: "block",
+    ...extra,
+  };
+}
+
 registerCleanupFunction(async function () {
   await setupPolicyEngineWithJson({ policies: {} });
 });
@@ -174,4 +198,174 @@ add_task(async function test_invalid_regex_rule_excluded() {
   let rules = getSerializedRules();
   is(rules.length, 1, "rule with an invalid ContentPatterns regex is excluded");
   is(rules[0].Name, "good-pattern", "the valid rule survives");
+});
+
+// The remaining Actions map to the download and print interception points;
+// TextPaste and FileUpload are covered above.
+add_task(async function test_interception_points_from_download_and_print() {
+  await setupPolicyEngineWithJson({
+    policies: {
+      DataLossPrevention: {
+        Rules: [
+          dlpRule("block-download", ["FileDownload"]),
+          dlpRule("block-print", ["Print"]),
+        ],
+      },
+    },
+  });
+
+  assertInterceptionPoints(
+    ["download", "print"],
+    "FileDownload and Print derive only their own interception points"
+  );
+});
+
+// A rule that is present but disabled must still be delivered (the engine skips
+// disabled rules itself) while contributing nothing to the interception points,
+// so turning a rule off cannot leave its hooks running.
+add_task(async function test_disabled_rule_does_not_enable_interception() {
+  await setupPolicyEngineWithJson({
+    policies: {
+      DataLossPrevention: {
+        Rules: [
+          dlpRule("enabled-paste", ["TextPaste"]),
+          dlpRule("disabled-print", ["Print"], { Enabled: false }),
+        ],
+      },
+    },
+  });
+
+  assertInterceptionPoints(
+    ["clipboard", "drag_and_drop"],
+    "a disabled rule's Actions do not enable interception points"
+  );
+  is(
+    getSerializedRules().length,
+    2,
+    "both rules are delivered; the engine applies the Enabled flag"
+  );
+});
+
+// FallbackResult maps to both default_result and timeout_result. "block" (0) is
+// covered above; check the other two and the default when it is omitted.
+add_task(async function test_fallback_result_mapping() {
+  for (let [fallback, expected] of [
+    ["allow", 2],
+    ["warn", 1],
+  ]) {
+    await setupPolicyEngineWithJson({
+      policies: {
+        DataLossPrevention: {
+          FallbackResult: fallback,
+          Rules: [dlpRule("a-rule", ["TextPaste"])],
+        },
+      },
+    });
+
+    is(
+      Services.prefs.getIntPref(CA_PREFIX + "default_result"),
+      expected,
+      `FallbackResult "${fallback}" maps to default_result ${expected}`
+    );
+    is(
+      Services.prefs.getIntPref(CA_PREFIX + "timeout_result"),
+      expected,
+      `FallbackResult "${fallback}" maps to timeout_result ${expected}`
+    );
+  }
+
+  await setupPolicyEngineWithJson({
+    policies: {
+      DataLossPrevention: { Rules: [dlpRule("a-rule", ["TextPaste"])] },
+    },
+  });
+  is(
+    Services.prefs.getIntPref(CA_PREFIX + "default_result"),
+    0,
+    "an omitted FallbackResult blocks by default"
+  );
+});
+
+add_task(async function test_allow_url_regex_list() {
+  const allowList = "https://ok\\.example\\.com/.*";
+  await setupPolicyEngineWithJson({
+    policies: {
+      DataLossPrevention: {
+        AllowUrlRegexList: allowList,
+        Rules: [dlpRule("a-rule", ["TextPaste"])],
+      },
+    },
+  });
+
+  checkLockedPref(CA_PREFIX + "allow_url_regex_list", allowList);
+});
+
+// The built-in provider pins every shared pref to a fixed value rather than
+// inheriting whatever was there, and locks them so the user cannot edit them.
+add_task(async function test_builtin_fixed_prefs_are_set_and_locked() {
+  await setupPolicyEngineWithJson({
+    policies: {
+      DataLossPrevention: { Rules: [dlpRule("a-rule", ["TextPaste"])] },
+    },
+  });
+
+  checkLockedPref(CA_PREFIX + "enabled", true);
+  checkLockedPref(CA_PREFIX + "use_wasm_backend", true);
+  checkLockedPref(CA_PREFIX + "wasm_module_extension_require_signature", true);
+  checkLockedPref(CA_PREFIX + "deny_url_regex_list", "");
+  checkLockedPref(CA_PREFIX + "agent_timeout", 300);
+  checkLockedPref(CA_PREFIX + "show_blocked_result", true);
+  checkLockedPref(CA_PREFIX + "bypass_for_same_tab_operations", false);
+  checkLockedPref(CA_PREFIX + "agent_name", "Firefox Enterprise DLP Engine");
+
+  for (let point of ["clipboard", "drag_and_drop"]) {
+    checkLockedPref(
+      `${CA_PREFIX}interception_point.${point}.plain_text_only`,
+      true
+    );
+  }
+});
+
+// External-agent-only prefs must be released when the built-in engine wins, so
+// its connection settings cannot linger in a profile the agent no longer serves.
+add_task(async function test_external_only_prefs_released_for_builtin() {
+  await setupPolicyEngineWithJson({
+    policies: {
+      ContentAnalysis: {
+        Enabled: false,
+        PipePathName: "a_pipe_name",
+        ClientSignature: "a_signature",
+        MaxConnectionsCount: 5,
+        IsPerUser: true,
+      },
+      DataLossPrevention: { Rules: [dlpRule("a-rule", ["TextPaste"])] },
+    },
+  });
+
+  is(
+    Services.prefs.getBoolPref(CA_PREFIX + "use_wasm_backend"),
+    true,
+    "the built-in engine wins over a disabled ContentAnalysis policy"
+  );
+  for (let pref of [
+    "pipe_path_name",
+    "client_signature",
+    "max_connections",
+    "is_per_user",
+  ]) {
+    ok(
+      !Services.prefs.prefIsLocked(CA_PREFIX + pref),
+      `${pref} is released rather than locked at the external agent's value`
+    );
+  }
+  isnot(
+    Services.prefs.getStringPref(CA_PREFIX + "pipe_path_name", ""),
+    "a_pipe_name",
+    "the external agent's pipe name did not survive"
+  );
+  isnot(
+    Services.prefs.getStringPref(CA_PREFIX + "client_signature", ""),
+    "a_signature",
+    "the external agent's client signature did not survive"
+  );
 });

--- a/toolkit/components/contentanalysis/ContentAnalysis.cpp
+++ b/toolkit/components/contentanalysis/ContentAnalysis.cpp
@@ -134,17 +134,9 @@ bool SourceIsSameTab(nsIContentAnalysisRequest* aRequest) {
 }  // anonymous namespace
 
 /* static */ bool nsIContentAnalysis::MightBeActive() {
-  // A DLP connection is not permitted to be added/removed while the
-  // browser is running, so we can cache this.
-  // Furthermore, if this is set via enterprise policy the pref will be locked
-  // so users won't be able to change it.
-  // Ideally we would make this a mirror: once pref, but this interacts in
-  // some weird ways with the enterprise policy for testing purposes.
-  static bool sIsEnabled =
-      mozilla::StaticPrefs::browser_contentanalysis_enabled();
   // Note that we can't check gAllowContentAnalysis here because it
   // only gets set in the parent process.
-  return sIsEnabled;
+  return mozilla::StaticPrefs::browser_contentanalysis_enabled();
 }
 
 namespace mozilla::contentanalysis {
@@ -738,8 +730,14 @@ ContentAnalysis::ContentAnalysis() : mSetByEnterprise(false) {
     return;
   }
   obsServ->AddObserver(this, "xpcom-shutdown-threads", false);
+  // React to live enterprise-policy updates so the backend can be swapped,
+  // (de)activated, or refreshed without a browser restart.
+  obsServ->AddObserver(this, "EnterprisePolicies:PolicyUpdatesApplied", false);
 
   mBackend = contentanalysis::CreateBackend();
+  if (mBackend->Kind() == ContentAnalysisBackend::BackendKind::eExternalAgent) {
+    SnapshotExternalConnectionConfig();
+  }
 
   // Forward max-connections pref changes to the backend, for testing (otherwise
   // it is locked). We cannot use RegisterCallbackAndCall since the callback
@@ -769,9 +767,16 @@ NS_IMETHODIMP
 ContentAnalysis::Observe(nsISupports* subject, const char* topic,
                          const char16_t* data) {
   AssertIsOnMainThread();
-  MOZ_ASSERT(nsCString("xpcom-shutdown-threads") == topic);
-  LOGD("Content Analysis received xpcom-shutdown-threads");
-  Close();
+  nsDependentCString topicStr(topic);
+  if (topicStr == "xpcom-shutdown-threads") {
+    LOGD("Content Analysis received xpcom-shutdown-threads");
+    Close();
+  } else if (topicStr == "EnterprisePolicies:PolicyUpdatesApplied") {
+    LOGD("Content Analysis received EnterprisePolicies:PolicyUpdatesApplied");
+    MaybeUpdateBackend();
+  } else {
+    MOZ_ASSERT_UNREACHABLE("Unexpected topic");
+  }
   return NS_OK;
 }
 
@@ -791,6 +796,7 @@ void ContentAnalysis::Close() {
       mozilla::services::GetObserverService();
   if (obsServ) {
     obsServ->RemoveObserver(this, "xpcom-shutdown-threads");
+    obsServ->RemoveObserver(this, "EnterprisePolicies:PolicyUpdatesApplied");
   }
 
   // The userActionMap must be cleared before the object is destroyed.
@@ -799,6 +805,97 @@ void ContentAnalysis::Close() {
   MOZ_ASSERT(mBackend);
   mBackend->Shutdown();
   LOGD("Content Analysis service is closed");
+}
+
+void ContentAnalysis::MaybeUpdateBackend() {
+  AssertIsOnMainThread();
+  if (IsShutDown()) {
+    // Already torn down for xpcom-shutdown; nothing to reconcile.
+    return;
+  }
+
+  // The allow/deny URL filter lists are consulted for every request by either
+  // backend (see FilterByUrlLists) and are compiled and cached once. A policy
+  // update may have changed them, so drop the cache; the next request re-parses
+  // from the (updated) prefs.
+  mParsedUrlLists = false;
+  mAllowUrlList.clear();
+  mDenyUrlList.clear();
+
+  // The backend should be live when Content Analysis is enabled and either the
+  // enterprise policy or the command-line arg turned it on -- mirroring
+  // GetIsActive. When live, the policy chooses the WASM or external backend.
+  bool wantActive = StaticPrefs::browser_contentanalysis_enabled() &&
+                    (mSetByEnterprise || gAllowContentAnalysisArgPresent);
+  ContentAnalysisBackend::BackendKind wantKind =
+      StaticPrefs::browser_contentanalysis_use_wasm_backend()
+          ? ContentAnalysisBackend::BackendKind::eWasmModule
+          : ContentAnalysisBackend::BackendKind::eExternalAgent;
+
+  // Even when the selection is unchanged, an external backend that stays
+  // external must be rebuilt if its connection prefs (pipe name, signature,
+  // per-user flag, thread limit) changed, since those are baked in at
+  // construction. Recreating -- rather than reconnecting in place -- also
+  // resizes the agent thread pool, which is only sized in the ctor.
+  bool externalConfigChanged =
+      wantActive && mBackendActive &&
+      wantKind == ContentAnalysisBackend::BackendKind::eExternalAgent &&
+      mBackend->Kind() == ContentAnalysisBackend::BackendKind::eExternalAgent &&
+      ExternalConnectionConfigChanged();
+
+  bool noChange = wantActive == mBackendActive &&
+                  (!wantActive || mBackend->Kind() == wantKind) &&
+                  !externalConfigChanged;
+  if (noChange) {
+    return;
+  }
+
+  // Activation, backend kind, or external connection config changed. Drain
+  // in-flight requests first so no stale verdict lands (the drained backend
+  // also drops any late resolution via its mInert flag), tear down the current
+  // backend if live, then build a fresh one for the new selection.
+  CancelAllRequests(/* aForbidFutureRequests */ false);
+  if (mBackendActive) {
+    mBackend->Shutdown();
+    mBackendActive = false;
+  }
+  if (wantActive) {
+    mBackend = contentanalysis::CreateBackend();
+    mBackendActive = true;
+    ++mBackendGeneration;
+    mBackend->EnsureReady();
+    if (mBackend->Kind() ==
+        ContentAnalysisBackend::BackendKind::eExternalAgent) {
+      SnapshotExternalConnectionConfig();
+    }
+  }
+}
+
+void ContentAnalysis::SnapshotExternalConnectionConfig() {
+  AssertIsOnMainThread();
+  Preferences::GetCString("browser.contentanalysis.pipe_path_name",
+                          mExternalPipePathName);
+  Preferences::GetString("browser.contentanalysis.client_signature",
+                         mExternalClientSignature);
+  mExternalIsPerUser = StaticPrefs::browser_contentanalysis_is_per_user();
+  mExternalMaxConnections =
+      StaticPrefs::browser_contentanalysis_max_connections();
+}
+
+bool ContentAnalysis::ExternalConnectionConfigChanged() const {
+  AssertIsOnMainThread();
+  nsCString pipePathName;
+  Preferences::GetCString("browser.contentanalysis.pipe_path_name",
+                          pipePathName);
+  nsString clientSignature;
+  Preferences::GetString("browser.contentanalysis.client_signature",
+                         clientSignature);
+  return pipePathName != mExternalPipePathName ||
+         clientSignature != mExternalClientSignature ||
+         StaticPrefs::browser_contentanalysis_is_per_user() !=
+             mExternalIsPerUser ||
+         StaticPrefs::browser_contentanalysis_max_connections() !=
+             mExternalMaxConnections;
 }
 
 bool ContentAnalysis::IsShutDown() {
@@ -826,6 +923,27 @@ bool ContentAnalysis::GetCreatingClientForTest() {
 NS_IMETHODIMP ContentAnalysis::ForceRecreateClientForTest() {
   MOZ_ASSERT(mBackend);
   return mBackend->ForceReinitializeForTest();
+}
+
+NS_IMETHODIMP ContentAnalysis::GetBackendKindForTest(nsACString& aResult) {
+  AssertIsOnMainThread();
+  if (!mBackendActive) {
+    aResult.AssignLiteral("none");
+    return NS_OK;
+  }
+  MOZ_ASSERT(mBackend);
+  if (mBackend->Kind() == ContentAnalysisBackend::BackendKind::eWasmModule) {
+    aResult.AssignLiteral("wasm-module");
+  } else {
+    aResult.AssignLiteral("external-agent");
+  }
+  return NS_OK;
+}
+
+NS_IMETHODIMP ContentAnalysis::GetBackendGenerationForTest(uint32_t* aResult) {
+  AssertIsOnMainThread();
+  *aResult = mBackendGeneration;
+  return NS_OK;
 }
 
 NS_IMETHODIMP
@@ -2195,6 +2313,17 @@ ContentAnalysis::AnalyzeContentRequestsCallback(
   // Wrap callback in a ContentAnalysisCallback, which will assert if the
   // callback is not called exactly once.
   auto safeCallback = MakeRefPtr<ContentAnalysisCallback>(aCallback);
+
+  bool isActive = false;
+  nsresult rv = GetIsActive(&isActive);
+  NS_ENSURE_SUCCESS(rv, rv);
+  if (!isActive) {
+    LOGD("Content analysis is not active, allowing request");
+    auto result = MakeRefPtr<ContentAnalysisNoResult>(
+        NoContentAnalysisResult::ALLOW_DUE_TO_CONTENT_ANALYSIS_NOT_ACTIVE);
+    safeCallback->ContentResult(result);
+    return NS_OK;
+  }
 
   // If any member of aRequests has a different user action ID than another,
   // throw an error.  If the user action IDs are empty, generate one and set

--- a/toolkit/components/contentanalysis/ContentAnalysis.h
+++ b/toolkit/components/contentanalysis/ContentAnalysis.h
@@ -314,6 +314,18 @@ class ContentAnalysis final : public nsIContentAnalysis,
   // Destroy the service.  Happens during xpcom-shutdown-threads.
   void Close();
 
+  // Re-select and refresh the backend after a live enterprise-policy update
+  // (driven by the EnterprisePolicies:PolicyUpdatesApplied notification).
+  void MaybeUpdateBackend();
+
+  // Record the current external-agent connection prefs into the mExternal*
+  // snapshot. Called after (re)building a live external-agent backend.
+  void SnapshotExternalConnectionConfig();
+
+  // True if the current external-agent connection prefs differ from the
+  // snapshot taken when the live external backend was built.
+  bool ExternalConnectionConfigChanged() const;
+
   // Did the URL filter completely handle the request or do we need to check
   // with the agent.
   enum UrlFilterResult { eCheck, eDeny, eAllow };
@@ -389,6 +401,24 @@ class ContentAnalysis final : public nsIContentAnalysis,
 
   // Backend engine that produces analysis verdicts.
   RefPtr<ContentAnalysisBackend> mBackend;
+
+  // Whether mBackend is a live (not shut-down) backend. False while the service
+  // is deactivated by policy; mBackend still points at the last (shut-down)
+  // backend so it stays non-null for the callers that assume it.
+  bool mBackendActive = true;
+
+  // Snapshot of the external-agent connection prefs the current external
+  // backend was built with. Consulted on a live policy update to decide whether
+  // a still-external backend must be rebuilt to pick up changed connection
+  // settings. Only meaningful while mBackend is a live external-agent backend.
+  nsCString mExternalPipePathName;
+  nsString mExternalClientSignature;
+  bool mExternalIsPerUser = false;
+  uint32_t mExternalMaxConnections = 0;
+
+  // Number of backends built so far, exposed to tests so they can tell a
+  // rebuild apart from an update the existing backend absorbed live.
+  uint32_t mBackendGeneration = 1;
 
   struct UserActionData final {
     nsCOMPtr<nsIContentAnalysisCallback> mCallback;

--- a/toolkit/components/contentanalysis/ContentAnalysisBackend.h
+++ b/toolkit/components/contentanalysis/ContentAnalysisBackend.h
@@ -35,6 +35,12 @@ class ContentAnalysisBackend {
   using DiagnosticInfoPromise =
       MozPromise<RefPtr<ContentAnalysisDiagnosticInfo>, nsresult, true>;
 
+  // The concrete backend type. ContentAnalysis compares this against the
+  // policy-selected backend on a live policy update to decide whether it must
+  // swap mBackend to a different implementation.
+  enum class BackendKind { eExternalAgent, eWasmModule };
+  virtual BackendKind Kind() const = 0;
+
   // Kick off backend initialization if necessary (e.g. connect to an agent,
   // fetch and load a module). Returns synchronously when backend is ready to
   // receive requests, even if backend may continue further initialization

--- a/toolkit/components/contentanalysis/ContentAnalysisUtils.sys.mjs
+++ b/toolkit/components/contentanalysis/ContentAnalysisUtils.sys.mjs
@@ -69,15 +69,21 @@ export const ContentAnalysisUtils = {
    *                       If this is undefined, this method will get the URI from the browsingContext.
    */
   setupContentAnalysisEventsForTextElement(textElement, browsingContext, url) {
-    // Do not use a lazy service getter for this, because tests set up different mocks,
-    // so if multiple tests run that call into this we can end up calling into an old mock.
-    const contentAnalysis = Cc["@mozilla.org/contentanalysis;1"].getService(
-      Ci.nsIContentAnalysis
-    );
-    if (!textElement || !contentAnalysis.isActive) {
+    if (!textElement) {
       return;
     }
     let caEventChecker = async event => {
+      // Fetch the service (and re-check isActive) per event rather than once at
+      // setup: Content Analysis can be turned on or off at runtime by an
+      // enterprise-policy update, so an element wired while inactive must still
+      // enforce once activated (and stop once deactivated). Fetching per event
+      // also avoids caching a stale mock across tests.
+      const contentAnalysis = Cc["@mozilla.org/contentanalysis;1"].getService(
+        Ci.nsIContentAnalysis
+      );
+      if (!contentAnalysis.isActive) {
+        return;
+      }
       let isPaste = event.type == "paste";
       let dataTransfer = isPaste ? event.clipboardData : event.dataTransfer;
       let data = dataTransfer.getData("text/plain");

--- a/toolkit/components/contentanalysis/ExternalAgentBackend.cpp
+++ b/toolkit/components/contentanalysis/ExternalAgentBackend.cpp
@@ -463,6 +463,9 @@ ExternalAgentBackend::~ExternalAgentBackend() {
 void ExternalAgentBackend::Shutdown() {
   AssertIsOnMainThread();
 
+  // Drop any agent response that arrives after this point
+  mInert = true;
+
   // Reject the promise to avoid assertions when it gets destroyed
   // No-op if the promise has already been resolved or rejected
   mClientPromise->Reject(NS_ERROR_ILLEGAL_DURING_SHUTDOWN, __func__);
@@ -941,8 +944,13 @@ void ExternalAgentBackend::HandleResponseFromAgent(
   NS_DispatchToMainThread(NS_NewRunnableFunction(
       __func__,
       [self = RefPtr{this}, aResponse = std::move(aResponse)]() mutable {
+        AssertIsOnMainThread();
         LOGD("HandleResponseFromAgent on main thread");
         LogResponse(&aResponse);
+        if (self->mInert) {
+          // Backend may be swapped out or shutting down
+          return;
+        }
         RefPtr<ContentAnalysis> owner =
             ContentAnalysis::GetContentAnalysisFromService();
         if (!owner) {

--- a/toolkit/components/contentanalysis/ExternalAgentBackend.h
+++ b/toolkit/components/contentanalysis/ExternalAgentBackend.h
@@ -38,6 +38,7 @@ class ExternalAgentBackend final : public ContentAnalysisBackend {
   ExternalAgentBackend(const ExternalAgentBackend&) = delete;
   ExternalAgentBackend& operator=(const ExternalAgentBackend&) = delete;
 
+  BackendKind Kind() const override { return BackendKind::eExternalAgent; }
   nsresult EnsureReady() override;
   nsresult Analyze(nsCOMPtr<nsIContentAnalysisRequest> aRequest,
                    bool aAutoAcknowledge) override;
@@ -144,6 +145,11 @@ class ExternalAgentBackend final : public ContentAnalysisBackend {
   bool mCreatingClient MOZ_GUARDED_BY(sMainThreadCapability) = false;
   bool mHaveResolvedClientPromise MOZ_GUARDED_BY(sMainThreadCapability) = false;
   int64_t mRequestCount MOZ_GUARDED_BY(sMainThreadCapability) = 0;
+
+  // Set once Shutdown() runs (e.g. when the service swaps this backend out on a
+  // live policy change). A response that arrives afterward is dropped so it
+  // can't deliver a stale verdict through the still-alive service.
+  bool mInert MOZ_GUARDED_BY(sMainThreadCapability) = false;
 };
 
 }  // namespace mozilla::contentanalysis

--- a/toolkit/components/contentanalysis/WasmModuleBackend.cpp
+++ b/toolkit/components/contentanalysis/WasmModuleBackend.cpp
@@ -39,17 +39,6 @@ namespace {
 // DataLossPrevention enterprise policy.
 static constexpr char kDlpRulesPref[] = "browser.contentanalysis.dlp_rules";
 
-static nsresult LoadDlpRules(nsTArray<RefPtr<nsIContentAnalysisRule>>& aRules) {
-  nsAutoString rulesJSON;
-  nsresult rv = Preferences::GetString(kDlpRulesPref, rulesJSON);
-  NS_ENSURE_SUCCESS(rv, rv);
-  if (rulesJSON.IsEmpty()) {
-    // No rules configured: nothing to enforce.
-    return NS_OK;
-  }
-  return ParseContentAnalysisRules(rulesJSON, aRules);
-}
-
 // Recover the nsresult from a rejected wasm-runner promise. The runner
 // rejects with a Components.Exception carrying the failure code in its
 // `result`.
@@ -121,6 +110,28 @@ nsresult WasmModuleBackend::EnsureReady() {
   return runner ? NS_OK : NS_ERROR_NOT_AVAILABLE;
 }
 
+nsresult WasmModuleBackend::LoadDlpRules(
+    nsTArray<RefPtr<nsIContentAnalysisRule>>& aRules) {
+  AssertIsOnMainThread();
+  nsAutoString rulesJSON;
+  nsresult rv = Preferences::GetString(kDlpRulesPref, rulesJSON);
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  if (rulesJSON != mCachedRulesJSON) {
+    nsTArray<RefPtr<nsIContentAnalysisRule>> parsed;
+    // An empty pref means no rules are configured, so there is nothing to
+    // enforce and nothing to parse.
+    if (!rulesJSON.IsEmpty()) {
+      MOZ_TRY(ParseContentAnalysisRules(rulesJSON, parsed));
+    }
+    mCachedRules = std::move(parsed);
+    mCachedRulesJSON = rulesJSON;
+  }
+
+  aRules = mCachedRules.Clone();
+  return NS_OK;
+}
+
 nsresult WasmModuleBackend::Analyze(
     nsCOMPtr<nsIContentAnalysisRequest> aRequest, bool aAutoAcknowledge) {
   AssertIsOnMainThread();
@@ -171,6 +182,11 @@ nsresult WasmModuleBackend::Analyze(
                            contentBytes = std::move(contentBytes),
                            rules = std::move(rules), userActionId,
                            aAutoAcknowledge]() mutable {
+                  AssertIsOnMainThread();
+                  if (self->mInert) {
+                    // Backend may be swapped out or shutting down
+                    return;
+                  }
                   RefPtr<ContentAnalysis> owner =
                       ContentAnalysis::GetContentAnalysisFromService();
                   if (!owner) {
@@ -231,6 +247,10 @@ void WasmModuleBackend::HandleWasmResponse(JSContext* aCx,
                                            bool aAutoAcknowledge) {
   AssertIsOnMainThread();
 
+  if (mInert) {
+    // Backend may be swapped out or shutting down
+    return;
+  }
   RefPtr<ContentAnalysis> owner =
       ContentAnalysis::GetContentAnalysisFromService();
   if (!owner) {
@@ -309,14 +329,20 @@ nsresult WasmModuleBackend::InvokeRunner(
       [self = RefPtr{this}, userActionId = nsCString(aUserActionId)](
           JSContext* aCx, JS::Handle<JS::Value> aValue, ErrorResult&) {
         AssertIsOnMainThread();
+        if (self->mInert) {
+          // Backend may be swapped out or shutting down
+          return;
+        }
+        RefPtr<ContentAnalysis> owner =
+            ContentAnalysis::GetContentAnalysisFromService();
+        if (!owner) {
+          // Shutting down.
+          return;
+        }
         nsresult rv = ExtractExceptionResult(aCx, aValue);
         self->mConnectedToAgent = false;
         self->mFailedSignatureVerification = rv == NS_ERROR_INVALID_SIGNATURE;
-        RefPtr<ContentAnalysis> owner =
-            ContentAnalysis::GetContentAnalysisFromService();
-        if (owner) {
-          owner->CancelWithError(nsCString(userActionId), rv);
-        }
+        owner->CancelWithError(nsCString(userActionId), rv);
       });
   return NS_OK;
 }
@@ -331,7 +357,11 @@ WasmModuleBackend::GetDiagnosticInfo() {
   return DiagnosticInfoPromise::CreateAndResolve(info, __func__);
 }
 
-void WasmModuleBackend::Shutdown() {}
+void WasmModuleBackend::Shutdown() {
+  AssertIsOnMainThread();
+  // Drop any runner promise that resolves after this point
+  mInert = true;
+}
 
 #undef WASM_RUNNER_CONTRACTID
 

--- a/toolkit/components/contentanalysis/WasmModuleBackend.h
+++ b/toolkit/components/contentanalysis/WasmModuleBackend.h
@@ -8,6 +8,7 @@
 #include "MainThreadUtils.h"
 #include "js/TypeDecls.h"
 #include "nsCOMPtr.h"
+#include "nsString.h"
 #include "nsTArray.h"
 
 namespace content_analysis::sdk {
@@ -33,6 +34,7 @@ class WasmModuleBackend final : public ContentAnalysisBackend {
   WasmModuleBackend(const WasmModuleBackend&) = delete;
   WasmModuleBackend& operator=(const WasmModuleBackend&) = delete;
 
+  BackendKind Kind() const override { return BackendKind::eWasmModule; }
   nsresult EnsureReady() override;
   nsresult Analyze(nsCOMPtr<nsIContentAnalysisRequest> aRequest,
                    bool aAutoAcknowledge) override;
@@ -59,6 +61,10 @@ class WasmModuleBackend final : public ContentAnalysisBackend {
                         const nsTArray<RefPtr<nsIContentAnalysisRule>>& aRules,
                         const nsACString& aUserActionId, bool aAutoAcknowledge);
 
+  // Fill aRules with the built-in rule set from the dlp_rules pref, parsing it
+  // only when it differs from what is already cached.
+  nsresult LoadDlpRules(nsTArray<RefPtr<nsIContentAnalysisRule>>& aRules);
+
   // Number of Analyze() calls made so far, for GetDiagnosticInfo.
   int64_t mRequestCount MOZ_GUARDED_BY(sMainThreadCapability) = 0;
 
@@ -70,6 +76,21 @@ class WasmModuleBackend final : public ContentAnalysisBackend {
   // extension is not signed.
   bool mFailedSignatureVerification MOZ_GUARDED_BY(sMainThreadCapability) =
       false;
+
+  // Set once Shutdown() runs (e.g. when the service swaps this backend out on a
+  // live policy change). A runner promise that resolves afterward is dropped so
+  // it can't deliver a stale verdict through the still-alive service.
+  bool mInert MOZ_GUARDED_BY(sMainThreadCapability) = false;
+
+  // The rules parsed from the dlp_rules pref, and the exact pref string they
+  // came from. Comparing the string is what keeps them current across live
+  // policy updates: a policy-locked pref does not reliably notify observers, so
+  // there is nothing to invalidate the cache from. Only assigned together, and
+  // only after a successful parse, so an unparsable rule set is retried on the
+  // next request instead of being cached as "no rules".
+  nsString mCachedRulesJSON MOZ_GUARDED_BY(sMainThreadCapability);
+  nsTArray<RefPtr<nsIContentAnalysisRule>> mCachedRules
+      MOZ_GUARDED_BY(sMainThreadCapability);
 };
 
 }  // namespace mozilla::contentanalysis

--- a/toolkit/components/contentanalysis/nsIContentAnalysis.idl
+++ b/toolkit/components/contentanalysis/nsIContentAnalysis.idl
@@ -529,6 +529,20 @@ interface nsIContentAnalysis : nsISupports
    * Force the content analysis client to be recreated. For use in tests only.
    */
   void forceRecreateClientForTest();
+
+  /**
+   * Which backend currently services requests: "external-agent", "wasm-module",
+   * or "none" while Content Analysis is deactivated by policy. For use in
+   * tests only.
+   */
+  readonly attribute ACString backendKindForTest;
+
+  /**
+   * Incremented every time a fresh backend is built. Lets a test distinguish a
+   * live policy update that rebuilt the backend from one that only changed
+   * prefs the existing backend reads live. For use in tests only.
+   */
+  readonly attribute uint32_t backendGenerationForTest;
 };
 
 /**

--- a/toolkit/components/contentanalysis/tests/xpcshell/test_wasm_backend.js
+++ b/toolkit/components/contentanalysis/tests/xpcshell/test_wasm_backend.js
@@ -9,10 +9,11 @@
 // and hands both to the in-process wasm DLP module via nsIContentAnalysisWasmRunner.
 //
 // The wasm module is bundled in a WebExtension and read through the real
-// production path, exactly as test_wasm_runner.js does. This test depends on the
-// example rule set hard-coded in WasmModuleBackend::BuildExampleRules (block
-// uploads to cloud-storage domains, warn on AI domains).
-// TODO - refactor the rules code so we can just specify them from the test here
+// production path, exactly as test_wasm_runner.js does. The rules below are
+// delivered the way the DataLossPrevention policy delivers them in production,
+// through the browser.contentanalysis.dlp_rules pref that WasmModuleBackend
+// reads (block uploads to cloud-storage domains, warn on AI domains, block
+// content marked CONFIDENTIAL).
 
 const { AddonManager } = ChromeUtils.importESModule(
   "resource://gre/modules/AddonManager.sys.mjs"
@@ -20,6 +21,36 @@ const { AddonManager } = ChromeUtils.importESModule(
 
 const REQUIRE_SIGNATURE_PREF =
   "browser.contentanalysis.wasm_module_extension_require_signature";
+
+const DLP_RULES = {
+  DLPRules: {
+    Rules: [
+      {
+        Name: "warn-ai-paste",
+        Enabled: true,
+        Actions: ["TextPaste", "FileUpload"],
+        Domains: ["chatgpt.com", "claude.ai", "gemini.google.com"],
+        Type: "warn",
+        Message:
+          "Pasting work data into AI services may violate company policy.",
+      },
+      {
+        Name: "block-cloud-uploads",
+        Enabled: true,
+        Actions: ["FileUpload"],
+        Domains: ["drive.google.com", "dropbox.com", "wetransfer.com"],
+        Type: "block",
+      },
+      {
+        Name: "block-confidential-content",
+        Enabled: true,
+        ContentPatterns: ["\\bCONFIDENTIAL\\b"],
+        Type: "block",
+        Message: "Content marked CONFIDENTIAL may not leave the organization.",
+      },
+    ],
+  },
+};
 
 // Prefs must be set before the ContentAnalysis service is first instantiated,
 // since the backend is chosen once in its constructor.
@@ -43,6 +74,10 @@ Services.prefs.setStringPref(
   ""
 );
 Services.prefs.setStringPref("browser.contentanalysis.deny_url_regex_list", "");
+Services.prefs.setStringPref(
+  "browser.contentanalysis.dlp_rules",
+  JSON.stringify(DLP_RULES)
+);
 
 const contentAnalysis = Cc["@mozilla.org/contentanalysis;1"].getService(
   Ci.nsIContentAnalysis
@@ -85,6 +120,19 @@ function makeRequest({
     sourceWindowGlobal: null,
     testOnlyIgnoreCanceledAndAlwaysSubmitToAgent: false,
   };
+}
+
+const DLP_RULES_PREF = "browser.contentanalysis.dlp_rules";
+
+function setDlpRules(rules) {
+  Services.prefs.setStringPref(
+    DLP_RULES_PREF,
+    JSON.stringify({ DLPRules: { Rules: rules } })
+  );
+}
+
+function restoreDefaultDlpRules() {
+  Services.prefs.setStringPref(DLP_RULES_PREF, JSON.stringify(DLP_RULES));
 }
 
 // Write a temp file with the given contents and return its absolute path,
@@ -422,5 +470,115 @@ add_task(async function test_succeeds_with_signature_check_if_signed() {
   );
 
   Services.prefs.setBoolPref(REQUIRE_SIGNATURE_PREF, false);
+  await extension.unload();
+});
+
+// Upload the same file to the same domain repeatedly; only the rule set varies.
+async function uploadToExample() {
+  const filePath = await makeTempFile(
+    "dlp_rule_cache.txt",
+    "ordinary file contents"
+  );
+  return contentAnalysis.analyzeContentRequests(
+    [
+      makeRequest({
+        analysisType: Ci.nsIContentAnalysisRequest.eFileAttached,
+        reason: Ci.nsIContentAnalysisRequest.eFilePickerDialog,
+        operationTypeForDisplay: Ci.nsIContentAnalysisRequest.eUpload,
+        fileNameForDisplay: "dlp_rule_cache.txt",
+        urlSpec: "https://example.com/upload",
+        filePath,
+      }),
+    ],
+    true
+  );
+}
+
+// Whether a request was allowed, treating a failure to analyze as "not allowed"
+// so a fail-closed error and an explicit block are both reported as blocked.
+async function uploadWasAllowed() {
+  try {
+    return (await uploadToExample()).shouldAllowContent;
+  } catch (e) {
+    return false;
+  }
+}
+
+// WasmModuleBackend caches the parsed rules keyed on the dlp_rules pref string.
+// A policy-locked pref does not reliably notify observers, so that string
+// comparison is the only thing keeping the rules current after a live policy
+// update -- if it regressed, the first rule set would be enforced forever.
+add_task(async function test_changed_rules_take_effect_without_invalidation() {
+  const extension = await installModuleExtension();
+
+  setDlpRules([
+    {
+      Name: "block-example-uploads",
+      Enabled: true,
+      Actions: ["FileUpload"],
+      Domains: ["example.com"],
+      Type: "block",
+    },
+  ]);
+  Assert.ok(
+    !(await uploadWasAllowed()),
+    "the rule blocking example.com uploads is enforced"
+  );
+
+  // Reuse the cached rules for an identical second request.
+  Assert.ok(
+    !(await uploadWasAllowed()),
+    "the cached rule set is still enforced on a repeat request"
+  );
+
+  // Same request, but the rule set no longer covers example.com.
+  setDlpRules([
+    {
+      Name: "block-dropbox-uploads",
+      Enabled: true,
+      Actions: ["FileUpload"],
+      Domains: ["dropbox.com"],
+      Type: "block",
+    },
+  ]);
+  Assert.ok(
+    await uploadWasAllowed(),
+    "a replaced rule set is picked up instead of the cached one"
+  );
+
+  restoreDefaultDlpRules();
+  await extension.unload();
+});
+
+// A rule set that fails to parse must not be cached as "no rules", which would
+// turn a single bad policy into a silent allow-everything from the second
+// request onward. Both requests below must fail closed.
+add_task(async function test_unparsable_rules_are_not_cached_as_no_rules() {
+  const extension = await installModuleExtension();
+
+  Services.prefs.setStringPref(DLP_RULES_PREF, "{ this is not valid JSON");
+
+  Assert.ok(!(await uploadWasAllowed()), "an unparsable rule set fails closed");
+  Assert.ok(
+    !(await uploadWasAllowed()),
+    "it still fails closed on the next request rather than caching as no rules"
+  );
+
+  // A valid rule set must still be adopted after the failures.
+  setDlpRules([
+    {
+      Name: "block-example-uploads",
+      Enabled: true,
+      Actions: ["FileUpload"],
+      Domains: ["example.com"],
+      Type: "block",
+    },
+  ]);
+  Assert.ok(
+    !(await uploadWasAllowed()),
+    "a valid rule set is parsed again after a failed parse"
+  );
+
+  restoreDefaultDlpRules();
   await extension.unload();
 });

--- a/toolkit/components/enterprisepolicies/tests/browser/live/browser.toml
+++ b/toolkit/components/enterprisepolicies/tests/browser/live/browser.toml
@@ -9,6 +9,10 @@ run-if = [
 
 ["browser_live_and_local_policies_merging.js"]
 
+["browser_live_content_analysis_activation.js"]
+
+["browser_live_content_analysis_dlp.js"]
+
 ["browser_live_disable_local_policies.js"]
 
 ["browser_live_policies_basic_tests.js"]

--- a/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_content_analysis_activation.js
+++ b/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_content_analysis_activation.js
@@ -1,0 +1,163 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+// Live activation of Content Analysis from off, covering the two places that
+// used to assume the activation state was fixed at browser startup:
+//
+//   * the front end, which gated its per-window wiring on isActive once, so a
+//     window that already existed when the policy arrived never showed the
+//     indicator, and
+//   * nsIContentAnalysis::MightBeActive(), which cached the enabled pref in a
+//     process-static on first read, so a content process that had already read
+//     it kept taking the plain clipboard path and skipped analysis entirely.
+//
+// Both are only observable when activation happens after the window and the
+// content process already exist, which is what these tests set up.
+
+const CA_PREFIX = "browser.contentanalysis.";
+
+const PASTE_RULE = {
+  Name: "warn-ai-paste",
+  Enabled: true,
+  Actions: ["TextPaste"],
+  Domains: ["chatgpt.com"],
+  Type: "warn",
+};
+
+const ca = Cc["@mozilla.org/contentanalysis;1"].getService(
+  Ci.nsIContentAnalysis
+);
+
+async function applyLivePolicies(policies) {
+  const updateApplied = EnterprisePolicyTesting.awaitNextPolicyUpdate();
+  EnterprisePolicyTesting.stubRemotePolicies({ policies });
+  await updateApplied;
+}
+
+async function startFrom(policies) {
+  await EnterprisePolicyTesting.setupEngineWithRemotePolicies({ policies });
+  const updateApplied = EnterprisePolicyTesting.awaitNextPolicyUpdate();
+  Services.obs.notifyObservers(null, "EnterprisePolicies:Update");
+  await updateApplied;
+}
+
+function indicatorShown(win) {
+  return win.document.documentElement.hasAttribute("contentanalysisactive");
+}
+
+add_task(async function test_indicator_appears_in_existing_windows() {
+  await startFrom({});
+
+  // Both windows exist before the policy arrives, which is the case the old
+  // startup-time gating got wrong.
+  const secondWindow = await BrowserTestUtils.openNewBrowserWindow();
+
+  Assert.ok(
+    !indicatorShown(window),
+    "no indicator in the original window while inactive"
+  );
+  Assert.ok(
+    !indicatorShown(secondWindow),
+    "no indicator in the second window while inactive"
+  );
+
+  await applyLivePolicies({
+    DataLossPrevention: { FallbackResult: "block", Rules: [PASTE_RULE] },
+  });
+
+  Assert.ok(ca.isActive, "Content Analysis active after the live update");
+  Assert.ok(
+    indicatorShown(window),
+    "indicator appeared in the original window without a restart"
+  );
+  Assert.ok(
+    indicatorShown(secondWindow),
+    "indicator appeared in the second window without a restart"
+  );
+
+  // Deactivation must clear it again in every window.
+  await applyLivePolicies({});
+
+  Assert.ok(!ca.isActive, "Content Analysis inactive again");
+  Assert.ok(
+    !indicatorShown(window),
+    "indicator removed from the original window on deactivation"
+  );
+  Assert.ok(
+    !indicatorShown(secondWindow),
+    "indicator removed from the second window on deactivation"
+  );
+
+  await BrowserTestUtils.closeWindow(secondWindow);
+});
+
+add_task(async function test_indicator_shown_in_a_window_opened_while_active() {
+  await startFrom({
+    DataLossPrevention: { FallbackResult: "block", Rules: [PASTE_RULE] },
+  });
+
+  Assert.ok(ca.isActive, "Content Analysis active");
+
+  const newWindow = await BrowserTestUtils.openNewBrowserWindow();
+  Assert.ok(
+    indicatorShown(newWindow),
+    "a window opened while active shows the indicator"
+  );
+
+  await BrowserTestUtils.closeWindow(newWindow);
+  await applyLivePolicies({});
+});
+
+// MightBeActive is the content-process gate for CA-aware clipboard reads. It
+// must reflect a live activation in a content process that was already running
+// (and had already consulted it) before the policy arrived.
+add_task(async function test_might_be_active_live_in_content_process() {
+  await startFrom({});
+
+  await BrowserTestUtils.withNewTab(
+    "https://example.com/",
+    async function (browser) {
+      // Read it once while inactive so any per-process caching would be primed
+      // with the stale value.
+      Assert.ok(
+        !(await SpecialPowers.spawn(browser, [], () => {
+          return Cc["@mozilla.org/contentanalysis;1"].getService(
+            Ci.nsIContentAnalysis
+          ).mightBeActive;
+        })),
+        "mightBeActive is false in the content process while inactive"
+      );
+
+      await applyLivePolicies({
+        DataLossPrevention: { FallbackResult: "block", Rules: [PASTE_RULE] },
+      });
+
+      Assert.equal(
+        Services.prefs.getBoolPref(CA_PREFIX + "enabled"),
+        true,
+        "the enabled pref is set in the parent"
+      );
+      Assert.ok(
+        await SpecialPowers.spawn(browser, [], () => {
+          return Cc["@mozilla.org/contentanalysis;1"].getService(
+            Ci.nsIContentAnalysis
+          ).mightBeActive;
+        }),
+        "mightBeActive turned true in the already-running content process"
+      );
+
+      await applyLivePolicies({});
+
+      Assert.ok(
+        !(await SpecialPowers.spawn(browser, [], () => {
+          return Cc["@mozilla.org/contentanalysis;1"].getService(
+            Ci.nsIContentAnalysis
+          ).mightBeActive;
+        })),
+        "mightBeActive turned false again after live deactivation"
+      );
+    }
+  );
+});

--- a/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_content_analysis_dlp.js
+++ b/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_content_analysis_dlp.js
@@ -1,0 +1,440 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+// Live (no-restart) arbitration between the external ContentAnalysis policy and
+// the built-in DataLossPrevention policy, and the C++ backend swap that follows.
+//
+// Two layers are asserted per transition:
+//   * the browser.contentanalysis.* prefs reconcileContentAnalysis computed, and
+//   * what ContentAnalysis::MaybeUpdateBackend then did with the live backend,
+//     read through backendKindForTest / backendGenerationForTest.
+//
+// The generation counter is what makes "did NOT swap" observable: prefs the
+// existing backend reads live (rules, interception points, default_result) must
+// take effect without rebuilding it.
+
+const CA_PREFIX = "browser.contentanalysis.";
+
+const INTERCEPTION_POINTS = [
+  "clipboard",
+  "download",
+  "drag_and_drop",
+  "file_upload",
+  "print",
+];
+
+const PASTE_RULE = {
+  Name: "warn-ai-paste",
+  Enabled: true,
+  Actions: ["TextPaste"],
+  Domains: ["chatgpt.com"],
+  Type: "warn",
+};
+
+const UPLOAD_RULE = {
+  Name: "block-cloud-upload",
+  Enabled: true,
+  Actions: ["FileUpload"],
+  Domains: ["dropbox.com"],
+  Type: "block",
+};
+
+const ca = Cc["@mozilla.org/contentanalysis;1"].getService(
+  Ci.nsIContentAnalysis
+);
+
+function backendKind() {
+  return ca.backendKindForTest;
+}
+
+function backendGeneration() {
+  return ca.backendGenerationForTest;
+}
+
+function serializedRuleNames() {
+  let json = Services.prefs.getStringPref(CA_PREFIX + "dlp_rules", "");
+  return json ? JSON.parse(json).DLPRules.Rules.map(rule => rule.Name) : [];
+}
+
+function assertInterceptionPoints(expectedOn, message) {
+  for (let point of INTERCEPTION_POINTS) {
+    Assert.equal(
+      Services.prefs.getBoolPref(
+        `${CA_PREFIX}interception_point.${point}.enabled`,
+        false
+      ),
+      expectedOn.includes(point),
+      `${message}: interception_point.${point}.enabled`
+    );
+  }
+}
+
+// Serve a new remote policy set and wait for the update to be applied. This is
+// the live path: the poller notices the changed set, the engine diffs it, and
+// EnterprisePolicies:PolicyUpdatesApplied lands after the prefs have settled.
+async function applyLivePolicies(policies) {
+  const updateApplied = EnterprisePolicyTesting.awaitNextPolicyUpdate();
+  EnterprisePolicyTesting.stubRemotePolicies({ policies });
+  await updateApplied;
+}
+
+// Establish a starting policy set, then drive one no-op update through so the
+// C++ backend is in sync with the prefs before the transition under test. An
+// engine restart re-runs the JS handlers but does not fire
+// PolicyUpdatesApplied, and the service is a singleton that outlives each task,
+// so without this the backend could still reflect the previous task's policies.
+async function startFrom(policies) {
+  await EnterprisePolicyTesting.setupEngineWithRemotePolicies({ policies });
+  const updateApplied = EnterprisePolicyTesting.awaitNextPolicyUpdate();
+  Services.obs.notifyObservers(null, "EnterprisePolicies:Update");
+  await updateApplied;
+}
+
+add_task(async function test_live_activation_selects_builtin_backend() {
+  await startFrom({});
+
+  Assert.equal(
+    backendKind(),
+    "none",
+    "no live backend while neither policy is present"
+  );
+  Assert.ok(!ca.isActive, "Content Analysis inactive with no policy");
+
+  await applyLivePolicies({
+    DataLossPrevention: { FallbackResult: "block", Rules: [PASTE_RULE] },
+  });
+
+  Assert.ok(ca.isActive, "Content Analysis active after adding DLP live");
+  Assert.equal(
+    Services.prefs.getBoolPref(CA_PREFIX + "use_wasm_backend"),
+    true,
+    "built-in WASM backend selected by policy"
+  );
+  Assert.equal(
+    backendKind(),
+    "wasm-module",
+    "live backend is the built-in WASM module"
+  );
+  Assert.deepEqual(
+    serializedRuleNames(),
+    ["warn-ai-paste"],
+    "the DLP rule was delivered"
+  );
+  assertInterceptionPoints(
+    ["clipboard", "drag_and_drop"],
+    "TextPaste derives clipboard and drag_and_drop"
+  );
+});
+
+add_task(async function test_live_rules_edit_does_not_rebuild_backend() {
+  await startFrom({
+    DataLossPrevention: { FallbackResult: "block", Rules: [PASTE_RULE] },
+  });
+
+  Assert.equal(backendKind(), "wasm-module", "starting on the WASM backend");
+  const generationBefore = backendGeneration();
+
+  // Same provider, different rules: the backend reads dlp_rules and the
+  // interception-point prefs live, so this must not rebuild it.
+  await applyLivePolicies({
+    DataLossPrevention: {
+      FallbackResult: "warn",
+      Rules: [PASTE_RULE, UPLOAD_RULE],
+    },
+  });
+
+  Assert.deepEqual(
+    serializedRuleNames(),
+    ["warn-ai-paste", "block-cloud-upload"],
+    "the edited rule set was delivered"
+  );
+  assertInterceptionPoints(
+    ["clipboard", "drag_and_drop", "file_upload"],
+    "adding a FileUpload rule enables file_upload"
+  );
+  Assert.equal(
+    Services.prefs.getIntPref(CA_PREFIX + "default_result"),
+    1,
+    "FallbackResult warn maps to default_result 1"
+  );
+  Assert.equal(
+    backendKind(),
+    "wasm-module",
+    "still on the built-in WASM backend"
+  );
+  Assert.equal(
+    backendGeneration(),
+    generationBefore,
+    "a rules-only change did not rebuild the backend"
+  );
+});
+
+// Diffing case: ContentAnalysis is added while DataLossPrevention is untouched,
+// so only the ContentAnalysis callbacks run. reconcileContentAnalysis reads the
+// whole active set, so the external agent still takes over.
+add_task(async function test_live_adding_external_suppresses_builtin() {
+  await startFrom({
+    DataLossPrevention: { FallbackResult: "block", Rules: [PASTE_RULE] },
+  });
+
+  Assert.equal(backendKind(), "wasm-module", "starting on the WASM backend");
+  const generationBefore = backendGeneration();
+
+  await applyLivePolicies({
+    ContentAnalysis: { Enabled: true },
+    DataLossPrevention: { FallbackResult: "block", Rules: [PASTE_RULE] },
+  });
+
+  Assert.equal(
+    Services.prefs.getBoolPref(CA_PREFIX + "use_wasm_backend"),
+    false,
+    "external agent wins over the built-in engine"
+  );
+  Assert.deepEqual(
+    serializedRuleNames(),
+    [],
+    "built-in rules withdrawn while the external agent is authoritative"
+  );
+  Assert.equal(
+    backendKind(),
+    "external-agent",
+    "live backend swapped to the external agent"
+  );
+  Assert.greater(
+    backendGeneration(),
+    generationBefore,
+    "the swap rebuilt the backend"
+  );
+});
+
+// The mirror-image diffing case: ContentAnalysis is removed while
+// DataLossPrevention is untouched, so only the ContentAnalysis onRemove runs.
+// The built-in engine must reclaim the backend rather than silently stay off.
+add_task(async function test_live_removing_external_reactivates_builtin() {
+  await startFrom({
+    ContentAnalysis: { Enabled: true },
+    DataLossPrevention: { FallbackResult: "block", Rules: [UPLOAD_RULE] },
+  });
+
+  Assert.equal(
+    backendKind(),
+    "external-agent",
+    "starting on the external agent"
+  );
+  const generationBefore = backendGeneration();
+
+  await applyLivePolicies({
+    DataLossPrevention: { FallbackResult: "block", Rules: [UPLOAD_RULE] },
+  });
+
+  Assert.equal(
+    Services.prefs.getBoolPref(CA_PREFIX + "use_wasm_backend"),
+    true,
+    "built-in engine reclaims the backend"
+  );
+  Assert.deepEqual(
+    serializedRuleNames(),
+    ["block-cloud-upload"],
+    "built-in rules delivered again"
+  );
+  Assert.equal(
+    backendKind(),
+    "wasm-module",
+    "live backend swapped back to the built-in WASM module"
+  );
+  Assert.greater(
+    backendGeneration(),
+    generationBefore,
+    "the swap back rebuilt the backend"
+  );
+  assertInterceptionPoints(
+    ["file_upload", "drag_and_drop"],
+    "interception points derived from the built-in rules again"
+  );
+});
+
+// Flipping ContentAnalysis.Enabled is an arbitration change even though both
+// policies stay present: a disabled ContentAnalysis block does not suppress the
+// built-in engine.
+add_task(async function test_live_external_enabled_flip_swaps_backend() {
+  await startFrom({
+    ContentAnalysis: { Enabled: false },
+    DataLossPrevention: { FallbackResult: "block", Rules: [PASTE_RULE] },
+  });
+
+  Assert.equal(
+    backendKind(),
+    "wasm-module",
+    "a disabled ContentAnalysis policy leaves the built-in engine running"
+  );
+  let generation = backendGeneration();
+
+  await applyLivePolicies({
+    ContentAnalysis: { Enabled: true },
+    DataLossPrevention: { FallbackResult: "block", Rules: [PASTE_RULE] },
+  });
+
+  Assert.equal(
+    backendKind(),
+    "external-agent",
+    "enabling ContentAnalysis hands the backend to the external agent"
+  );
+  Assert.greater(backendGeneration(), generation, "enabling rebuilt");
+  generation = backendGeneration();
+
+  await applyLivePolicies({
+    ContentAnalysis: { Enabled: false },
+    DataLossPrevention: { FallbackResult: "block", Rules: [PASTE_RULE] },
+  });
+
+  Assert.equal(
+    backendKind(),
+    "wasm-module",
+    "disabling ContentAnalysis returns the backend to the built-in engine"
+  );
+  Assert.greater(backendGeneration(), generation, "disabling rebuilt");
+  Assert.deepEqual(
+    serializedRuleNames(),
+    ["warn-ai-paste"],
+    "built-in rules delivered once the external agent stands down"
+  );
+});
+
+// An external agent that stays external still needs a rebuild when its
+// connection config changes, because pipe name, signature, per-user flag and
+// thread-pool size are baked into the backend at construction.
+add_task(async function test_live_external_connection_change_rebuilds() {
+  await startFrom({
+    ContentAnalysis: { Enabled: true, PipePathName: "live_dlp_pipe_a" },
+  });
+
+  Assert.equal(
+    backendKind(),
+    "external-agent",
+    "starting on the external agent"
+  );
+  let generation = backendGeneration();
+
+  await applyLivePolicies({
+    ContentAnalysis: { Enabled: true, PipePathName: "live_dlp_pipe_b" },
+  });
+
+  Assert.equal(
+    Services.prefs.getStringPref(CA_PREFIX + "pipe_path_name"),
+    "live_dlp_pipe_b",
+    "the new pipe name reached the pref"
+  );
+  Assert.equal(
+    backendKind(),
+    "external-agent",
+    "still the external agent after a connection change"
+  );
+  Assert.greater(
+    backendGeneration(),
+    generation,
+    "a changed pipe name rebuilt the external backend"
+  );
+  generation = backendGeneration();
+
+  // An update that touches nothing the connection depends on must not churn it.
+  await applyLivePolicies({
+    ContentAnalysis: {
+      Enabled: true,
+      PipePathName: "live_dlp_pipe_b",
+      ShowBlockedResult: false,
+    },
+  });
+
+  Assert.equal(
+    backendGeneration(),
+    generation,
+    "an unrelated ContentAnalysis change left the connection alone"
+  );
+});
+
+// reconcileContentAnalysis owns every pref the two policies share, so that the
+// winner's configuration fully replaces the loser's. Transition live from an
+// external agent that set URL filters to a DLP policy that sets none: the
+// built-in engine must fall back to the built-in defaults, not inherit the
+// agent's filters. Only a live update exercises this -- an engine restart resets
+// tracked prefs first, which would mask an inherited value.
+add_task(async function test_builtin_does_not_inherit_external_url_filters() {
+  const allowList = "https://allowed\\.example\\.com/.*";
+  // The shipped default excludes about: pages from analysis; releasing the pref
+  // must restore exactly that, rather than clearing it to the empty string.
+  const defaultAllowList = Services.prefs
+    .getDefaultBranch("")
+    .getStringPref(CA_PREFIX + "allow_url_regex_list");
+  Assert.notEqual(
+    defaultAllowList,
+    allowList,
+    "the default allow list differs from the one the agent sets"
+  );
+
+  await startFrom({
+    ContentAnalysis: {
+      Enabled: true,
+      AllowUrlRegexList: allowList,
+      DenyUrlRegexList: "https://denied\\.example\\.com/.*",
+    },
+  });
+
+  Assert.equal(
+    Services.prefs.getStringPref(CA_PREFIX + "allow_url_regex_list", ""),
+    allowList,
+    "the external agent's allow list is in effect to begin with"
+  );
+
+  await applyLivePolicies({
+    DataLossPrevention: { FallbackResult: "block", Rules: [PASTE_RULE] },
+  });
+
+  Assert.equal(backendKind(), "wasm-module", "the built-in engine took over");
+  Assert.equal(
+    Services.prefs.getStringPref(CA_PREFIX + "deny_url_regex_list", ""),
+    "",
+    "the external agent's deny list did not carry over"
+  );
+  Assert.equal(
+    Services.prefs.getStringPref(CA_PREFIX + "allow_url_regex_list", ""),
+    defaultAllowList,
+    "the allow list fell back to its default instead of the agent's value"
+  );
+});
+
+// Removing every policy must tear the backend down, not leave a live one that a
+// stray interception request could still reach.
+add_task(async function test_live_deactivation_tears_down_backend() {
+  await startFrom({
+    DataLossPrevention: { FallbackResult: "block", Rules: [PASTE_RULE] },
+  });
+
+  Assert.equal(backendKind(), "wasm-module", "starting on the WASM backend");
+  Assert.ok(ca.isActive, "Content Analysis active before deactivation");
+
+  await applyLivePolicies({});
+
+  Assert.ok(!ca.isActive, "Content Analysis inactive after removing DLP");
+  Assert.equal(
+    Services.prefs.getBoolPref(CA_PREFIX + "enabled", false),
+    false,
+    "the enabled pref was released"
+  );
+  Assert.equal(backendKind(), "none", "the live backend was torn down");
+  Assert.deepEqual(serializedRuleNames(), [], "rules withdrawn");
+
+  // The interception-point prefs are released rather than set to false, so they
+  // revert to their built-in defaults (most of which are true). Nothing is
+  // intercepted anyway because ShouldCheckReason gates on the enabled pref,
+  // which is what keeps a stray request from reaching the dead backend.
+  for (let point of INTERCEPTION_POINTS) {
+    Assert.ok(
+      !Services.prefs.prefIsLocked(
+        `${CA_PREFIX}interception_point.${point}.enabled`
+      ),
+      `interception_point.${point}.enabled was released by policy`
+    );
+  }
+});


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2058222 

- Add ability to change ContentAnalysis backend depending on which policy is active
   - Cancels any requests in flight at the moment of the change and old backend becomes inert to avoid late responses
- Adjust some existing ContentAnalysis infrastructure to be able to react to CA becoming disabled at runtime (previously not possible).
   - Any interception point that still tries to make a request will get filtered in ShouldCheckReason
   - Interception points should be more aware of IsEnabled

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Testing <!-- OPTIONAL -->

* [x] Added tests
* [ ] Manual testing performed

<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
