### PR TITLE
Bug 2034430 - Skip Firefox Relay tests in enterprise builds

### DIFF
--- a/toolkit/components/passwordmgr/test/browser/browser.toml
+++ b/toolkit/components/passwordmgr/test/browser/browser.toml
@@ -284,15 +284,19 @@ skip-if = [
 
 ["browser_relay_signup_flow.js"]
 support-files = ["browser_relay_utils.js"]
+skip-if = ["enterprise"] # Relay is not supported in enterprise builds
 
 ["browser_relay_signup_flow_showToAllBrowsers.js"]
 support-files = ["browser_relay_utils.js"]
+skip-if = ["enterprise"] # Relay is not supported in enterprise builds
 
 ["browser_relay_telemetry.js"]
 support-files = ["browser_relay_utils.js"]
+skip-if = ["enterprise"] # Relay is not supported in enterprise builds
 
 ["browser_relay_use.js"]
 support-files = ["browser_relay_utils.js"]
+skip-if = ["enterprise"] # Relay is not supported in enterprise builds
 
 ["browser_telemetry_SignUpFormRuleset.js"]
 


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2034430

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

This PR is a recreation of #780 due to issues running in taskcluster. Additionally, it was decided that since this pref can be disabled via a `Preferences` policy, it can be added to a base set of policies to disable other features that is being worked on under Bug-2060298. With that change, the PR scope is narrowed to simply skipping the Relay tests on enterprise builds.

This PR does the following:
- ~Sets the signon.firefoxRelay.feature pref default to "disabled" (instead of "available") in enterprise builds via #ifdef MOZ_ENTERPRISE in firefox.js~
- Skips the existing Relay browser tests (browser_relay_signup_flow.js, browser_relay_signup_flow_showToAllBrowsers.js, browser_relay_telemetry.js,
  browser_relay_use.js) on enterprise builds since they assume the feature is available
- ~Adds a new enterprise-only test (browser_relay_disabled_enterprise.js) that verifies:~
  - ~The default pref value is "disabled"~
  - ~FirefoxRelayUtils.relayIsAvailableOrEnabled() returns false~
  - ~The Relay autocomplete item does not appear in the password popup~

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Related: #780
