### PR TITLE
Bug 2021342 - Load encryption key from console earlier

### DIFF
--- a/browser/components/BrowserComponents.manifest
+++ b/browser/components/BrowserComponents.manifest
@@ -23,6 +23,7 @@ category browser-before-ui-startup resource:///modules/AccountsGlue.sys.mjs Acco
 category browser-before-ui-startup moz-src:///browser/modules/ObserverForwarder.sys.mjs ObserverForwarder.init
 #ifdef MOZ_ENTERPRISE
 category browser-before-ui-startup resource://gre/modules/enterprise/EnterpriseEndpoints.sys.mjs EnterpriseEndpoints.init
+category browser-before-ui-startup resource://gre/modules/enterprise/EnterpriseStorageEncryption.sys.mjs EnterpriseStorageEncryption.init
 #endif
 #ifdef XP_WIN
 category browser-before-ui-startup moz-src:///browser/components/shell/StartupOSIntegration.sys.mjs StartupOSIntegration.applyCustomIconOnStartup

--- a/browser/components/BrowserGlue.sys.mjs
+++ b/browser/components/BrowserGlue.sys.mjs
@@ -21,7 +21,6 @@ ChromeUtils.defineESModuleGetters(lazy, {
   BrowserUtils: "resource://gre/modules/BrowserUtils.sys.mjs",
   BrowserUsageTelemetry: "resource:///modules/BrowserUsageTelemetry.sys.mjs",
   BrowserWindowTracker: "resource:///modules/BrowserWindowTracker.sys.mjs",
-  ConsoleClient: "resource://gre/modules/enterprise/ConsoleClient.sys.mjs",
   ContentBlockingPrefs:
     "moz-src:///browser/components/protections/ContentBlockingPrefs.sys.mjs",
   ContextualIdentityService:
@@ -1109,78 +1108,6 @@ BrowserGlue.prototype = {
         task: async () => {
           await lazy.ContextualIdentityService.load();
           lazy.Discovery.update();
-        },
-      },
-
-      {
-        name: "EnterpriseStorageEncryption.load",
-        condition:
-          AppConstants.MOZ_ENTERPRISE &&
-          Services.prefs.getBoolPref(
-            "security.storage.encryption.enabled",
-            false
-          ),
-        task: async () => {
-          // A managed browser that cannot unlock its encrypted storage must not
-          // keep running: it would prompt for a primary secret the user does not
-          // know, or operate against a profile it cannot decrypt. Fail the launch
-          // with a dedicated exit code (Bug 2021342), mirroring the launcher-side
-          // abort in FeltProcessParent.
-          const fail = (msg, e) => {
-            console.error(
-              `EnterpriseStorageEncryption.load: ${msg}${e ? ": " + e : ""}`
-            );
-            Services.startup.quit(
-              Ci.nsIAppStartup.eForceQuit,
-              Ci.nsIFelt.FeltEncryptionExitCode_SdrTokenUnlockFailed
-            );
-          };
-
-          // The API returns { data: "secret_value" }.
-          let primarySecret;
-          try {
-            primarySecret = (await lazy.ConsoleClient.getPrimarySecret()).data;
-          } catch (e) {
-            fail("Failed to get primary secret", e);
-            return;
-          }
-          if (!primarySecret) {
-            fail("No primary secret in payload");
-            return;
-          }
-
-          let pk11token;
-          try {
-            pk11token = Cc[
-              "@mozilla.org/security/internalkeytoken;1"
-            ].createInstance(Ci.nsIPKCS11Token);
-          } catch (e) {
-            fail("Error getting PK11 token", e);
-            return;
-          }
-
-          // Ensure the internal token's password is the primarySecret.
-          if (!pk11token.hasPassword) {
-            try {
-              await pk11token.changePassword("", primarySecret);
-            } catch (e) {
-              fail("Failed to set the primary secret on the token", e);
-              return;
-            }
-          }
-
-          // changePassword does not authenticate the session, so log in
-          // explicitly and verify.
-          try {
-            const sdr = Cc["@mozilla.org/security/sdr;1"].getService(
-              Ci.nsISecretDecoderRing
-            );
-            if (!sdr.login(primarySecret) || !pk11token.isLoggedIn) {
-              fail("Internal token not logged in after unlock");
-            }
-          } catch (e) {
-            fail("SDR login failed", e);
-          }
         },
       },
     ];

--- a/toolkit/components/enterprise/modules/EnterpriseStorageEncryption.sys.mjs
+++ b/toolkit/components/enterprise/modules/EnterpriseStorageEncryption.sys.mjs
@@ -1,0 +1,89 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import { AppConstants } from "resource://gre/modules/AppConstants.sys.mjs";
+
+const lazy = {};
+
+ChromeUtils.defineESModuleGetters(lazy, {
+  ConsoleClient: "resource://gre/modules/enterprise/ConsoleClient.sys.mjs",
+});
+
+export const EnterpriseStorageEncryption = {
+  async init() {
+    if (
+      AppConstants.MOZ_ENTERPRISE &&
+      Services.prefs.getBoolPref(
+        "security.storage.encryption.enabled",
+        false
+      ) &&
+      !Services.felt?.isFeltUI()
+    ) {
+      await this.load();
+    }
+  },
+
+  async load() {
+    // A managed browser that cannot unlock its encrypted storage must not
+    // keep running: it would prompt for a primary secret the user does not
+    // know, or operate against a profile it cannot decrypt. Fail the launch
+    // with a dedicated exit code (Bug 2021342), mirroring the launcher-side
+    // abort in FeltProcessParent.
+    const fail = (msg, e) => {
+      console.error(
+        `EnterpriseStorageEncryption.load: ${msg}${e ? ": " + e : ""}`
+      );
+      Services.startup.quit(
+        Ci.nsIAppStartup.eForceQuit,
+        Ci.nsIFelt.FeltEncryptionExitCode_SdrTokenUnlockFailed
+      );
+    };
+
+    // The API returns { data: "secret_value" }.
+    let primarySecret;
+    try {
+      primarySecret = (await lazy.ConsoleClient.getPrimarySecret()).data;
+    } catch (e) {
+      fail("Failed to get primary secret", e);
+      return;
+    }
+    if (!primarySecret) {
+      fail("No primary secret in payload");
+      return;
+    }
+
+    let pk11token;
+    try {
+      pk11token = Cc["@mozilla.org/security/internalkeytoken;1"].createInstance(
+        Ci.nsIPKCS11Token
+      );
+    } catch (e) {
+      fail("Error getting PK11 token", e);
+      return;
+    }
+
+    // Ensure the internal token's password is the primarySecret.
+    if (!pk11token.hasPassword) {
+      try {
+        await pk11token.changePassword("", primarySecret);
+      } catch (e) {
+        fail("Failed to set the primary secret on the token", e);
+        return;
+      }
+    }
+
+    // changePassword does not authenticate the session, so log in
+    // explicitly and verify.
+    try {
+      const sdr = Cc["@mozilla.org/security/sdr;1"].getService(
+        Ci.nsISecretDecoderRing
+      );
+      if (!sdr.login(primarySecret) || !pk11token.isLoggedIn) {
+        fail("Internal token not logged in after unlock");
+      }
+    } catch (e) {
+      fail("SDR login failed", e);
+    }
+  },
+};

--- a/toolkit/components/enterprise/moz.build
+++ b/toolkit/components/enterprise/moz.build
@@ -14,6 +14,7 @@ EXTRA_JS_MODULES.enterprise += [
     "modules/EnterpriseEndpoints.sys.mjs",
     "modules/EnterpriseHandler.sys.mjs",
     "modules/EnterpriseOSInfo.sys.mjs",
+    "modules/EnterpriseStorageEncryption.sys.mjs",
     "modules/Updates.sys.mjs",
 ]
 


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2021342

Session restore of about:logins could expose a race condition where trying to access the primary password that should be filled from the console's sent primary secret is done but the code loading the secret from the console has not been ran yet.

Moving to browser-before-ui-startup startup phase.

### Testing <!-- OPTIONAL -->

* [x] Manual testing performed

**Preconditions:**

    Have passwords saved in about:logins
    Have the browser set to open tabs from the last session

**Steps**

    Open about:logins
    While on the about:logins page, sign out of the browser
    Reopen FxE

**Expected result**

    The browser opens up on the about:logins page