### PR TITLE
Bug 2059588 - Add console bearer authentication to crash reports/pings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1422,6 +1422,7 @@ dependencies = [
  "fluent",
  "glean",
  "gtkbind",
+ "http",
  "intl-memoizer",
  "libloading",
  "log",

--- a/toolkit/components/enterprise/modules/ConsoleClient.sys.mjs
+++ b/toolkit/components/enterprise/modules/ConsoleClient.sys.mjs
@@ -749,12 +749,30 @@ export const ConsoleClient = {
       Services.obs.addObserver(this, "felt-firefox-access-token-refreshed");
       Services.obs.addObserver(this, "felt-firefox-shutdown");
 
+      // Seed the crash reporter with any token already available at startup.
+      this._syncCrashReporterAuthToken();
+
       this.consoleBaseURI.then(
         ({ hostname }) => lazy.ConsoleProxyBypassFilter.register(hostname),
         e => lazy.log.error("Failed to register console proxy bypass:", e)
       );
     }
     return this;
+  },
+
+  /**
+   * Hand the current access token to the crash reporter so it can authenticate
+   * crash report and crash ping uploads with the console.
+   * Called on every token update in the browser process.
+   */
+  _syncCrashReporterAuthToken() {
+    try {
+      Services.appinfo.setAuthToken(
+        Services.felt.getAccessTokenIfValid() || ""
+      );
+    } catch (e) {
+      lazy.log.warn("Failed to sync crash reporter auth token", e);
+    }
   },
 
   observe(_, topic) {
@@ -781,6 +799,8 @@ export const ConsoleClient = {
         this._refreshResolve?.();
         // The `finally()` block of our promise chain will
         // reset/nullify the promise.
+        // Keep the crash reporter's inherited token in sync.
+        this._syncCrashReporterAuthToken();
         break;
       }
       case "nsPref:changed": {

--- a/toolkit/crashreporter/CrashSubmit.sys.mjs
+++ b/toolkit/crashreporter/CrashSubmit.sys.mjs
@@ -2,6 +2,20 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { AppConstants } from "resource://gre/modules/AppConstants.sys.mjs";
+
+const lazy = {};
+
+// ConsoleClient only exists in enterprise builds (toolkit/components/enterprise
+// is gated on MOZ_ENTERPRISE), so only define the getter there.
+if (AppConstants.MOZ_ENTERPRISE) {
+  ChromeUtils.defineESModuleGetters(lazy, {
+    CONSOLE_ADDRESS_PREF:
+      "resource://gre/modules/enterprise/ConsoleClient.sys.mjs",
+    ConsoleClient: "resource://gre/modules/enterprise/ConsoleClient.sys.mjs",
+  });
+}
+
 const SUCCESS = "success";
 const FAILED = "failed";
 const SUBMITTING = "submitting";
@@ -46,6 +60,31 @@ async function writeSubmittedReportAsync(crashID, viewURL) {
   }
 
   await writeFileAsync("submitted", `${crashID}.txt`, data);
+}
+
+// Whether the given upload URL is the configured enterprise console, the only
+// destination the Felt bearer token may be sent to.
+function isConsoleURL(url) {
+  if (!AppConstants.MOZ_ENTERPRISE) {
+    return false;
+  }
+
+  let consoleAddress = Services.prefs.getStringPref(
+    lazy.CONSOLE_ADDRESS_PREF,
+    ""
+  );
+  if (!consoleAddress) {
+    return false;
+  }
+
+  try {
+    const origin = new URL(url).origin;
+    // "null" is the opaque origin of URLs like data: or file:, which must never
+    // compare equal to anything.
+    return origin !== "null" && origin === new URL(consoleAddress).origin;
+  } catch {
+    return false;
+  }
 }
 
 // the Submitter class represents an individual submission.
@@ -139,8 +178,10 @@ Submitter.prototype = {
       serverURL = envOverride;
     }
 
-    let xhr = new XMLHttpRequest();
-    xhr.open("POST", serverURL, true);
+    // Only ever send authentication token to the console URL.
+    let shouldAuthenticate = isConsoleURL(serverURL);
+
+    let didAuthRetry = false;
 
     let formData = new FormData();
 
@@ -197,8 +238,30 @@ Submitter.prototype = {
     let manager = Services.crashmanager;
     let submissionID = manager.generateSubmissionID();
 
-    xhr.addEventListener("readystatechange", () => {
+    // Called when the send itself fails (e.g. building or opening the request
+    // throws, or the promise chain below rejects) rather than producing a
+    // response.
+    let failSubmission = err => {
+      this.notifyStatus(FAILED, `failed to send crash report: ${err}`);
+      this.cleanup();
+    };
+
+    let onReadyStateChange = event => {
+      const xhr = event.target;
       if (xhr.readyState == 4) {
+        // Enterprise: if the console rejected the token, refresh it and retry
+        // once before falling through to the normal response handling below.
+        if (
+          AppConstants.MOZ_ENTERPRISE &&
+          shouldAuthenticate &&
+          !didAuthRetry &&
+          (xhr.status === 401 || xhr.status === 403) &&
+          Services.felt?.isFeltBrowser?.()
+        ) {
+          didAuthRetry = true;
+          send(true).catch(failSubmission);
+          return;
+        }
         let ret =
           xhr.status === 200 ? this.parseResponse(xhr.responseText) : {};
         let failmsg;
@@ -208,6 +271,12 @@ Submitter.prototype = {
               case 400:
                 return xhr.responseText;
 
+              case 401:
+                return "Discarded=unauthorized";
+
+              case 403:
+                return "Discarded=forbidden";
+
               case 413:
                 return "Discarded=post_body_too_large";
 
@@ -216,10 +285,11 @@ Submitter.prototype = {
             }
           };
           let err = xhrStatus(xhr.status);
-          if (err.length && err.startsWith("Discarded=")) {
+          const discardedPrefix = "Discarded=";
+          if (err.length && err.startsWith(discardedPrefix)) {
             // Place the error code after, otherwise JS will complain we start
             // with a number when dealing with the telemetry value on JS side
-            const errMsg = `${err.split("Discarded=")[1]}_${xhr.status}`;
+            const errMsg = `${err.substring(discardedPrefix.length)}_${xhr.status}`;
             Glean.crashSubmission.collectorErrors[errMsg].add();
             failmsg = `received bad response: ${xhr.status} ${err}`;
           }
@@ -257,7 +327,27 @@ Submitter.prototype = {
           }
         });
       }
-    });
+    };
+
+    // Enterprise auth as a thin wrapper around the send: fetch the bearer token
+    // (refreshing it when retrying), build the request, attach the (upstream)
+    // response handler, and send. The handler above calls this again with
+    // `refresh = true` to retry once after the console rejected the token.
+    let send = async refresh => {
+      let token = null;
+      if (shouldAuthenticate) {
+        token = refresh
+          ? await this.refreshAuthToken()
+          : await this.getAuthToken();
+      }
+      const xhr = new XMLHttpRequest();
+      xhr.open("POST", serverURL, true);
+      if (token) {
+        xhr.setRequestHeader("Authorization", `Bearer ${token}`);
+      }
+      xhr.addEventListener("readystatechange", onReadyStateChange);
+      xhr.send(formData);
+    };
 
     let p = Promise.all(promises);
     let id = this.id;
@@ -267,10 +357,37 @@ Submitter.prototype = {
         return manager.addSubmissionAttempt(id, submissionID, new Date());
       });
     }
-    p.then(() => {
-      xhr.send(formData);
-    });
+    p.then(() => send(false)).catch(failSubmission);
     return true;
+  },
+
+  // Returns the Felt access token used to authenticate uploads to the
+  // enterprise admin console, or null for non-enterprise builds (where uploads
+  // remain unauthenticated). Never throws: on failure the report is sent
+  // unauthenticated and recorded as a failed submission.
+  async getAuthToken() {
+    if (!AppConstants.MOZ_ENTERPRISE || !Services.felt?.isFeltBrowser?.()) {
+      return null;
+    }
+    try {
+      return await lazy.ConsoleClient.getAccessToken();
+    } catch {
+      return null;
+    }
+  },
+
+  // Force a Felt token refresh and return the new access token, or null on
+  // failure. Never throws; used to retry a submission rejected with 401/403.
+  async refreshAuthToken() {
+    if (!AppConstants.MOZ_ENTERPRISE || !Services.felt?.isFeltBrowser?.()) {
+      return null;
+    }
+    try {
+      await lazy.ConsoleClient._refreshSession();
+      return await lazy.ConsoleClient.getAccessToken();
+    } catch {
+      return null;
+    }
   },
 
   // `ret` is determined based on `status`:

