### PR TITLE
Bug 2062629 - Add optional enterprise sign-out on browser restart and crash

### DIFF
--- a/testing/enterprise/manifest.toml
+++ b/testing/enterprise/manifest.toml
@@ -90,9 +90,19 @@ run-if = [
   "buildapp == 'browser'",
 ]
 
+["test_felt_browser_signout_on_crash.py"]
+run-if = [
+  "buildapp == 'browser'", # browser specific: child browser crash + signout
+]
+
 ["test_felt_browser_signout_on_exit.py"]
 run-if = [
   "buildapp == 'browser'", # broken on non browser app
+]
+
+["test_felt_browser_signout_on_restart.py"]
+run-if = [
+  "buildapp == 'browser'", # browser specific: child browser restart + signout
 ]
 
 ["test_felt_browser_signout_verify.py"]

--- a/testing/enterprise/test_felt_browser_signout_on_crash.py
+++ b/testing/enterprise/test_felt_browser_signout_on_crash.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import os
+import sys
+
+sys.path.append(os.path.dirname(__file__))
+
+from base_test import Environment
+from felt_browser_crashes import BrowserCrashes
+
+
+class BrowserSignoutOnCrash(BrowserCrashes):
+    """With crash signout enabled, a crash revokes the session and returns to login with a
+    notice instead of silently relaunching the browser authenticated."""
+
+    EXTRA_PREFS = {
+        "enterprise.signout.crash.enabled": True,
+    }
+
+    def test_browser_signout_on_crash(self):
+        super().run_felt_base()
+        self.run_felt_verify_signed_in()
+        self._manually_closed_child = True
+        self.crash_parent()
+        self.run_felt_verify_signed_out()
+
+    def run_felt_verify_signed_in(self):
+        self.connect_child_browser()
+        self.assert_user_signed_in(env=Environment.FIREFOX)
+        assert self.signout_count.value == 0, "No signout should have been posted yet"
+
+    def run_felt_verify_signed_out(self):
+        self.await_felt_auth_window()
+        self.force_window()
+
+        self._wait.until(lambda _: self.signout_count.value == 1)
+        assert self.signout_count.value == 1, (
+            f"Expected exactly 1 signout request after crash, got {self.signout_count.value}"
+        )
+
+        self._driver.set_context("chrome")
+        crash_msg = self.get_elem(".felt-browser-info-signed-out-crash")
+        assert "signed out" in crash_msg.text.lower(), (
+            f"Expected the crash sign-out message, got: {crash_msg.text!r}"
+        )
+
+        email_value = self._driver.execute_script(
+            "return document.getElementById('felt-form__email').value;"
+        )
+        self._driver.set_context("content")
+        assert email_value == "nobody@mozilla.org", (
+            f"Expected the email pre-filled after crash sign-out, got: {email_value!r}"
+        )
+
+        self.assert_user_signed_out(env=Environment.FELT)

--- a/testing/enterprise/test_felt_browser_signout_on_restart.py
+++ b/testing/enterprise/test_felt_browser_signout_on_restart.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import os
+import sys
+
+sys.path.append(os.path.dirname(__file__))
+
+from base_test import Environment
+from felt_tests import FeltTests
+from marionette_driver.errors import (
+    NoSuchWindowException,
+    UnknownException,
+)
+
+
+class BrowserSignoutOnRestart(FeltTests):
+    """With restart signout enabled, a restart revokes the session and returns to login
+    instead of relaunching the browser authenticated."""
+
+    EXTRA_PREFS = {
+        "enterprise.signout.restart.enabled": True,
+    }
+
+    def test_browser_signout_on_restart(self):
+        super().run_felt_base()
+        self.run_felt_verify_signed_in()
+        self.run_felt_perform_restart()
+        self.run_felt_verify_signed_out()
+
+    def run_felt_verify_signed_in(self):
+        self.connect_child_browser()
+        self._browser_pid = self._child_driver.session_capabilities["moz:processID"]
+        self.assert_user_signed_in(env=Environment.FIREFOX)
+        assert self.signout_count.value == 0, "No signout should have been posted yet"
+
+    def run_felt_perform_restart(self):
+        try:
+            self._child_driver.set_context("chrome")
+            self._child_driver.execute_script(
+                "Services.startup.quit(Ci.nsIAppStartup.eRestart | Ci.nsIAppStartup.eAttemptQuit);"
+            )
+        except UnknownException:
+            self._logger.info("Received expected UnknownException")
+        except NoSuchWindowException:
+            self._logger.info("Received expected NoSuchWindowException")
+        except OSError:
+            self._logger.info(
+                "Firefox quit before execute_script returned, Marionette socket was closed"
+            )
+        finally:
+            self._manually_closed_child = True
+
+    def run_felt_verify_signed_out(self):
+        self.wait_process_exit(self._browser_pid)
+        self.await_felt_auth_window()
+        self.force_window()
+
+        self._wait.until(lambda _: self.signout_count.value == 1)
+        assert self.signout_count.value == 1, (
+            f"Expected exactly 1 signout request after restart, got {self.signout_count.value}"
+        )
+        self.assert_user_signed_out(env=Environment.FELT)

