### PR TITLE
Bug 2061600 - Update non-existing es locale to existing es-ES

### DIFF
--- a/browser/locales/enterprise-l10n-changesets.json
+++ b/browser/locales/enterprise-l10n-changesets.json
@@ -21,7 +21,7 @@
         ],
         "revision": "d02e9a686ee0454f6bb41bf67fc09a16a14c9541"
     },
-    "es": {
+    "es-ES": {
         "pin": false,
         "platforms": [
             "linux64",


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2061600

Bug-2060543 added additional locales to `browser/locales/enterprise-l10n-changesets.json` including a non-existing `"es"` local, which needs to be updated to `"es-ES"`.

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->
