### PR TITLE
Bug 2062592 - Fix schema validation for AIChatbot policy custom provider

### DIFF
--- a/browser/components/enterprisepolicies/schemas/policies-schema.json
+++ b/browser/components/enterprisepolicies/schemas/policies-schema.json
@@ -132,9 +132,7 @@
               "items": {
                 "type": "object",
                 "properties": {
-                  "url": {
-                    "type": "URL"
-                  },
+                  "url": { "$ref": "#/definitions/url" },
                   "name": {
                     "type": "string"
                   },

--- a/browser/components/enterprisepolicies/tests/xpcshell/test_aichatbot.js
+++ b/browser/components/enterprisepolicies/tests/xpcshell/test_aichatbot.js
@@ -1,0 +1,48 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+const { CHAT_PROVIDERS_DEFAULT } = ChromeUtils.importESModule(
+  "resource:///modules/GenAI.sys.mjs"
+);
+
+add_task(async function test_aichatbot_custom_provider_added() {
+  await setupPolicyEngineWithJson({
+    policies: {
+      AIChatbot: {
+        Providers: {
+          Add: [
+            {
+              id: "my-private-ai",
+              name: "My Private AI",
+              url: "https://example.com/chat",
+              iconUrl: "https://example.com/icon.png",
+              queryParam: "q",
+            },
+          ],
+        },
+      },
+    },
+  });
+
+  equal(
+    Services.policies.status,
+    Ci.nsIEnterprisePolicies.ACTIVE,
+    "Engine is active"
+  );
+
+  let providers = Services.prefs
+    .getStringPref("browser.ml.chat.providers", "")
+    .split(",");
+
+  ok(
+    providers.includes("my-private-ai"),
+    "Custom provider was successfully added to the list of providers"
+  );
+  equal(
+    providers.length,
+    CHAT_PROVIDERS_DEFAULT.split(",").length + 1,
+    "Built-in providers are preserved and the custom provider is appended"
+  );
+});

--- a/browser/components/enterprisepolicies/tests/xpcshell/xpcshell.toml
+++ b/browser/components/enterprisepolicies/tests/xpcshell/xpcshell.toml
@@ -15,6 +15,10 @@ support-files = [
 
 ["test_addon_update.js"]
 
+["test_aichatbot.js"]
+# Only run in MOZ_ENTERPRISE builds
+run-if = ["enterprise"]
+
 ["test_appupdatepin.js"]
 
 ["test_appupdateurl.js"]


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2062592

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

The policy schema was recently updated upstream, but the `AIChatbot` policy which is only in the `enterprise-firefox` repo contained old type definitions. 

This PR updates the type of `AIChatbot.Providers.Add.url` to use the new schema definition and adds a simple xpcshell test for this case.

---
### Screenshots

<img width="1467" height="859" alt="image" src="https://github.com/user-attachments/assets/ad3efd08-af2d-4c11-8872-37e6beaa38a7" />

_Before fix: AIChatbot policy shows errors and custom provider is not present in sidebar_

<img width="1467" height="859" alt="image" src="https://github.com/user-attachments/assets/7a7ae233-b5a9-47dc-b7a3-9501be936e19" />

_After fix: AIChatbot policy with no errors and custom provider present in sidebar_

---

### Testing <!-- OPTIONAL -->

* [x] Added tests
* [x] Manual testing performed


**Steps to verify changes:**
1. Set a valid `AIChatbot` policy
2. Navigate to `about:policies`
3. Open the AIChatbot sidebar

**Expected result:**

`about:policies` displays no errors, and the custom chatbot appears in the AI Chatbot sidebar tool.