--- a/toolkit/components/felt/Felt.sys.mjs
+++ b/toolkit/components/felt/Felt.sys.mjs
@@ -317,7 +317,7 @@ export class Felt {
 
       case "FeltParent:FirefoxLogoutExit": {
         Services.felt.makeBackgroundProcess(false);
-        this.showWindow();
+        this.showWindow(message.data?.errorMessage ?? "");
         break;
       }
 

--- a/toolkit/components/felt/content/FeltProcessParent.sys.mjs
+++ b/toolkit/components/felt/content/FeltProcessParent.sys.mjs
@@ -40,6 +40,8 @@ const PROCESS_START_REASON = {
   RESTART: "restart",
   CRASH: "crash",
 };
+const SIGNOUT_ON_CRASH_PREF = "enterprise.signout.crash.enabled";
+const SIGNOUT_ON_RESTART_PREF = "enterprise.signout.restart.enabled";
 
 export function queueURL(payload) {
   // If Firefox AND Felt are both ready, forward immediately
@@ -223,26 +225,43 @@ export class FeltProcessParent extends JSProcessActorParent {
                         `ParentProcess: Firefox exited for restart, restartDisabled=${restartDisabled}`
                       );
 
-                      if (!restartDisabled && !pendingUpdate) {
-                        lazy.log.debug(`ParentProcess: Starting new Firefox`);
-                        gFeltProcessParentInstance.startFirefox(
-                          PROCESS_START_REASON.RESTART
-                        );
-                      } else if (pendingUpdate) {
+                      const signOutOnRestart = Services.prefs.getBoolPref(
+                        SIGNOUT_ON_RESTART_PREF,
+                        false
+                      );
+                      if (pendingUpdate) {
                         lazy.log.debug(
                           `ParentProcess: Restart requested and pending update, restarting FELT UI`
                         );
-                        Services.cpmm.sendAsyncMessage(
-                          "FeltParent:FirefoxRestartUpdateExit",
-                          {}
-                        );
-                      } else {
+                        if (signOutOnRestart) {
+                          gFeltProcessParentInstance.signOutAndDispatch(
+                            "FeltParent:FirefoxRestartUpdateExit"
+                          );
+                        } else {
+                          Services.cpmm.sendAsyncMessage(
+                            "FeltParent:FirefoxRestartUpdateExit",
+                            {}
+                          );
+                        }
+                      } else if (restartDisabled) {
                         lazy.log.debug(
                           `ParentProcess: Restart disabled, sending normal exit to restore FELT UI`
                         );
                         Services.cpmm.sendAsyncMessage(
                           "FeltParent:FirefoxNormalExit",
                           {}
+                        );
+                      } else if (signOutOnRestart) {
+                        lazy.log.debug(
+                          `ParentProcess: Sign-out on restart, revoking session`
+                        );
+                        gFeltProcessParentInstance.signOutAndDispatch(
+                          "FeltParent:FirefoxLogoutExit"
+                        );
+                      } else {
+                        lazy.log.debug(`ParentProcess: Starting new Firefox`);
+                        gFeltProcessParentInstance.startFirefox(
+                          PROCESS_START_REASON.RESTART
                         );
                       }
                     })
@@ -662,6 +681,18 @@ export class FeltProcessParent extends JSProcessActorParent {
       return;
     }
 
+    if (Services.prefs.getBoolPref(SIGNOUT_ON_CRASH_PREF, false)) {
+      lazy.log.debug(
+        "enterprise.signout.crash.enabled set, revoking session and returning to login."
+      );
+      this.abnormalExitCounter = 0;
+      this.abnormalExitFirstTime = 0;
+      this.signOutAndDispatch("FeltParent:FirefoxLogoutExit", {
+        errorMessage: "felt-browser-info-signed-out-crash",
+      });
+      return;
+    }
+
     if (this.abnormalExitCounter === 0) {
       this.abnormalExitFirstTime =
         Services.telemetry.msSinceProcessStart() / 1000;
@@ -895,6 +926,25 @@ export class FeltProcessParent extends JSProcessActorParent {
             reason: "logout",
           });
         });
