### PR TITLE
Bug 2059889 - Control "Tabs from other devices" visibility based on Sync policy

### DIFF
--- a/browser/components/enterprisepolicies/helpers/SyncPolicy.sys.mjs
+++ b/browser/components/enterprisepolicies/helpers/SyncPolicy.sys.mjs
@@ -30,7 +30,8 @@ const ENGINE_PREFS = {
   Settings: "services.sync.engine.prefs",
 };
 
-const SYNC_FEATURE = "change-sync-state";
+const SYNC = "sync";
+const SYNC_TABS = "sync-tabs";
 
 /**
  * Customizes Sync settings (all settings are optional):
@@ -84,6 +85,11 @@ export const SyncPolicy = {
     } = params;
 
     if (isIgnoringUserPreferences) {
+      // "Tabs from other devices" needs both Sync and its tabs engine unlocked.
+      if (shouldEnableSync === false || typeSettings.OpenTabs === false) {
+        manager.disallowFeature(SYNC_TABS);
+      }
+
       const isSyncCurrentlyEnabled = this.isSyncCurrentlyEnabled();
       if (shouldEnableSync && !isSyncCurrentlyEnabled) {
         lazy.log.debug("Enable Sync");
@@ -107,7 +113,7 @@ export const SyncPolicy = {
 
     // Only lock the Sync feature if 'Enabled' is configured
     if (isIgnoringUserPreferences && shouldEnableSync !== undefined) {
-      manager.disallowFeature(SYNC_FEATURE);
+      manager.disallowFeature(SYNC);
     }
   },
 
@@ -117,8 +123,11 @@ export const SyncPolicy = {
    * @param {EnterprisePoliciesManager} manager
    */
   async restoreSettings(manager) {
-    if (!Services.policies.isAllowed(SYNC_FEATURE)) {
-      manager.allowFeature(SYNC_FEATURE);
+    if (!Services.policies.isAllowed(SYNC)) {
+      manager.allowFeature(SYNC);
+    }
+    if (!Services.policies.isAllowed(SYNC_TABS)) {
+      manager.allowFeature(SYNC_TABS);
     }
     for (const pref of Object.values(ENGINE_PREFS)) {
       lazy.log.debug(`Unsetting ${pref}`);

--- a/browser/components/firefoxview/firefoxview.mjs
+++ b/browser/components/firefoxview/firefoxview.mjs
@@ -95,10 +95,9 @@ async function updateSearchKeyboardShortcut() {
 }
 
 function updateSyncVisibility() {
-  const syncEnabled = Services.prefs.getBoolPref(
-    "identity.fxaccounts.enabled",
-    false
-  );
+  const syncEnabled =
+    Services.prefs.getBoolPref("identity.fxaccounts.enabled", false) &&
+    Services.policies.isAllowed("sync-tabs");
   for (const el of document.querySelectorAll(".sync-ui-item")) {
     el.hidden = !syncEnabled;
   }

--- a/browser/components/preferences/config/account-sync.mjs
+++ b/browser/components/preferences/config/account-sync.mjs
@@ -506,10 +506,7 @@ Preferences.addSetting({
   deps: ["uiStateUpdate"],
   visible() {
     return (
-      !(
-        AppConstants.MOZ_ENTERPRISE &&
-        !Services.policies.isAllowed("change-sync-state")
-      ) &&
+      !(AppConstants.MOZ_ENTERPRISE && !Services.policies.isAllowed("sync")) &&
       SyncHelpers.uiStateStatus === window.UIState.STATUS_SIGNED_IN &&
       !SyncHelpers.isSyncEnabled
     );
@@ -624,8 +621,7 @@ Preferences.addSetting({
   },
   visible: () => {
     return !(
-      AppConstants.MOZ_ENTERPRISE &&
-      !Services.policies.isAllowed("change-sync-state")
+      AppConstants.MOZ_ENTERPRISE && !Services.policies.isAllowed("sync")
     );
   },
 });

--- a/browser/components/preferences/dialogs/syncChooseWhatToSync.js
+++ b/browser/components/preferences/dialogs/syncChooseWhatToSync.js
@@ -28,10 +28,7 @@ let gSyncChooseWhatToSync = {
     this._setupEventListeners();
     this._adjustForPrefs();
     let options = window.arguments[0];
-    if (
-      options.disconnectFun &&
-      Services.policies.isAllowed("change-sync-state")
-    ) {
+    if (options.disconnectFun && Services.policies.isAllowed("sync")) {
       // Offer 'Disconnect' functionality if it was provided
       document.addEventListener("dialogextra2", function () {
         options.disconnectFun().then(disconnected => {

--- a/browser/components/preferences/sync.js
+++ b/browser/components/preferences/sync.js
@@ -304,7 +304,7 @@ var gSyncPane = {
     );
     connectAnotherDeviceLink.setAttribute("restricted-enterprise-view", true);
 
-    if (!Services.policies.isAllowed("change-sync-state")) {
+    if (!Services.policies.isAllowed("sync")) {
       // Hide info box and "Turn on syncing..." button (visible when Sync is disabled)
       const syncOffBox = document.getElementById("syncNotConfigured");
       syncOffBox.setAttribute("restricted-enterprise-view", true);

--- a/browser/components/sidebar/browser-sidebar.js
+++ b/browser/components/sidebar/browser-sidebar.js
@@ -185,6 +185,16 @@ var SidebarController = {
       ],
     ]);
 
+    // Hide synced tabs when accounts or Sync are disabled by policy, rather
+    // than surfacing a panel that can only show an error.
+    const syncedTabsSidebar = this._sidebars.get("viewTabsSidebar");
+    Object.defineProperty(syncedTabsSidebar, "visible", {
+      get: () =>
+        Services.prefs.getBoolPref("identity.fxaccounts.enabled", false) &&
+        Services.policies.isAllowed("sync-tabs"),
+      configurable: true,
+    });
+
     this.registerPrefSidebar(
       "browser.ml.chat.enabled",
       "viewGenaiChatSidebar",
@@ -629,6 +639,17 @@ var SidebarController = {
       Services.obs.addObserver(this, "sessionstore-single-window-restored");
       this._windowRestoredObserverAdded = true;
     }
+    if (!this._policiesObserverAdded) {
+      Services.obs.addObserver(this, "EnterprisePolicies:PolicyUpdatesApplied");
+      this._policiesObserverAdded = true;
+    }
+    if (!this._syncedTabsPrefObserver) {
+      this._syncedTabsPrefObserver = () => this.updateSyncedTabsVisibility();
+      Services.prefs.addObserver(
+        "identity.fxaccounts.enabled",
+        this._syncedTabsPrefObserver
+      );
+    }
   },
 
   uninit() {
@@ -659,9 +680,23 @@ var SidebarController = {
     Services.obs.removeObserver(this, "tabstrip-orientation-change");
     Services.obs.removeObserver(this, "ai-window-state-changed");
     Services.obs.removeObserver(this, "sessionstore-single-window-restored");
+    if (this._policiesObserverAdded) {
+      Services.obs.removeObserver(
+        this,
+        "EnterprisePolicies:PolicyUpdatesApplied"
+      );
+    }
+    if (this._syncedTabsPrefObserver) {
+      Services.prefs.removeObserver(
+        "identity.fxaccounts.enabled",
+        this._syncedTabsPrefObserver
+      );
+      this._syncedTabsPrefObserver = null;
+    }
     delete this._tabstripOrientationObserverAdded;
     delete this._aiWindowObserverAdded;
     delete this._windowRestoredObserverAdded;
+    delete this._policiesObserverAdded;
 
     CustomizableUI.removeListener(this);
 
@@ -836,6 +871,10 @@ var SidebarController = {
             sidebar._updateMenus?.();
           }
         }
+        break;
+      }
+      case "EnterprisePolicies:PolicyUpdatesApplied": {
+        this.updateSyncedTabsVisibility();
         break;
       }
     }
@@ -1935,6 +1974,23 @@ var SidebarController = {
     if (!this.uninitializing) {
       this.updatePinnedTabsHeightOnResize();
     }
+  },
+
+  /**
+   * Refresh the synced tabs tool after its account/policy gating may have
+   * changed, closing an open panel that is no longer allowed to be shown.
+   */
+  updateSyncedTabsVisibility() {
+    const syncedTabsSidebar = this.sidebars.get("viewTabsSidebar");
+    if (
+      !syncedTabsSidebar?.visible &&
+      this._state?.command == "viewTabsSidebar"
+    ) {
+      this._state.command = "";
+      this.lastOpenedId = null;
+      this.hide();
+    }
+    window.dispatchEvent(new CustomEvent("SidebarItemChanged"));
   },
 
   /**

--- a/services/sync/modules/service.sys.mjs
+++ b/services/sync/modules/service.sys.mjs
@@ -975,10 +975,7 @@ Sync11Service.prototype = {
 
   // configures/enabled/turns-on sync. There must be an FxA user signed in.
   async configure() {
-    if (
-      AppConstants.MOZ_ENTERPRISE &&
-      !Services.policies.isAllowed("change-sync-state")
-    ) {
+    if (AppConstants.MOZ_ENTERPRISE && !Services.policies.isAllowed("sync")) {
       // This should never hit. If the Sync policy locks the sync state all calls to this method are guarded.
       this._log.error(
         "Sync is disabled and locked by the Sync policy and can only be enabled by a policy update."
@@ -1008,10 +1005,7 @@ Sync11Service.prototype = {
   async startOver() {
     this._log.trace("Invoking Service.startOver.");
 
-    if (
-      AppConstants.MOZ_ENTERPRISE &&
-      !Services.policies.isAllowed("change-sync-state")
-    ) {
+    if (AppConstants.MOZ_ENTERPRISE && !Services.policies.isAllowed("sync")) {
       // This should never hit. If the Sync policy locks the sync state all calls to this method are guarded.
       this._log.error(
         "Sync is enabled and locked by the Sync policy and can only be disabled by a policy update."

--- a/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_policy_Sync.js
+++ b/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_policy_Sync.js
@@ -4,7 +4,10 @@
 "use strict";
 
 // The feature the Sync policy disallows when it locks the sync state.
-const SYNC_FEATURE = "change-sync-state";
+const SYNC_FEATURE = "sync";
+
+// The feature the Sync policy disallows when it locks the open tabs engine state.
+const SYNC_FEATURE_TABS = "sync-tabs";
 
 function checkSyncFeatureAllowed(expectedAllowed) {
   Assert.equal(
@@ -14,10 +17,64 @@ function checkSyncFeatureAllowed(expectedAllowed) {
   );
 }
 
+function checkSyncTabsFeatureAllowed(expectedAllowed) {
+  Assert.equal(
+    Services.policies.isAllowed(SYNC_FEATURE_TABS),
+    expectedAllowed,
+    `${SYNC_FEATURE_TABS} feature is ${
+      expectedAllowed ? "allowed" : "disallowed"
+    }`
+  );
+}
+
 async function updatePolicies(policies) {
   const updateApplied = EnterprisePolicyTesting.awaitNextPolicyUpdate();
   EnterprisePolicyTesting.stubRemotePolicies(policies);
   await updateApplied;
+}
+
+function getSyncedTabsTool() {
+  return SidebarController.getTools().find(
+    tool => tool.commandID == "viewTabsSidebar"
+  );
+}
+
+// The synced tabs sidebar tool reflects its `visible` getter live, refreshed by
+// SidebarController's policy observer; wait for it to settle after a change.
+async function checkSyncedTabsTool(expectedHidden) {
+  await TestUtils.waitForCondition(
+    () => getSyncedTabsTool().hidden === expectedHidden,
+    `Synced tabs sidebar tool should be ${
+      expectedHidden ? "hidden" : "visible"
+    }`
+  );
+  is(
+    getSyncedTabsTool().hidden,
+    expectedHidden,
+    `Synced tabs sidebar tool hidden=${expectedHidden}`
+  );
+}
+
+// Firefox View reads the sync-tabs gating on load, so open a fresh tab to check
+// how the "Tabs from other devices" nav renders under the current policy.
+async function checkFirefoxViewSyncedTabsHidden(expectedHidden) {
+  await BrowserTestUtils.withNewTab("about:firefoxview", async browser => {
+    const doc = browser.contentDocument;
+    const navButton = await TestUtils.waitForCondition(() =>
+      doc.querySelector('moz-page-nav-button[view="syncedtabs"]')
+    );
+    await TestUtils.waitForCondition(
+      () => navButton.hidden === expectedHidden,
+      `Firefox View synced tabs nav should be ${
+        expectedHidden ? "hidden" : "visible"
+      }`
+    );
+    is(
+      navButton.hidden,
+      expectedHidden,
+      `Firefox View synced tabs nav hidden=${expectedHidden}`
+    );
+  });
 }
 
 const { UIState } = ChromeUtils.importESModule(
@@ -28,7 +85,7 @@ const { getFxAccountsSingleton } = ChromeUtils.importESModule(
 );
 
 // The sync pane renders from UIState, so we mock it to reach the signed-in
-// states that expose the controls gated on the change-sync-state feature.
+// states that expose the controls gated on the sync feature.
 const SIGNED_IN_SYNC_ON = {
   status: UIState.STATUS_SIGNED_IN,
   email: "test@example.com",
@@ -149,7 +206,7 @@ add_task(async function test_sync_controls_reflect_feature_lock() {
     // Enabling awaits connectSync before disallowFeature, so wait for the lock.
     await TestUtils.waitForCondition(
       () => !Services.policies.isAllowed(SYNC_FEATURE),
-      "the change-sync-state feature is locked"
+      "the sync feature is locked"
     );
     await checkDisconnect(true);
 
@@ -160,7 +217,7 @@ add_task(async function test_sync_controls_reflect_feature_lock() {
     // A prior connect means this may disconnect (async) before disallowFeature.
     await TestUtils.waitForCondition(
       () => !Services.policies.isAllowed(SYNC_FEATURE),
-      "the change-sync-state feature is locked"
+      "the sync feature is locked"
     );
     await checkTurnOn(true);
 
@@ -173,4 +230,54 @@ add_task(async function test_sync_controls_reflect_feature_lock() {
     restoreFxa();
     Services.prefs.clearUserPref("services.sync.username");
   }
+});
+
+// The synced tabs sidebar tool and the Firefox View "Tabs from other devices"
+// nav follow the sync-tabs feature the Sync policy gates. Driving the states
+// with live updates also proves the sidebar tool re-gates without a restart.
+add_task(async function test_synced_tabs_visibility_follows_sync_policy() {
+  await EnterprisePolicyTesting.setupEngineWithRemotePolicies(
+    { policies: {} },
+    null
+  );
+
+  info("No policy: the synced tabs surfaces are visible.");
+  checkSyncTabsFeatureAllowed(true);
+  await checkSyncedTabsTool(false);
+  await checkFirefoxViewSyncedTabsHidden(false);
+
+  info("Sync disabled and locked: the synced tabs surfaces are hidden.");
+  await updatePolicies({
+    policies: { Sync: { Enabled: false, Locked: true } },
+  });
+  checkSyncTabsFeatureAllowed(false);
+  await checkSyncedTabsTool(true);
+  await checkFirefoxViewSyncedTabsHidden(true);
+
+  info("Tabs engine disabled and locked: the synced tabs surfaces are hidden.");
+  await updatePolicies({
+    policies: { Sync: { Enabled: true, Locked: true, OpenTabs: false } },
+  });
+  checkSyncTabsFeatureAllowed(false);
+  await checkSyncedTabsTool(true);
+  await checkFirefoxViewSyncedTabsHidden(true);
+
+  info("Sync locked on with tabs: the synced tabs surfaces stay visible.");
+  await updatePolicies({
+    policies: { Sync: { Enabled: true, Locked: true, OpenTabs: true } },
+  });
+  // Locking Sync on awaits connectSync before disallowing sync.
+  await TestUtils.waitForCondition(
+    () => !Services.policies.isAllowed(SYNC_FEATURE),
+    "the sync feature is locked"
+  );
+  checkSyncTabsFeatureAllowed(true);
+  await checkSyncedTabsTool(false);
+  await checkFirefoxViewSyncedTabsHidden(false);
+
+  info("Policy removed: the synced tabs surfaces are visible again.");
+  await updatePolicies({ policies: {} });
+  checkSyncTabsFeatureAllowed(true);
+  await checkSyncedTabsTool(false);
+  await checkFirefoxViewSyncedTabsHidden(false);
 });

--- a/toolkit/components/enterprisepolicies/tests/xpcshell/live/test_live_policy_Sync.js
+++ b/toolkit/components/enterprisepolicies/tests/xpcshell/live/test_live_policy_Sync.js
@@ -26,7 +26,7 @@ const { getFxAccountsSingleton } = ChromeUtils.importESModule(
   "resource://gre/modules/FxAccounts.sys.mjs"
 );
 
-const SYNC_FEATURE = "change-sync-state";
+const SYNC_FEATURE = "sync";
 
 // Engine prefs the Sync policy drives, keyed by their policy property name.
 const ENGINE_PREFS = {
@@ -205,7 +205,7 @@ add_task(async function test_locked_disabled_disconnects_and_locks_feature() {
 });
 
 // An unlocked Sync policy only changes the engine setting's default values;
-// the preference stay unlocked and the sync feature stays allowed.
+// the preferences stay unlocked and the sync feature stays allowed.
 add_task(async function test_unlocked_engine_pref_sets_default() {
   const initialPasswords = Services.prefs.getBoolPref(ENGINE_PREFS.Passwords);
 


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2059889

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

The "Tabs from other devices" views in both the sidebar and `about:firefoxview` do not behave as expected when `Sync` is disabled by policy. The sidebar item is always visible, and depending on prefs/policies, it displays different messages which are not useful if Sync is disabled by policy. The item in Firefox View acts mostly the same, but does hide under the `DisableAccounts` policy (which we do not support).

This PR adds the ability to control the visibility of the Firefox View and sidebar tools based on the Sync enterprise policy. When Sync is locked and disabled by policy, or the OpenTabs engine is disabled with Sync enabled, the tools are hidden rather than surfacing a panel that can only show an error. When Sync is not locked by policy, the tools remain visible since they can show "Turn on Sync" messaging.

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

<img width="1512" height="900" alt="before-sync-disabled-locked" src="https://github.com/user-attachments/assets/281881b2-dd7d-450b-8806-4156f96822c1" />

_Before: Sync disabled and locked_

<img width="1512" height="900" alt="before-sync-enabled-locked-opentabs-on" src="https://github.com/user-attachments/assets/13036078-8f31-431a-82c6-034b9baeb7f0" />

_Before: Sync enabled and locked with OpenTabs on_

<img width="1512" height="900" alt="before-sync-enabled-locked-opentabs-off" src="https://github.com/user-attachments/assets/a69a50d1-2f6e-485b-a237-283ba2495532" />

_Before: Sync enabled and unlocked with OpenTabs off_

<img width="1512" height="900" alt="before-disableaccounts-true" src="https://github.com/user-attachments/assets/538685f7-259e-48f2-99de-7aac9b06f7bd" />

_Before: DisableAccounts true (not really relevant since unsupported, just showing one more state)_

<img width="1512" height="900" alt="after_opentabs_sync_disabled" src="https://github.com/user-attachments/assets/cb67c0f5-4f5b-4270-886d-f8e9a648ed14" />

_After: Sync disabled and locked (or enabled with OpenTabs disabled)_

<img width="1512" height="900" alt="after_opentabs_sync_enabled" src="https://github.com/user-attachments/assets/2eb3aeff-31d0-4657-a1ec-df9f3782b1fa" />

_After: Sync enabled and locked with OpenTabs on_

<img width="1512" height="900" alt="after-sync-enabled-unlocked-opentabs-false" src="https://github.com/user-attachments/assets/e7d5875c-3e55-4c45-a919-c407f20b8bc4" />

_After: Sync enabled and unlocked with OpenTabs off_

---

### Testing <!-- OPTIONAL -->

* [x] Added tests
* [x] Manual testing performed


**Steps to verify changes:**

1. Launch Firefox with a policy that locks Sync off and disables OpenTabs, e.g.:
`{ "policies": { "SyncSettings": { "Enabled": false, "TypeSettings": { "OpenTabs": false } } } }`
2. Open Firefox View and confirm the "Tabs from other devices" section is hidden. 
3. Open the sidebar customize/tools list and confirm the "Tabs from other devices" tool is absent and does not show in the sidebar settings.
4. Unlock the `Sync` policy or enable Sync and confirm "Tabs from other devices" is visible in both Firefox View and the sidebar.

**Expected result:**

"Tabs from other devices" is not present in either the sidebar or Firefox View when `Sync` policy:

- Is disabled and locked
- Is enabled and locked and `OpenTabs` is false

"Tabs from other devices" is present in either the sidebar or Firefox View when `Sync` policy:

- Is enabled and locked and `OpenTabs` is true
- Is enabled and unlocked and `OpenTabs` is true or false