--- a/toolkit/crashreporter/client/app/Cargo.toml
+++ b/toolkit/crashreporter/client/app/Cargo.toml
@@ -15,6 +15,7 @@ env_logger = { version = "0.10", default-features = false }
 flate2 = "1"
 fluent = "0.17.0"
 glean = { workspace = true }
+http = "1.4"
 intl-memoizer = "0.5"
 libloading = "0.8"
 log = "0.4.17"

--- a/toolkit/crashreporter/client/app/src/enterprise_prefs.rs
+++ b/toolkit/crashreporter/client/app/src/enterprise_prefs.rs
@@ -65,6 +65,29 @@ pub fn console_glean_url(server_url: Option<&str>) -> anyhow::Result<String> {
     Ok(url.to_string())
 }
 
+/// Whether `url` is on the configured enterprise console.
+///
+/// Unlike [`console_base`], the console address is only taken from AutoConfig:
+/// the URL being validated cannot vouch for itself.
+pub fn is_console_url(url: &str) -> bool {
+    match same_origin_as_console(url) {
+        Ok(result) => result,
+        Err(e) => {
+            log::warn!("could not check {url} against the enterprise console address: {e:#}");
+            false
+        }
+    }
+}
+
+fn same_origin_as_console(url: &str) -> anyhow::Result<bool> {
+    let url = Url::parse(url)?;
+    let console = Url::parse(&read_autoconfig_string_pref(CONSOLE_ADDRESS_PREF)?)?;
+    let origin = url.origin();
+    // Opaque origins (such as that of a `data:` URL) must never match, not even
+    // each other.
+    Ok(origin.is_tuple() && origin == console.origin())
+}
+
 /// Resolve the enterprise console base URL (without a trailing slash).
 ///
 /// Resolution order:
@@ -192,6 +215,44 @@ mod test {
             );
             anyhow::Ok(())
         })
+    }
+
+    #[test]
+    fn console_url_matches_console_origin() {
+        with_autoconfig(|| {
+            // Any path on the console origin is the console.
+            assert!(is_console_url(
+                "https://console.example.com/foo/api/browser/crash-reports/submit"
+            ));
+            assert!(is_console_url("https://console.example.com/"));
+        });
+    }
+
+    #[test]
+    fn console_url_rejects_other_urls() {
+        with_autoconfig(|| {
+            // A different host, scheme or port is not the console.
+            assert!(!is_console_url("https://evil.example.com/foo"));
+            assert!(!is_console_url("http://console.example.com/foo"));
+            assert!(!is_console_url("https://console.example.com:8443/foo"));
+            // Nor is a url with an opaque origin, or one we cannot parse.
+            assert!(!is_console_url("data:text/plain,hello"));
+            assert!(!is_console_url("/submit?id=x"));
+        });
+    }
+
+    #[test]
+    fn console_url_rejects_without_autoconfig() {
+        let mock_files = MockFiles::new();
+        mock::builder()
+            .set(MockFS, mock_files.clone())
+            .set(
+                crate::std::env::MockCurrentExe,
+                "work_dir/crashreporter".into(),
+            )
+            .run(|| {
+                assert!(!is_console_url("https://console.example.com/foo"));
+            });
     }
 
     #[test]

