### PR TITLE
Bug 2062123 - Limit skeleton ui test to browser app

### DIFF
--- a/testing/enterprise/manifest.toml
+++ b/testing/enterprise/manifest.toml
@@ -102,7 +102,7 @@ run-if = [
 
 ["test_felt_browser_skeleton_ui.py"]
 run-if = [
-  "os == 'win'",
+  "os == 'win' && buildapp == 'browser'",
 ]
 
 ["test_felt_browser_starts.py"]


### PR DESCRIPTION
### Description <!-- REQUIRED -->

Bugzilla: Bug-2062123

This should not run on Thunderbird, so limit to browser app