### PR TITLE
Bug 2059720 - Disable Firefox Relay integration for enterprise builds

### DIFF
--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -2974,7 +2974,11 @@ pref("browser.migrate.preferences-entrypoint.enabled", true);
 // "offered"        - we have offered feature to user and they have not yet made a decision.
 // "enabled"        - user opted in to the feature.
 // "disabled"       - user opted out of the feature.
+#ifdef MOZ_ENTERPRISE
+pref("signon.firefoxRelay.feature", "");
+#else
 pref("signon.firefoxRelay.feature", "available");
+#endif
 pref("signon.management.page.breach-alerts.enabled", true);
 pref("signon.management.page.vulnerable-passwords.enabled", true);
 pref("signon.management.page.sort", "name");


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2059720

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

Enterprise builds do not use Firefox Relay. Default signon.firefoxRelay.feature to "" for MOZ_ENTERPRISE builds to hide the Relay checkbox in `about:preferences and fully disable Firefox Relay.

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

<img width="619" height="294" alt="Screenshot 2026-07-31 at 4 34 16 PM" src="https://github.com/user-attachments/assets/8ae4bf88-21a8-48d3-8a6f-608f740accda" />

_Before disabling Firefox Relay_

<img width="619" height="234" alt="Screenshot 2026-07-31 at 4 38 14 PM" src="https://github.com/user-attachments/assets/afff01a3-38c8-4b00-aa4a-fff0c879f2e4" />

_After disabling Firefox Relay_

---

### Testing <!-- OPTIONAL -->

* [ ] Added tests
* [x] Manual testing performed

**Steps to verify changes:**

1. Navigate to `about:preferences#privacy` and scroll to "Additional Protections"

**Expected result:**

"Suggest Firefox Relay email masks" checkbox is not present.