--- a/toolkit/crashreporter/client/app/src/glean.rs
+++ b/toolkit/crashreporter/client/app/src/glean.rs
@@ -181,23 +181,41 @@ mod uploader {
     impl PingUploader for Uploader {
         fn upload(&self, upload_request: CapablePingUploadRequest) -> UploadResult {
             let upload_request = upload_request.capable(|cap| cap.is_empty()).unwrap();
-            let request_builder = http::RequestBuilder::Post {
-                body: upload_request.body.as_slice(),
-                headers: upload_request.headers.as_slice(),
-            };
 
-            let do_send = move || match request_builder.build(upload_request.url.as_ref()) {
-                Err(e) => {
-                    log::error!("failed to build request for glean ping: {e}");
-                    UploadResult::unrecoverable_failure()
-                }
-                Ok(request) => match request.send() {
-                    Err(e) => {
-                        log::error!("failed to send glean ping: {e:#}");
-                        UploadResult::recoverable_failure()
+            let do_send = move || {
+                cfg_if::cfg_if! {
+                    if #[cfg(feature = "enterprise")] {
+                        let mut pairs = upload_request.headers.clone();
+                        let auth = crate::net::auth::enterprise_authorization_header(
+                            upload_request.url.as_ref(),
+                        );
+                        if let Some(header) = auth {
+                            pairs.push(header);
+                        }
+                        let headers = http::header_map_from_pairs(pairs);
+                    } else {
+                        let headers = http::header_map_from_pairs(upload_request.headers.clone());
                     }
-                    Ok(_) => UploadResult::http_status(200),
-                },
+                }
+
+                let request_builder = http::RequestBuilder::Post {
+                    body: upload_request.body.as_slice(),
+                    headers,
+                };
+
+                match request_builder.build(upload_request.url.as_ref()) {
+                    Err(e) => {
+                        log::error!("failed to build request for glean ping: {e}");
+                        UploadResult::unrecoverable_failure()
+                    }
+                    Ok(request) => match request.send() {
+                        Err(e) => {
+                            log::error!("failed to send glean ping: {e:#}");
+                            UploadResult::recoverable_failure()
+                        }
+                        Ok(_) => UploadResult::http_status(200),
+                    },
+                }
             };
 
             #[cfg(mock)]

--- a/toolkit/crashreporter/client/app/src/logic.rs
+++ b/toolkit/crashreporter/client/app/src/logic.rs
@@ -650,6 +650,10 @@ impl ReportCrash {
             dump_file: self.config.dump_file(),
             memory_file: memory_file.as_deref(),
             url,
+            #[cfg(feature = "enterprise")]
+            auth_headers: net::http::header_map_from_pairs(
+                net::auth::enterprise_authorization_header(url),
+            ),
         };
 
         let report_response = async_scoped_thread(|| report.send())

--- a/toolkit/crashreporter/client/app/src/net/auth.rs
+++ b/toolkit/crashreporter/client/app/src/net/auth.rs
@@ -1,0 +1,86 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! Best-effort Felt bearer token for authenticating enterprise crash uploads.
+//!
+//! In Firefox Enterprise, crash reports and crash pings are uploaded to the
+//! admin console, which requires the same bearer token used for other console
+//! communication. The crashing Firefox process exports its current access token
+//! into its environment as `MOZ_CRASHREPORTER_AUTH_TOKEN`; the crash reporter
+//! client (and the `crashreporterNetworkBackend` background task it may spawn)
+//! inherit that environment and attach it as an `Authorization` header.
+//!
+//! This is best-effort: only the access token that was valid at crash time is
+//! available (the refresh token never leaves the Felt UI process), so there is
+//! no way to refresh it here. If the token is missing or the server rejects it,
+//! the upload is sent unauthenticated (and a pending report is retried later by
+//! an authenticated in-process session).
+
+/// Return an `Authorization: Bearer` header for an upload to `url`, built from
+/// the access token that the crashing process exported into the environment.
+///
+/// Returns `None` if no token is present (non-enterprise builds, or a crash
+/// before sign-in), or if `url` is not on the enterprise console.
+pub fn enterprise_authorization_header(url: &str) -> Option<(String, String)> {
+    let token = crate::std::env::var(ekey!("AUTH_TOKEN")).ok()?;
+    if token.is_empty() {
+        return None;
+    }
+    if !crate::enterprise_prefs::is_console_url(url) {
+        log::warn!("not authenticating the upload: {url} is not the enterprise console");
+        return None;
+    }
+    Some(("Authorization".to_owned(), format!("Bearer {token}")))
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::std::{
+        env::{MockCurrentExe, MockEnv},
+        fs::{MockFS, MockFiles},
+        mock,
+    };
+
+    const CONSOLE_URL: &str = "https://console.example.com/api/browser/crash-reports/submit";
+
+    fn run_with_env(value: Option<&str>, url: &str) -> Option<(String, String)> {
+        let files = MockFiles::new();
+        files.add_dir("work_dir").add_file(
+            "work_dir/firefox.cfg",
+            crate::test::enterprise_autoconfig("https://console.example.com"),
+        );
+
+        let mut builder = mock::builder();
+        builder
+            .set(MockFS, files)
+            .set(MockCurrentExe, "work_dir/crashreporter".into());
+        if let Some(value) = value {
+            builder.set(MockEnv(ekey!("AUTH_TOKEN").into()), value.to_owned());
+        }
+        builder.run(|| enterprise_authorization_header(url))
+    }
+
+    #[test]
+    fn token_present_yields_header() {
+        let header = run_with_env(Some("abc"), CONSOLE_URL).expect("expected a header");
+        assert_eq!(header.0, "Authorization");
+        assert_eq!(header.1, "Bearer abc");
+    }
+
+    #[test]
+    fn empty_token_yields_none() {
+        assert!(run_with_env(Some(""), CONSOLE_URL).is_none());
+    }
+
+    #[test]
+    fn missing_token_yields_none() {
+        assert!(run_with_env(None, CONSOLE_URL).is_none());
+    }
+
+    #[test]
+    fn non_console_url_yields_none() {
+        assert!(run_with_env(Some("abc"), "https://evil.example.com/submit").is_none());
+    }
+}

--- a/toolkit/crashreporter/client/app/src/net/http.rs
+++ b/toolkit/crashreporter/client/app/src/net/http.rs
@@ -19,8 +19,11 @@ use crate::std::{
     sync::atomic::{AtomicUsize, Ordering::Relaxed},
 };
 use anyhow::Context;
+pub use http::HeaderMap;
+use http::{header::AUTHORIZATION, HeaderName, HeaderValue};
 use once_cell::sync::Lazy;
 use serde::Serialize;
+use std::str::FromStr;
 
 #[cfg(mock)]
 use crate::std::mock::{mock_key, MockKey};
@@ -108,20 +111,70 @@ std::mock::mocked_static! {
 
 /*
  * IMPORTANT! Keep the serialized JSON format for RequestBuilder compatible with
- * toolkit/crashreporter/networking/BackgroundTask_crashNetwork.sys.mjs
+ * toolkit/crashreporter/networking/BackgroundTask_crashreporterNetworkBackend.sys.mjs
  */
 
 /// Types of requests that can be created.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(tag = "type")]
 pub enum RequestBuilder<'a> {
     /// Send a POST with multiple mime parts.
-    MimePost { parts: Vec<MimePart<'a>> },
+    MimePost {
+        parts: Vec<MimePart<'a>>,
+        #[serde(serialize_with = "serialize_headers")]
+        headers: HeaderMap,
+    },
     /// Send a POST.
     Post {
         body: &'a [u8],
-        headers: &'a [(String, String)],
+        #[serde(serialize_with = "serialize_headers")]
+        headers: HeaderMap,
     },
+}
+
+/// Build a [`HeaderMap`] from name/value string pairs, dropping (with a warning)
+/// any entries that are not valid HTTP headers.
+///
+/// Using the typed [`HeaderName`]/[`HeaderValue`] here guarantees the header
+/// names and values cannot contain CR/LF, NUL, or other control characters, so
+/// they cannot inject additional headers or corrupt request framing when later
+/// formatted for curl/libcurl. The `Authorization` value is additionally marked
+/// sensitive so it is redacted from debug logging.
+pub fn header_map_from_pairs(pairs: impl IntoIterator<Item = (String, String)>) -> HeaderMap {
+    let mut map = HeaderMap::new();
+    for (name, value) in pairs {
+        match (HeaderName::from_str(&name), HeaderValue::from_str(&value)) {
+            (Ok(name), Ok(mut value)) => {
+                if name == AUTHORIZATION {
+                    value.set_sensitive(true);
+                }
+                map.append(name, value);
+            }
+            _ => log::warn!("dropping invalid crash upload header {name:?}"),
+        }
+    }
+    map
+}
+
+/// Format a header as a `name: value` line for curl/libcurl.
+/// We only construct HeaderValues with from_str so to_str is safe to unwrap.
+fn curl_header_line(name: &HeaderName, value: &HeaderValue) -> String {
+    format!("{}: {}", name.as_str(), value.to_str().unwrap())
+}
+
+/// Serialize a [`HeaderMap`] as an array of `[name, value]` pairs, matching the
+/// JSON format expected by `BackgroundTask_crashreporterNetworkBackend.sys.mjs`.
+fn serialize_headers<S>(headers: &HeaderMap, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    use serde::ser::SerializeSeq;
+    let mut seq = serializer.serialize_seq(Some(headers.len()))?;
+    for (name, value) in headers.iter() {
+        let value = value.to_str().map_err(serde::ser::Error::custom)?;
+        seq.serialize_element(&(name.as_str(), value))?;
+    }
+    seq.end()
 }
 
 /// A single mime part to send.
@@ -156,6 +209,7 @@ pub enum Request<'a> {
     CurlChild {
         child: Child,
         stdin: Option<Box<dyn Read + Send + 'static>>,
+        header_file: Option<TempRequestFile>,
     },
     LibCurl {
         easy: super::libcurl::Easy<'static>,
@@ -265,17 +319,23 @@ impl<'a> RequestBuilder<'a> {
         cmd.arg("--fail");
         cmd.args(["--user-agent", user_agent()]);
 
+        // Headers are passed in a (randomly named) file to avoid leaking `Authorization` bearer
+        // token in readable process arguments.
+        let header_file = self.curl_header_file()?;
+        if let Some(header_file) = &header_file {
+            cmd.arg("--header");
+            let mut arg = std::ffi::OsString::from("@");
+            arg.push(&header_file.path);
+            cmd.arg(arg);
+        }
+
         match self {
-            Self::MimePost { parts } => {
+            Self::MimePost { parts, .. } => {
                 for part in parts {
                     part.curl_command_args(&mut cmd, &mut stdin)?;
                 }
             }
-            Self::Post { body, headers } => {
-                for (k, v) in headers.iter() {
-                    cmd.args(["--header", &format!("{k}: {v}")]);
-                }
-
+            Self::Post { body, .. } => {
                 cmd.args(["--data-binary", "@-"]);
                 stdin = Some(Box::new(std::io::Cursor::new(body.to_vec())));
             }
@@ -287,8 +347,29 @@ impl<'a> RequestBuilder<'a> {
         cmd.stdout(std::process::Stdio::piped());
         cmd.stderr(std::process::Stdio::piped());
 
-        cmd.spawn()
-            .map(move |child| Request::CurlChild { child, stdin })
+        cmd.spawn().map(move |child| Request::CurlChild {
+            child,
+            stdin,
+            header_file,
+        })
+    }
+
+    /// Write the request headers to a temporary file, if there are any.
+    fn curl_header_file(&self) -> std::io::Result<Option<TempRequestFile>> {
+        use std::io::Write;
+
+        let headers = match self {
+            Self::MimePost { headers, .. } | Self::Post { headers, .. } => headers,
+        };
+        if headers.is_empty() {
+            return Ok(None);
+        }
+
+        let mut file = TempRequestFile::new_curl_headers()?;
+        for (name, value) in headers.iter() {
+            writeln!(&mut *file, "{}", curl_header_line(name, value))?;
+        }
+        Ok(Some(file))
     }
 
     /// Send the request with the `curl` library.
@@ -301,7 +382,15 @@ impl<'a> RequestBuilder<'a> {
         easy.set_max_redirs(30)?;
 
         match self {
-            Self::MimePost { parts } => {
+            Self::MimePost { parts, headers } => {
+                if !headers.is_empty() {
+                    let mut header_list = easy.slist();
+                    for (name, value) in headers.iter() {
+                        header_list.append(&curl_header_line(name, value))?;
+                    }
+                    easy.set_headers(header_list)?;
+                }
+
                 let mut mime = easy.mime()?;
 
                 for part in parts {
@@ -312,8 +401,8 @@ impl<'a> RequestBuilder<'a> {
             }
             Self::Post { body, headers } => {
                 let mut header_list = easy.slist();
-                for (k, v) in headers.iter() {
-                    header_list.append(&format!("{k}: {v}"))?;
+                for (name, value) in headers.iter() {
+                    header_list.append(&curl_header_line(name, value))?;
                 }
                 easy.set_headers(header_list)?;
 
@@ -345,26 +434,35 @@ pub struct TempRequestFile {
     file: ManuallyDrop<File>,
 }
 
-static REQUEST_NUM: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
-
 impl TempRequestFile {
     fn new() -> std::io::Result<Self> {
-        // Incorporate process id and a process-unique id to avoid runtime conflicts.
+        Self::create("request", "json")
+    }
+
+    /// Create a file containing curl headers rather than a serialized request.
+    fn new_curl_headers() -> std::io::Result<Self> {
+        Self::create("headers", "txt")
+    }
+
+    fn create(kind: &str, extension: &str) -> std::io::Result<Self> {
+        // Incorporate a random component to avoid conflicts and so that the path cannot be
+        // guessed by another process (the contents may include sensitive headers).
         let path = std::env::temp_dir().join(format!(
-            "{}{}-request{}.json",
-            env!("CARGO_PKG_NAME"),
-            std::process::id(),
-            REQUEST_NUM.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            "{kind}-{}.{extension}",
+            uuid::Uuid::new_v4().simple()
         ));
         if let Some(p) = path.parent() {
             std::fs::create_dir_all(p)?;
         }
-        let file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .open(&path)?;
+        let mut options = OpenOptions::new();
+        // `create_new` guarantees we never write into a file (or symlink) that already exists.
+        options.read(true).write(true).create_new(true);
+        #[cfg(all(unix, not(mock)))]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let file = options.open(&path)?;
         Ok(TempRequestFile {
             path,
             file: ManuallyDrop::new(file),
@@ -501,7 +599,11 @@ impl Request<'_> {
                     builder.send_with_curl(url).context("curl error")?.send()
                 })?
             }
-            Self::CurlChild { mut child, stdin } => {
+            Self::CurlChild {
+                mut child,
+                stdin,
+                header_file,
+            } => {
                 if let Some(mut stdin) = stdin {
                     let mut child_stdin = child
                         .stdin
@@ -515,6 +617,8 @@ impl Request<'_> {
                 let output = child
                     .wait_with_output()
                     .context("failed to wait on curl process")?;
+                // Only delete the header file once curl has read it.
+                drop(header_file);
                 anyhow::ensure!(
                     output.status.success(),
                     "process failed (exit status {}) with stderr: {}",

--- a/toolkit/crashreporter/client/app/src/net/mod.rs
+++ b/toolkit/crashreporter/client/app/src/net/mod.rs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#[cfg(feature = "enterprise")]
+pub mod auth;
 pub mod http;
 mod libcurl;
 pub mod ping;

--- a/toolkit/crashreporter/client/app/src/net/report.rs
+++ b/toolkit/crashreporter/client/app/src/net/report.rs
@@ -35,6 +35,9 @@ pub struct CrashReport<'a> {
     pub dump_file: &'a Path,
     pub memory_file: Option<&'a Path>,
     pub url: &'a str,
+    /// Extra HTTP headers (e.g. an enterprise `Authorization` header).
+    #[cfg(feature = "enterprise")]
+    pub auth_headers: http::HeaderMap,
 }
 
 impl CrashReport<'_> {
@@ -87,7 +90,14 @@ impl CrashReport<'_> {
                 })
             }
 
-            request = Some(http::RequestBuilder::MimePost { parts }.build(self.url)?);
+            cfg_if::cfg_if! {
+                if #[cfg(feature = "enterprise")] {
+                    let headers = self.auth_headers.clone();
+                } else {
+                    let headers = Default::default();
+                }
+            };
+            request = Some(http::RequestBuilder::MimePost { parts, headers }.build(self.url)?);
         }
 
         let response = request.unwrap().send()?;
@@ -146,6 +156,8 @@ mod test {
                 dump_file: Path::new("minidump.dmp"),
                 memory_file,
                 url: "reports.example.com".as_ref(),
+                #[cfg(feature = "enterprise")]
+                auth_headers: Default::default(),
             };
 
             let checked = crate::test::Counter::new();
@@ -180,7 +192,13 @@ mod test {
                                     mime_type: None,
                                 });
                             }
-                            assert_eq!(request, &http::RequestBuilder::MimePost { parts });
+                            assert_eq!(
+                                request,
+                                &http::RequestBuilder::MimePost {
+                                    parts,
+                                    headers: Default::default(),
+                                }
+                            );
 
                             Ok(Ok(vec![]))
                         }
@@ -192,6 +210,48 @@ mod test {
         }
     }
 
+    #[cfg(feature = "enterprise")]
+    #[test]
+    fn report_auth_headers() {
+        let report = CrashReport {
+            extra: &serde_json::json! {{}},
+            dump_file: Path::new("minidump.dmp"),
+            memory_file: None,
+            url: "reports.example.com".as_ref(),
+            auth_headers: http::header_map_from_pairs([(
+                "Authorization".to_owned(),
+                "Bearer abc".to_owned(),
+            )]),
+        };
+
+        let checked = crate::test::Counter::new();
+
+        mock::builder()
+            .set(
+                http::MockHttp,
+                Box::new(cc!(
+                    (checked)
+                    move |request, _url| {
+                        checked.inc();
+                        match request {
+                            http::RequestBuilder::MimePost { headers, .. } => {
+                                assert_eq!(headers.len(), 1);
+                                assert_eq!(
+                                    headers.get("authorization").unwrap().to_str().unwrap(),
+                                    "Bearer abc"
+                                );
+                            }
+                            _ => panic!("expected a MimePost request"),
+                        }
+                        Ok(Ok(vec![]))
+                    }
+                )),
+            )
+            .run(|| report.send().unwrap());
+
+        checked.assert_one();
+    }
+
     #[test]
     fn report_response() {
         let report = CrashReport {
@@ -199,6 +259,8 @@ mod test {
             dump_file: Path::new("minidump.dmp"),
             memory_file: None,
             url: "reports.example.com".as_ref(),
+            #[cfg(feature = "enterprise")]
+            auth_headers: Default::default(),
         };
 
         mock::builder()

--- a/toolkit/crashreporter/client/app/src/std/fs.rs
+++ b/toolkit/crashreporter/client/app/src/std/fs.rs
@@ -337,6 +337,7 @@ pub struct OpenOptions {
     write: bool,
     truncate: bool,
     create: bool,
+    create_new: bool,
 }
 
 macro_rules! flag_setter {
@@ -355,6 +356,7 @@ impl OpenOptions {
             write: false,
             truncate: false,
             create: false,
+            create_new: false,
         }
     }
 
@@ -362,6 +364,7 @@ impl OpenOptions {
     flag_setter!(write);
     flag_setter!(truncate);
     flag_setter!(create);
+    flag_setter!(create_new);
 
     pub fn open(&self, path: impl AsRef<Path>) -> Result<File> {
         let path = path.as_ref();
@@ -370,13 +373,17 @@ impl OpenOptions {
             files
                 .parent_dir(path, move |d| -> Result<File> {
                     let content = if let Some(item) = d.get(name) {
-                        match &item.content {
-                            MockFSContent::File(result) => {
-                                result.as_ref().cloned().map_err(|e| e.kind())
+                        if self.create_new {
+                            Err(ErrorKind::AlreadyExists)
+                        } else {
+                            match &item.content {
+                                MockFSContent::File(result) => {
+                                    result.as_ref().cloned().map_err(|e| e.kind())
+                                }
+                                MockFSContent::Dir(_) => Err(ErrorKind::NotFound),
                             }
-                            MockFSContent::Dir(_) => Err(ErrorKind::NotFound),
                         }
-                    } else if !self.create {
+                    } else if !self.create && !self.create_new {
                         Err(ErrorKind::NotFound)
                     } else {
                         let content = MockFileContent::default();

--- a/toolkit/crashreporter/client/app/src/test.rs
+++ b/toolkit/crashreporter/client/app/src/test.rs
@@ -164,6 +164,18 @@ fn test_config() -> Config {
     cfg
 }
 
+/// The contents of an enterprise AutoConfig file setting the console address.
+///
+/// Real files are byte-shifted, but plaintext is also supported (see
+/// `enterprise_prefs::read_autoconfig_string_pref`).
+#[cfg(feature = "enterprise")]
+pub fn enterprise_autoconfig(console_address: &str) -> String {
+    format!(
+        "// first line is ignored\n\
+         lockPref(\"enterprise.console.address\", \"{console_address}\");"
+    )
+}
+
 fn init_test_logger() {
     static INIT: std::sync::Once = std::sync::Once::new();
     INIT.call_once(|| {
@@ -208,6 +220,15 @@ impl GuiTest {
                 Ok(compact_json(MOCK_MINIDUMP_EXTRA).into()),
                 current_system_time(),
             );
+
+        // Enterprise builds read the console address from the installation's
+        // AutoConfig file to decide whether an upload may be authenticated;
+        // point it at the report url used by the mocked crash annotations.
+        #[cfg(feature = "enterprise")]
+        mock_files.add_dir("work_dir").add_file(
+            "work_dir/firefox.cfg",
+            enterprise_autoconfig("https://reports.example.com"),
+        );
 
         // Create a default mock environment which allows successful operation.
         let mut mock = mock::builder();
@@ -307,10 +328,15 @@ impl GuiTest {
 
     /// Get the file assertion helper.
     pub fn assert_files(&self) -> AssertFiles {
+        #[cfg_attr(not(feature = "enterprise"), allow(unused_mut))]
+        let mut inner = self.files.assert_files();
+        // Part of the test setup rather than of what the application wrote.
+        #[cfg(feature = "enterprise")]
+        inner.ignore("work_dir/firefox.cfg");
         AssertFiles {
             data_dir: "data_dir".into(),
             events_dir: "events_dir".into(),
-            inner: self.files.assert_files(),
+            inner,
         }
     }
 }
@@ -1378,7 +1404,8 @@ fn background_task_network_backend() {
                             "value": platform_path("data_dir/pending/minidump.memory.json.gz"),
                         },
                     }
-                ]
+                ],
+                "headers": []
             })
             .to_string();
 
@@ -1403,6 +1430,183 @@ fn background_task_network_backend() {
             Ok(crate::std::process::success_output())
         }),
     );
+    test.run(|interact| {
+        interact.element("quit", |_style, b: &model::Button| b.click.fire(&()));
+    });
+
+    ran_process.assert_one();
+
+    test.assert_files()
+        .saved_settings(Settings::default())
+        .submitted();
+}
+
+
+
+/// Test the interface to the primary network backend (Necko, through a background task)
+/// and that the invocation includes the authorization header
+///
+/// This doesn't yet test Glean pings because of reliability issues (see Bug 1937295).
+#[cfg(feature = "enterprise")]
+#[test]
+fn background_task_network_backend_with_authorization_header() {
+    let mut test = GuiTest::new();
+    test.files.add_file("minidump.memory.json.gz", "");
+    let ran_process = Counter::new();
+    let mock_ran_process = ran_process.clone();
+    test.mock
+        .set(
+            crate::std::env::MockEnv("MOZ_CRASHREPORTER_AUTH_TOKEN".into()),
+            "SomeToken".into()
+        )
+        .set(
+            Command::mock("work_dir/firefox"),
+            Box::new(move |cmd| {
+                if cmd.spawning {
+                    return Ok(crate::std::process::success_output());
+                }
+
+                mock_ran_process.inc();
+
+                let expected_args: Vec<OsString> = [
+                    "--backgroundtask",
+                    "crashreporterNetworkBackend",
+                    "https://reports.example.com",
+                    net::http::user_agent(),
+                ]
+                .into_iter()
+                .map(Into::into)
+                .collect();
+
+                assert_eq!(cmd.args.len(), 5);
+                assert_eq!(cmd.args[..4], expected_args);
+                let request_file = &cmd.args[4];
+
+                let expected_contents = serde_json::json!({
+                    "type": "MimePost",
+                    "parts": [
+                        {
+                            "name": "extra",
+                            "content": {
+                                "type": "String",
+                                "value": serde_json::json!({
+                                    "Vendor":"FooCorp",
+                                    "ProductName":"Bar",
+                                    "ReleaseChannel":"release",
+                                    "BuildID":"1234",
+                                    "AsyncShutdownTimeout":"{}",
+                                    "StackTraces":"{}",
+                                    "Version":"100.0",
+                                    "URL":"https://url.example.com",
+                                    "Throttleable":"1",
+                                    "CrashTime": current_unix_time().to_string(),
+                                    "MinidumpSha256Hash": MOCK_MINIDUMP_SHA256,
+                                    "SubmittedFrom":"Client",
+                                }).to_string(),
+                            },
+                            "filename": "extra.json",
+                            "mime_type": "application/json",
+                        },
+                        {
+                            "name": "upload_file_minidump",
+                            "content": {
+                                "type": "File",
+                                "value": platform_path("data_dir/pending/minidump.dmp"),
+                            },
+                        },
+                        {
+                            "name": "memory_report",
+                            "content": {
+                                "type": "File",
+                                "value": platform_path("data_dir/pending/minidump.memory.json.gz"),
+                            },
+                        }
+                    ],
+                    "headers": [["authorization", "Bearer SomeToken"]]
+                })
+                .to_string();
+
+                use ::std::io::{Read, Seek, Write};
+                let mut file = OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .open(request_file)
+                    .expect("cannot open request file");
+                {
+                    let mut contents = String::new();
+                    file.read_to_string(&mut contents)
+                        .expect("cannot read request file");
+                    assert_eq!(contents, expected_contents);
+                }
+
+                file.rewind().expect("cannot rewind file");
+                file.set_len(0).expect("cannot truncate file");
+                file.write_all(format!("CrashID={MOCK_REMOTE_CRASH_ID}").as_bytes())
+                    .expect("cannot write to request file");
+
+                Ok(crate::std::process::success_output())
+            }),
+        );
+    test.run(|interact| {
+        interact.element("quit", |_style, b: &model::Button| b.click.fire(&()));
+    });
+
+    ran_process.assert_one();
+
+    test.assert_files()
+        .saved_settings(Settings::default())
+        .submitted();
+}
+
+/// Test that the authorization header is not written to the background task's request
+/// file when the report url isn't the enterprise console. The request file is on disk, so
+/// the token must not reach it at all.
+#[cfg(feature = "enterprise")]
+#[test]
+fn background_task_network_backend_omits_authorization_header_for_other_url() {
+    let mut test = GuiTest::new();
+    test.config.report_url = Some("https://evil.example.com".into());
+    let ran_process = Counter::new();
+    let mock_ran_process = ran_process.clone();
+    test.mock
+        .set(
+            crate::std::env::MockEnv("MOZ_CRASHREPORTER_AUTH_TOKEN".into()),
+            "SomeToken".into(),
+        )
+        .set(
+            Command::mock("work_dir/firefox"),
+            Box::new(move |cmd| {
+                if cmd.spawning {
+                    return Ok(crate::std::process::success_output());
+                }
+
+                mock_ran_process.inc();
+
+                assert_eq!(cmd.args[2], OsString::from("https://evil.example.com"));
+                let request_file = &cmd.args[4];
+
+                use ::std::io::{Read, Seek, Write};
+                let mut file = OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .open(request_file)
+                    .expect("cannot open request file");
+                {
+                    let mut contents = String::new();
+                    file.read_to_string(&mut contents)
+                        .expect("cannot read request file");
+                    assert!(contents.contains(r#""headers":[]"#), "{contents}");
+                    assert!(!contents.contains("SomeToken"), "{contents}");
+                }
+
+                file.rewind().expect("cannot rewind file");
+                file.set_len(0).expect("cannot truncate file");
+                file.write_all(format!("CrashID={MOCK_REMOTE_CRASH_ID}").as_bytes())
+                    .expect("cannot write to request file");
+
+                Ok(crate::std::process::success_output())
+            }),
+        );
     test.run(|interact| {
         interact.element("quit", |_style, b: &model::Button| b.click.fire(&()));
     });
@@ -1462,6 +1666,136 @@ fn curl_binary() {
             Ok(output)
         }),
     );
+    test.run(|interact| {
+        interact.element("quit", |_style, b: &model::Button| b.click.fire(&()));
+    });
+
+    ran_process.assert_one();
+}
+
+/// Assert that the curl arguments pass a header file (`--header @file`) with the given contents,
+/// returning the arguments with the `--header` option removed.
+#[cfg(feature = "enterprise")]
+fn take_curl_header_file(args: &[OsString], expected_contents: &str) -> Vec<OsString> {
+    use ::std::io::Read;
+
+    let index = args
+        .iter()
+        .position(|a| a == "--header")
+        .expect("no --header argument");
+
+    let arg = args[index + 1].to_str().expect("invalid --header argument");
+    let path = arg.strip_prefix('@').expect("--header value is not a file");
+
+    let mut file = OpenOptions::new()
+        .read(true)
+        .open(path)
+        .expect("cannot open curl header file");
+    let mut contents = String::new();
+    file.read_to_string(&mut contents)
+        .expect("cannot read curl header file");
+    assert_eq!(contents, expected_contents);
+
+    let mut args = args.to_vec();
+    args.drain(index..index + 2);
+    args
+}
+
+#[cfg(feature = "enterprise")]
+#[test]
+fn curl_binary_with_authorization_header() {
+    let mut test = GuiTest::new();
+    test.files.add_file("minidump.memory.json.gz", "");
+    let ran_process = Counter::new();
+    let mock_ran_process = ran_process.clone();
+    test.mock
+        .set(
+            crate::std::env::MockEnv("MOZ_CRASHREPORTER_AUTH_TOKEN".into()),
+            "SomeToken".into()
+        )
+        .set(
+            Command::mock("curl"),
+            Box::new(move |cmd| {
+                if cmd.spawning {
+                    return Ok(crate::std::process::success_output());
+                }
+
+                // Curl strings need backslashes escaped.
+                let curl_escaped_separator = if std::path::MAIN_SEPARATOR == '\\' {
+                    "\\\\"
+                } else {
+                    std::path::MAIN_SEPARATOR_STR
+                };
+
+                let expected_args: Vec<OsString> = [
+                    "--fail",
+                    "--user-agent",
+                    net::http::user_agent(),
+                    "--form",
+                    "extra=@-;filename=extra.json;type=application/json",
+                    "--form",
+                    &format!(
+                        "upload_file_minidump=@\"data_dir{0}pending{0}minidump.dmp\"",
+                        curl_escaped_separator
+                    ),
+                    "--form",
+                    &format!(
+                        "memory_report=@\"data_dir{0}pending{0}minidump.memory.json.gz\"",
+                        curl_escaped_separator
+                    ),
+                    "https://reports.example.com",
+                ]
+                .into_iter()
+                .map(Into::into)
+                .collect();
+                let args =
+                    take_curl_header_file(&cmd.args, "authorization: Bearer SomeToken\n");
+                assert_eq!(args, expected_args);
+                let mut output = crate::std::process::success_output();
+                output.stdout = format!("CrashID={MOCK_REMOTE_CRASH_ID}").into();
+                mock_ran_process.inc();
+                Ok(output)
+            }),
+        );
+    test.run(|interact| {
+        interact.element("quit", |_style, b: &model::Button| b.click.fire(&()));
+    });
+
+    ran_process.assert_one();
+}
+
+/// Test that the authorization header is not attached when the report url isn't the
+/// enterprise console, since the url comes from the crash annotations or the environment.
+#[cfg(feature = "enterprise")]
+#[test]
+fn curl_binary_omits_authorization_header_for_other_url() {
+    let mut test = GuiTest::new();
+    test.config.report_url = Some("https://evil.example.com".into());
+    let ran_process = Counter::new();
+    let mock_ran_process = ran_process.clone();
+    test.mock
+        .set(
+            crate::std::env::MockEnv("MOZ_CRASHREPORTER_AUTH_TOKEN".into()),
+            "SomeToken".into(),
+        )
+        .set(
+            Command::mock("curl"),
+            Box::new(move |cmd| {
+                if cmd.spawning {
+                    return Ok(crate::std::process::success_output());
+                }
+
+                assert!(!cmd.args.contains(&OsString::from("--header")));
+                assert_eq!(
+                    cmd.args.last().unwrap(),
+                    &OsString::from("https://evil.example.com")
+                );
+                let mut output = crate::std::process::success_output();
+                output.stdout = format!("CrashID={MOCK_REMOTE_CRASH_ID}").into();
+                mock_ran_process.inc();
+                Ok(output)
+            }),
+        );
     test.run(|interact| {
         interact.element("quit", |_style, b: &model::Button| b.click.fire(&()));
     });
@@ -1537,7 +1871,8 @@ fn background_task_curl_fallback() {
                                 "value": platform_path("data_dir/pending/minidump.dmp"),
                             },
                         }
-                    ]
+                    ],
+                    "headers": []
                 })
                 .to_string();
 
@@ -1592,6 +1927,159 @@ fn background_task_curl_fallback() {
                 .map(Into::into)
                 .collect();
                 assert_eq!(cmd.args, expected_args);
+                let mut output = crate::std::process::success_output();
+                output.stdout = format!("CrashID={MOCK_REMOTE_CRASH_ID}").into();
+                mock_ran_curl.inc();
+                Ok(output)
+            }),
+        );
+    test.run(|interact| {
+        interact.element("quit", |_style, b: &model::Button| b.click.fire(&()));
+    });
+
+    ran_bgtask.assert_one();
+    ran_curl.assert_one();
+
+    // Verify that background tasks are still enabled.
+    assert!(background_task_attempts.should_attempt());
+
+    test.assert_files()
+        .saved_settings(Settings::default())
+        .submitted();
+}
+
+/// Test that the primary network backend (Necko) falls back to using curl if it fails,
+/// and that the invocation includes the authorization header
+#[cfg(feature = "enterprise")]
+#[test]
+fn background_task_curl_fallback_with_authorization_header() {
+    let mut test = GuiTest::new();
+    let ran_bgtask = Counter::new();
+    let mock_ran_bgtask = ran_bgtask.clone();
+    let ran_curl = Counter::new();
+    let mock_ran_curl = ran_curl.clone();
+    let background_task_attempts = Arc::new(net::http::BackgroundTaskAttempts::new(2));
+    test.mock
+        .set(
+            crate::std::env::MockEnv("MOZ_CRASHREPORTER_AUTH_TOKEN".into()),
+            "SomeToken".into()
+        )
+        .set(
+            net::http::BACKGROUND_TASK_ATTEMPTS,
+            background_task_attempts.clone(),
+        )
+        .set(
+            Command::mock("work_dir/firefox"),
+            Box::new(move |cmd| {
+                if cmd.spawning {
+                    return Ok(crate::std::process::success_output());
+                }
+                mock_ran_bgtask.inc();
+
+                let expected_args: Vec<OsString> = [
+                    "--backgroundtask",
+                    "crashreporterNetworkBackend",
+                    "https://reports.example.com",
+                    net::http::user_agent(),
+                ]
+                .into_iter()
+                .map(Into::into)
+                .collect();
+
+                assert_eq!(cmd.args.len(), 5);
+                assert_eq!(cmd.args[..4], expected_args);
+                let request_file = &cmd.args[4];
+
+                let expected_contents = serde_json::json!({
+                    "type": "MimePost",
+                    "parts": [
+                        {
+                            "name": "extra",
+                            "content": {
+                                "type": "String",
+                                "value": serde_json::json!({
+                                    "Vendor":"FooCorp",
+                                    "ProductName":"Bar",
+                                    "ReleaseChannel":"release",
+                                    "BuildID":"1234",
+                                    "AsyncShutdownTimeout":"{}",
+                                    "StackTraces": "{}",
+                                    "Version":"100.0",
+                                    "URL":"https://url.example.com",
+                                    "Throttleable":"1",
+                                    "CrashTime": current_unix_time().to_string(),
+                                    "MinidumpSha256Hash": MOCK_MINIDUMP_SHA256,
+                                    "SubmittedFrom":"Client",
+                                }).to_string(),
+                            },
+                            "filename": "extra.json",
+                            "mime_type": "application/json",
+                        },
+                        {
+                            "name": "upload_file_minidump",
+                            "content": {
+                                "type": "File",
+                                "value": platform_path("data_dir/pending/minidump.dmp"),
+                            },
+                        }
+                    ],
+                    "headers": [["authorization", "Bearer SomeToken"]]
+                })
+                .to_string();
+
+                use ::std::io::Read;
+                let mut file = OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .open(request_file)
+                    .expect("cannot open request file");
+                {
+                    let mut contents = String::new();
+                    file.read_to_string(&mut contents)
+                        .expect("cannot read request file");
+                    assert_eq!(contents, expected_contents);
+                }
+
+                Ok(crate::std::process::Output {
+                    status: crate::std::process::exit_status(3),
+                    stdout: vec![],
+                    stderr: vec![],
+                })
+            }),
+        )
+        .set(
+            Command::mock("curl"),
+            Box::new(move |cmd| {
+                if cmd.spawning {
+                    return Ok(crate::std::process::success_output());
+                }
+
+                // Curl strings need backslashes escaped.
+                let curl_escaped_separator = if std::path::MAIN_SEPARATOR == '\\' {
+                    "\\\\"
+                } else {
+                    std::path::MAIN_SEPARATOR_STR
+                };
+
+                let expected_args: Vec<OsString> = [
+                    "--fail",
+                    "--user-agent",
+                    net::http::user_agent(),
+                    "--form",
+                    "extra=@-;filename=extra.json;type=application/json",
+                    "--form",
+                    &format!(
+                        "upload_file_minidump=@\"data_dir{0}pending{0}minidump.dmp\"",
+                        curl_escaped_separator
+                    ),
+                    "https://reports.example.com",
+                ]
+                .into_iter()
+                .map(Into::into)
+                .collect();
+                let args =
+                    take_curl_header_file(&cmd.args, "authorization: Bearer SomeToken\n");
+                assert_eq!(args, expected_args);
                 let mut output = crate::std::process::success_output();
                 output.stdout = format!("CrashID={MOCK_REMOTE_CRASH_ID}").into();
                 mock_ran_curl.inc();

--- a/toolkit/crashreporter/networking/BackgroundTask_crashreporterNetworkBackend.sys.mjs
+++ b/toolkit/crashreporter/networking/BackgroundTask_crashreporterNetworkBackend.sys.mjs
@@ -9,6 +9,17 @@ import { EXIT_CODE } from "resource://gre/modules/BackgroundTasksManager.sys.mjs
  * toolkit/crashreporter/client/app/src/net/http.rs
  */
 
+// Build a null-prototype headers object from the serialized `[name, value]`
+// pairs, treating an absent list as no headers. The null prototype prevents
+// prototype pollution via a "__proto__" key.
+function deserializeHeaders(pairs) {
+  const headers = Object.create(null);
+  for (const [name, value] of pairs ?? []) {
+    headers[name] = value;
+  }
+  return headers;
+}
+
 async function createRequestInit(requestBuilder) {
   switch (requestBuilder.type) {
     case "MimePost": {
@@ -28,16 +39,15 @@ async function createRequestInit(requestBuilder) {
       }
       return {
         method: "POST",
+        headers: deserializeHeaders(requestBuilder.headers),
         body: formData,
       };
     }
     case "Post": {
-      const body = requestBuilder.body;
-      const headers = requestBuilder.headers;
       return {
         method: "POST",
-        headers: Object.fromEntries(headers),
-        body: new Uint8Array(body),
+        headers: deserializeHeaders(requestBuilder.headers),
+        body: new Uint8Array(requestBuilder.body),
       };
     }
   }

--- a/toolkit/crashreporter/networking/tests/xpcshell/test_BackgroundTask_crashreporterNetworkBackend.js
+++ b/toolkit/crashreporter/networking/tests/xpcshell/test_BackgroundTask_crashreporterNetworkBackend.js
@@ -110,6 +110,46 @@ add_task(async function test_mime_post() {
   Assert.equal(content, "CrashID=abcdef");
 });
 
+server.registerPathHandler("/mime_post_headers", (request, response) => {
+  response.processAsync();
+  (async () => {
+    Assert.equal(request.method, "POST");
+    // Headers carried by a MimePost request (e.g. an enterprise Authorization
+    // header) must be forwarded to the upload.
+    Assert.equal(request.getHeader("Authorization"), "Bearer abc");
+    const body = CommonUtils.readBytesFromInputStream(request.bodyInputStream);
+    const data = await new Response(body, {
+      headers: { "Content-Type": request.getHeader("Content-Type") },
+    }).formData();
+    Assert.equal(await data.get("extra").text(), EXTRA_DATA);
+  })().then(() => {
+    response.write("CrashID=abcdef");
+    response.finish();
+  });
+});
+
+add_task(async function test_mime_post_headers() {
+  const requestFile = await tempTestFile("mime-post-headers-request");
+  await IOUtils.writeJSON(requestFile, {
+    type: "MimePost",
+    headers: [["Authorization", "Bearer abc"]],
+    parts: [
+      {
+        name: "extra",
+        content: {
+          type: "String",
+          value: EXTRA_DATA,
+        },
+        filename: "extra.json",
+        mime_type: "application/json",
+      },
+    ],
+  });
+
+  const exitCode = await sendRequest("/mime_post_headers", requestFile);
+  Assert.equal(exitCode, 0);
+});
+
 server.registerPathHandler("/post", (request, response) => {
   response.processAsync();
   Assert.equal(request.method, "POST");

--- a/toolkit/crashreporter/nsDummyExceptionHandler.cpp
+++ b/toolkit/crashreporter/nsDummyExceptionHandler.cpp
@@ -141,6 +141,10 @@ nsresult SetServerURL(const nsACString& aServerURL) {
   return NS_ERROR_NOT_IMPLEMENTED;
 }
 
+nsresult SetAuthToken(const nsACString& aToken) {
+  return NS_ERROR_NOT_IMPLEMENTED;
+}
+
 nsresult SetRestartArgs(int argc, char** argv) {
   return NS_ERROR_NOT_IMPLEMENTED;
 }

--- a/toolkit/crashreporter/nsExceptionHandler.cpp
+++ b/toolkit/crashreporter/nsExceptionHandler.cpp
@@ -14,6 +14,7 @@
 #include "nsIDUtils.h"
 #include "nsIFileStreams.h"
 #include "nsNetUtil.h"
+#include "nsReadableUtils.h"
 #include "nsString.h"
 #include "mozilla/DebugOnly.h"
 #include "mozilla/GeckoArgs.h"
@@ -230,6 +231,11 @@ static CrashHelperClient* gCrashHelperClient
 static google_breakpad::ExceptionHandler* gExceptionHandler = nullptr;
 static mozilla::Atomic<bool> gEncounteredChildException(false);
 constinit static nsCString gServerURL;
+// Full "KEY=VALUE" environment entry for the enterprise auth token, passed only
+// to the crash reporter child process (never set in our own environment).
+// Empty when there is no token. Pre-formatted so the crash path only has to
+// read it, without any allocation.
+constinit static nsCString gAuthTokenEnvEntry;
 
 static MOZ_GLIBCXX_CONSTINIT xpstring pendingDirectory;
 static MOZ_GLIBCXX_CONSTINIT xpstring crashReporterPath;
@@ -1156,6 +1162,72 @@ static void AnnotateMemoryStatus(AnnotationTable&) {
  * @param aMinidumpPath The path of the minidump file, passed as an argument
  *        to the launched program
  */
+#  if !defined(XP_WIN) && !defined(XP_MACOSX)
+// Used to build a child-only environment for the crash reporter on Linux.
+extern "C" char** environ;
+#  endif
+
+// The following helpers build a child-only environment for the crash reporter
+// containing the enterprise auth token, so the token is handed to the crash
+// reporter alone rather than living in our own environment (where every child
+// process would inherit it). They leave the environment untouched when there is
+// no token.
+#  ifdef XP_WIN
+// Append a custom environment block (a copy of ours plus the auth token) to
+// `aBlock`, for passing to CreateProcess. Leaves `aBlock` empty when there is
+// no token, so the caller inherits our environment.
+static void BuildChildEnvBlock(nsAString& aBlock) {
+  if (gAuthTokenEnvEntry.IsEmpty()) {
+    return;
+  }
+  LPWCH curEnv = GetEnvironmentStringsW();
+  if (!curEnv) {
+    return;
+  }
+  for (LPWCH v = curEnv; *v; v += wcslen(v) + 1) {
+    aBlock.Append(nsDependentString(reinterpret_cast<const char16_t*>(v)));
+    aBlock.Append(char16_t(0));
+  }
+  FreeEnvironmentStringsW(curEnv);
+  AppendUTF8toUTF16(gAuthTokenEnvEntry, aBlock);
+  aBlock.Append(char16_t(0));  // terminate the token entry
+  aBlock.Append(char16_t(0));  // terminate the block
+}
+#  else
+// Number of slots (including the token entry and the null terminator) in the
+// stack buffer used to build the crash reporter's environment.
+static const size_t kChildEnvCapacity = 512;
+
+// Copy the null-terminated environment `aSource` into `aBuffer` (which has
+// `aCapacity` slots) and append the auth token. Returns the null-terminated
+// `aBuffer`, or nullptr when there is no token or the environment did not fit,
+// in which case the caller launches with the inherited environment.
+//
+// The caller supplies the buffer so the result lives on the caller's stack: on
+// Linux this runs post-fork in a signal-handler context, where heap allocation
+// is unsafe. macOS and Linux share this logic and differ only in how `aSource`
+// is obtained.
+static char** CopyEnvWithAuthToken(char** aSource, char** aBuffer,
+                                   size_t aCapacity) {
+  if (gAuthTokenEnvEntry.IsEmpty() || !aSource) {
+    return nullptr;
+  }
+  size_t n = 0;
+  // Leave room for the token entry and the null terminator.
+  while (aSource[n] && n < aCapacity - 2) {
+    aBuffer[n] = aSource[n];
+    ++n;
+  }
+  if (aSource[n]) {
+    // The environment did not fit within aCapacity.
+    return nullptr;
+  }
+  aBuffer[n++] = const_cast<char*>(gAuthTokenEnvEntry.get());
+  aBuffer[n] = nullptr;
+  return aBuffer;
+}
+#  endif  // XP_WIN
+
 static bool LaunchProgram(const XP_CHAR* aProgramPath,
                           const XP_CHAR* aMinidumpPath) {
 #  ifdef XP_WIN
@@ -1173,13 +1245,25 @@ static bool LaunchProgram(const XP_CHAR* aProgramPath,
   STARTUPINFO si = {};
   si.cb = sizeof(si);
 
+  DWORD creationFlags =
+      NORMAL_PRIORITY_CLASS | CREATE_NO_WINDOW | CREATE_BREAKAWAY_FROM_JOB;
+  LPVOID envBlock = nullptr;  // null => inherit our environment
+  // Storage for a custom environment block; must outlive the CreateProcess
+  // call. A plain nsString (not nsAutoString) since the block is far larger
+  // than any inline buffer and will be heap-allocated regardless.
+  nsString childEnv;
+  BuildChildEnvBlock(childEnv);
+  if (!childEnv.IsEmpty()) {
+    envBlock = reinterpret_cast<LPVOID>(childEnv.BeginWriting());
+    creationFlags |= CREATE_UNICODE_ENVIRONMENT;
+  }
+
   // If CreateProcess() fails don't do anything.
   if (CreateProcess(
           /* lpApplicationName */ nullptr, (LPWSTR)cmdLine,
           /* lpProcessAttributes */ nullptr, /* lpThreadAttributes */ nullptr,
-          /* bInheritHandles */ FALSE,
-          NORMAL_PRIORITY_CLASS | CREATE_NO_WINDOW | CREATE_BREAKAWAY_FROM_JOB,
-          /* lpEnvironment */ nullptr, /* lpCurrentDirectory */ nullptr, &si,
+          /* bInheritHandles */ FALSE, creationFlags,
+          /* lpEnvironment */ envBlock, /* lpCurrentDirectory */ nullptr, &si,
           &pi)) {
     CloseHandle(pi.hProcess);
     CloseHandle(pi.hThread);
@@ -1195,6 +1279,12 @@ static bool LaunchProgram(const XP_CHAR* aProgramPath,
     env = *nsEnv;
   }
 
+  char* childEnvBuf[kChildEnvCapacity];
+  if (char** childEnv =
+          CopyEnvWithAuthToken(env, childEnvBuf, kChildEnvCapacity)) {
+    env = childEnv;
+  }
+
   int rv = posix_spawnp(&pid, my_argv[0], nullptr, nullptr, my_argv, env);
 
   if (rv != 0) {
@@ -1206,6 +1296,15 @@ static bool LaunchProgram(const XP_CHAR* aProgramPath,
   if (pid == -1) {
     return false;
   } else if (pid == 0) {
+    // Build the replacement environment on the stack: we are post-fork in a
+    // signal-handler context, where heap allocation is unsafe.
+    char* childEnvBuf[kChildEnvCapacity];
+    if (char** childEnv =
+            CopyEnvWithAuthToken(environ, childEnvBuf, kChildEnvCapacity)) {
+      (void)execle(aProgramPath, aProgramPath, aMinidumpPath, nullptr,
+                   childEnv);
+      // If execle() failed, fall through to the plain execl() below.
+    }
     (void)execl(aProgramPath, aProgramPath, aMinidumpPath, nullptr);
     _exit(1);
   }
@@ -2368,6 +2467,7 @@ nsresult UnsetExceptionHandler() {
   delete gExceptionHandler;
 
   gServerURL = "";
+  gAuthTokenEnvEntry.Truncate();
   TeardownAppNotes();
 
   if (!gExceptionHandler) return NS_ERROR_NOT_INITIALIZED;
@@ -2688,6 +2788,19 @@ nsresult SetServerURL(const nsACString& aServerURL) {
   // Store the server URL as an annotation, the crash reporter client knows how
   // to handle this specially.
   gServerURL = aServerURL;
+  return NS_OK;
+}
+
+nsresult SetAuthToken(const nsACString& aToken) {
+  if (aToken.IsEmpty() || aToken.FindChar('\0') != kNotFound) {
+    gAuthTokenEnvEntry.Truncate();
+    return aToken.IsEmpty() ? NS_OK : NS_ERROR_INVALID_ARG;
+  }
+
+  // Pre-format the full environment entry so that LaunchProgram (which runs on
+  // the crash path) only has to reference it without allocating.
+  gAuthTokenEnvEntry.AssignLiteral("MOZ_CRASHREPORTER_AUTH_TOKEN=");
+  gAuthTokenEnvEntry.Append(aToken);
   return NS_OK;
 }
 
@@ -3753,6 +3866,7 @@ bool UnsetRemoteExceptionHandler(bool wasSet) {
   }
 #endif
   gServerURL = "";
+  gAuthTokenEnvEntry.Truncate();
   TeardownAppNotes();
 
   return true;

--- a/toolkit/crashreporter/nsExceptionHandler.h
+++ b/toolkit/crashreporter/nsExceptionHandler.h
@@ -116,6 +116,9 @@ bool GetCrashEventsDir(nsAString& aPath);
 bool GetEnabled();
 bool GetServerURL(nsACString& aServerURL);
 nsresult SetServerURL(const nsACString& aServerURL);
+// Sets the bearer token passed (only) to the crash reporter child process to
+// authenticate enterprise console uploads. Pass an empty string to clear it.
+nsresult SetAuthToken(const nsACString& aToken);
 bool GetMinidumpPath(nsAString& aPath);
 nsresult SetMinidumpPath(const nsAString& aPath);
 

--- a/toolkit/xre/nsAppRunner.cpp
+++ b/toolkit/xre/nsAppRunner.cpp
@@ -1855,6 +1855,11 @@ nsXULAppInfo::SetServerURL(nsIURL* aServerURL) {
 }
 
 NS_IMETHODIMP
+nsXULAppInfo::SetAuthToken(const nsACString& aToken) {
+  return CrashReporter::SetAuthToken(aToken);
+}
+
+NS_IMETHODIMP
 nsXULAppInfo::GetMinidumpPath(nsIFile** aMinidumpPath) {
   if (!CrashReporter::GetEnabled()) {
     return NS_ERROR_NOT_INITIALIZED;

--- a/xpcom/system/nsICrashReporter.idl
+++ b/xpcom/system/nsICrashReporter.idl
@@ -196,4 +196,10 @@ interface nsICrashReporter : nsISupports
    * @throws NS_ERROR_NOT_INITIALIZED if crash reporting is disabled.
    */
   void saveMemoryReport();
+
+  /**
+   * Set the bearer token used to authenticate crash report and crash ping
+   * uploads to the enterprise console. Pass an empty string to clear it.
+   */
+  void setAuthToken(in ACString token);
 };


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2059588

Include authentication header with access token from Felt for crashes. For crashreporter app (for app crashes), pass access token into the spawned process's environment.

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Testing <!-- OPTIONAL -->

* [x] Added tests
* [x] Manual testing performed

<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