+      });
+  }
+
+  /**
+   * Revoke the session server-side, drop the local tokens, then hand off to the
+   * FELT UI with the given follow-up message.
+   *
+   * @param {string} message - Message to send once tokens are cleared
+   *  (e.g FeltParent::FirefoxLogoutExit to return to login).
+   * @param {object} [data] - Payload for the follow-up message.
+   */
+  signOutAndDispatch(message, data = {}) {
+    lazy.ConsoleClient.performServerSignout()
+      .catch(err => {
+        lazy.log.error(`Sign-out server request failed: ${err}`);
+      })
+      .finally(() => {
+        Services.felt.clearTokens();
+        Services.cpmm.sendAsyncMessage(message, data);
       });
   }
 

--- a/toolkit/components/felt/content/felt.xhtml
+++ b/toolkit/components/felt/content/felt.xhtml
@@ -308,6 +308,11 @@
             type="error"
             dismissable="true"
           ></moz-message-bar>
+          <moz-message-bar
+            class="felt-browser-info-signed-out-crash is-hidden"
+            data-l10n-id="felt-browser-info-signed-out-crash"
+            type="info"
+          ></moz-message-bar>
         </div>
       </div>
     </div>

--- a/toolkit/locales/en-US/toolkit/enterprise/felt.ftl
+++ b/toolkit/locales/en-US/toolkit/enterprise/felt.ftl
@@ -63,6 +63,9 @@ felt-error-sdr-token-unlock-failed =
 felt-browser-info-console-forced-logout =
     .heading = You’ve been signed out
     .message = An administrator signed you out as part of routine account management. If you have any questions, please contact your administrator directly.
+felt-browser-info-signed-out-crash =
+    .heading = You’ve been signed out
+    .message = { -brand-short-name } closed unexpectedly, so your session was ended to keep your account secure. Please sign in again.
 
 ## Network error headings
 


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2062629

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

Adds two optional FELT preferences (default false) that force a sign-out on browser-lifecycle events, to later be leveraged in a policy:

- `enterprise.signout.onRestart`: sign out on restart
- `enterprise.signout.onCrash` sign out on a child browser crash

> Note: Keeping this in draft since it is undetermined whether the policy-managed signouts are needed.

---

### Dependencies

- Bug-2040292

---

### Testing

* [x] Added tests
* [x] Manual testing performed

**Steps to verify changes:**
1. `./mach run --setpref "enterprise.signout.onCrash=true"`, sign in, then
   load `about:crashparent` in the browser.
2. `./mach run --setpref "enterprise.signout.onRestart=true"`, sign in, then
   trigger a restart (restart quick action / `about:restartrequired`).

**Expected result:**
The FELT launcher returns to its login screen, instead of silently relaunching the authenticated browser. With the prefs unset/false, behavior is unchanged (crash relaunches, restart relaunches, both stay signed in).