### PR TITLE
Bug 2058036 - Combine the *Telemetry policies into a single SecurityLogging policy

### DIFF
--- a/browser/components/downloads/DownloadsTelemetry.enterprise.sys.mjs
+++ b/browser/components/downloads/DownloadsTelemetry.enterprise.sys.mjs
@@ -16,10 +16,12 @@
  *
  * {
  *   "policies": {
- *     "DownloadTelemetry": {
- *       "Enabled": true,
- *       "UrlLogging": "full",
- *       "FileLogging": "full"
+ *     "SecurityLogging": {
+ *       "Download": {
+ *         "Enabled": true,
+ *         "UrlLogging": "full",
+ *         "FileLogging": "full"
+ *       }
  *     }
  *   }
  * }

--- a/browser/components/downloads/metrics.yaml
+++ b/browser/components/downloads/metrics.yaml
@@ -74,8 +74,9 @@ downloads:
         type: quantity
       source_url:
         description: >
-          The download source URL. Collection level configurable via enterprise
-          policy DownloadTelemetryUrlLogging: "full" (default), "domain", or "none".
+          The download source URL. Collection level configurable via the
+          SecurityLogging policy's Download.UrlLogging setting: "full"
+          (default), "domain", or "none".
         type: string
       is_private:
         description: >
@@ -118,8 +119,9 @@ downloads:
         type: string
       source_url:
         description: >
-          The download source URL. Collection level configurable via enterprise
-          policy DownloadTelemetryUrlLogging: "full" (default), "domain", or "none".
+          The download source URL. Collection level configurable via the
+          SecurityLogging policy's Download.UrlLogging setting: "full"
+          (default), "domain", or "none".
         type: string
       is_private:
         description: >

--- a/browser/components/enterprisepolicies/Policies.sys.mjs
+++ b/browser/components/enterprisepolicies/Policies.sys.mjs
@@ -31,6 +31,8 @@ ChromeUtils.defineESModuleGetters(lazy, {
   FileUtils: "resource://gre/modules/FileUtils.sys.mjs",
   ProxyPolicies: "resource:///modules/policies/ProxyPolicies.sys.mjs",
   SearchService: "moz-src:///toolkit/components/search/SearchService.sys.mjs",
+  SecurityLoggingPolicy:
+    "resource:///modules/policies/SecurityLoggingPolicy.sys.mjs",
   AIChatbotPolicies: "resource:///modules/policies/AIChatbotPolicies.sys.mjs",
   QuickSuggest: "moz-src:///browser/components/urlbar/QuickSuggest.sys.mjs",
   WatermarkPolicy: "resource:///modules/policies/WatermarkPolicy.sys.mjs",
@@ -605,47 +607,6 @@ export var Policies = {
     onRemove(manager, _oldParams) {
       lazy.unblockAboutPage(manager, "about:support");
       manager.allowFeature("aboutSupport");
-    },
-  },
-
-  BlocklistDomainBrowsedTelemetry: {
-    onBeforeAddons(manager, param) {
-      if (param && typeof param === "object") {
-        // Enable/disable blocklist domain browsed telemetry
-        if (typeof param.Enabled === "boolean") {
-          lazy.PoliciesUtils.setAndLockPref(
-            "browser.policies.enterprise.telemetry.blocklistDomainBrowsed.enabled",
-            param.Enabled
-          );
-        } else {
-          lazy.PoliciesUtils.unsetAndUnlockPref(
-            "browser.policies.enterprise.telemetry.blocklistDomainBrowsed.enabled"
-          );
-        }
-
-        // Set URL logging level
-        if (
-          typeof param.UrlLogging === "string" &&
-          ["full", "domain", "none"].includes(param.UrlLogging)
-        ) {
-          lazy.PoliciesUtils.setAndLockPref(
-            "browser.policies.enterprise.telemetry.blocklistDomainBrowsed.urlLogging",
-            param.UrlLogging
-          );
-        } else {
-          lazy.PoliciesUtils.unsetAndUnlockPref(
-            "browser.policies.enterprise.telemetry.blocklistDomainBrowsed.urlLogging"
-          );
-        }
-      }
-    },
-    onRemove(_manager, _oldParams) {
-      lazy.PoliciesUtils.unsetAndUnlockPref(
-        "browser.policies.enterprise.telemetry.blocklistDomainBrowsed.enabled"
-      );
-      lazy.PoliciesUtils.unsetAndUnlockPref(
-        "browser.policies.enterprise.telemetry.blocklistDomainBrowsed.urlLogging"
-      );
     },
   },
 
@@ -1711,61 +1672,6 @@ export var Policies = {
         "browser.download.useDownloadDir",
         true
       );
-    },
-  },
-
-  DownloadTelemetry: {
-    onBeforeAddons(manager, param) {
-      if (param && typeof param === "object") {
-        // Enable/disable download telemetry
-        if (typeof param.Enabled === "boolean") {
-          lazy.PoliciesUtils.setAndLockPref(
-            "browser.download.enterprise.telemetry.enabled",
-            param.Enabled
-          );
-        }
-
-        // Set URL logging level
-        if (
-          typeof param.UrlLogging === "string" &&
-          ["full", "domain", "none"].includes(param.UrlLogging)
-        ) {
-          lazy.PoliciesUtils.setAndLockPref(
-            "browser.download.enterprise.telemetry.urlLogging",
-            param.UrlLogging
-          );
-        }
-
-        // Set file logging level
-        if (
-          typeof param.FileLogging === "string" &&
-          ["full", "metadata", "none"].includes(param.FileLogging)
-        ) {
-          lazy.PoliciesUtils.setAndLockPref(
-            "browser.download.enterprise.telemetry.fileLogging",
-            param.FileLogging
-          );
-        }
-      }
-    },
-    onRemove(manager, oldParams) {
-      if (oldParams && typeof oldParams === "object") {
-        if ("Enabled" in oldParams) {
-          lazy.PoliciesUtils.unsetAndUnlockPref(
-            "browser.download.enterprise.telemetry.enabled"
-          );
-        }
-        if ("UrlLogging" in oldParams) {
-          lazy.PoliciesUtils.unsetAndUnlockPref(
-            "browser.download.enterprise.telemetry.urlLogging"
-          );
-        }
-        if ("FileLogging" in oldParams) {
-          lazy.PoliciesUtils.unsetAndUnlockPref(
-            "browser.download.enterprise.telemetry.fileLogging"
-          );
-        }
-      }
     },
   },
 
@@ -3185,45 +3091,6 @@ export var Policies = {
     },
   },
 
-  PrintPageTelemetry: {
-    onBeforeAddons(manager, param) {
-      if (param && typeof param === "object") {
-        // Enable/disable print page telemetry
-        if (typeof param.Enabled === "boolean") {
-          lazy.PoliciesUtils.setAndLockPref(
-            "print.enterprise.telemetry.printPage.enabled",
-            param.Enabled
-          );
-        }
-
-        // Set URL logging level
-        if (
-          typeof param.UrlLogging === "string" &&
-          ["full", "domain", "none"].includes(param.UrlLogging)
-        ) {
-          lazy.PoliciesUtils.setAndLockPref(
-            "print.enterprise.telemetry.printPage.urlLogging",
-            param.UrlLogging
-          );
-        }
-      }
-    },
-    onRemove(manager, oldParams) {
-      if (oldParams && typeof oldParams === "object") {
-        if ("Enabled" in oldParams) {
-          lazy.PoliciesUtils.unsetAndUnlockPref(
-            "print.enterprise.telemetry.printPage.enabled"
-          );
-        }
-        if ("UrlLogging" in oldParams) {
-          lazy.PoliciesUtils.unsetAndUnlockPref(
-            "print.enterprise.telemetry.printPage.urlLogging"
-          );
-        }
-      }
-    },
-  },
-
   PrivateBrowsingModeAvailability: {
     onBeforeAddons(manager, param) {
       switch (param) {
@@ -3767,6 +3634,15 @@ export var Policies = {
           lazy.log.error(`Error running SecurityDevices.onProfileAfterChange`);
           lazy.log.debug(ex);
         });
+    },
+  },
+
+  SecurityLogging: {
+    onBeforeAddons(_manager, param) {
+      lazy.SecurityLoggingPolicy.apply(param);
+    },
+    onRemove(_manager, oldParams) {
+      lazy.SecurityLoggingPolicy.remove(oldParams);
     },
   },
 

--- a/browser/components/enterprisepolicies/helpers/SecurityLoggingPolicy.sys.mjs
+++ b/browser/components/enterprisepolicies/helpers/SecurityLoggingPolicy.sys.mjs
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const lazy = {};
+
+ChromeUtils.defineESModuleGetters(lazy, {
+  PoliciesUtils: "resource://gre/modules/PoliciesHelpers.sys.mjs",
+});
+
+const SECURITY_LOGGING_PREFS = {
+  BlocklistDomainBrowsed: {
+    Enabled:
+      "browser.policies.enterprise.telemetry.blocklistDomainBrowsed.enabled",
+    UrlLogging:
+      "browser.policies.enterprise.telemetry.blocklistDomainBrowsed.urlLogging",
+  },
+  Download: {
+    Enabled: "browser.download.enterprise.telemetry.enabled",
+    UrlLogging: "browser.download.enterprise.telemetry.urlLogging",
+    FileLogging: "browser.download.enterprise.telemetry.fileLogging",
+  },
+  PrintPage: {
+    Enabled: "print.enterprise.telemetry.printPage.enabled",
+    UrlLogging: "print.enterprise.telemetry.printPage.urlLogging",
+  },
+  UnsafeDownload: {
+    Enabled:
+      "browser.safebrowsing.enterprise.telemetry.unsafeDownload.enabled",
+    UrlLogging:
+      "browser.safebrowsing.enterprise.telemetry.unsafeDownload.urlLogging",
+  },
+  UnsafeSiteVisit: {
+    Enabled:
+      "browser.safebrowsing.enterprise.telemetry.unsafeSiteVisit.enabled",
+    UrlLogging:
+      "browser.safebrowsing.enterprise.telemetry.unsafeSiteVisit.urlLogging",
+  },
+};
+
+function forEachSetting(param, callback) {
+  for (const [event, settings] of Object.entries(SECURITY_LOGGING_PREFS)) {
+    const eventParam = param?.[event];
+    if (!eventParam) {
+      continue;
+    }
+    for (const [setting, pref] of Object.entries(settings)) {
+      if (Object.hasOwn(eventParam, setting)) {
+        callback(pref, eventParam[setting]);
+      }
+    }
+  }
+}
+
+export const SecurityLoggingPolicy = {
+  apply(param) {
+    forEachSetting(param, (pref, value) =>
+      lazy.PoliciesUtils.setAndLockPref(pref, value)
+    );
+  },
+
+  remove(oldParam) {
+    forEachSetting(oldParam, pref =>
+      lazy.PoliciesUtils.unsetAndUnlockPref(pref)
+    );
+  },
+};

--- a/browser/components/enterprisepolicies/helpers/SecurityLoggingPolicy.sys.mjs
+++ b/browser/components/enterprisepolicies/helpers/SecurityLoggingPolicy.sys.mjs
@@ -9,6 +9,9 @@ ChromeUtils.defineESModuleGetters(lazy, {
 });
 
 const SECURITY_LOGGING_PREFS = {
+  AddonInstall: {
+    Enabled: "extensions.enterprise.telemetry.addonInstall.enabled",
+  },
   BlocklistDomainBrowsed: {
     Enabled:
       "browser.policies.enterprise.telemetry.blocklistDomainBrowsed.enabled",
@@ -25,8 +28,7 @@ const SECURITY_LOGGING_PREFS = {
     UrlLogging: "print.enterprise.telemetry.printPage.urlLogging",
   },
   UnsafeDownload: {
-    Enabled:
-      "browser.safebrowsing.enterprise.telemetry.unsafeDownload.enabled",
+    Enabled: "browser.safebrowsing.enterprise.telemetry.unsafeDownload.enabled",
     UrlLogging:
       "browser.safebrowsing.enterprise.telemetry.unsafeDownload.urlLogging",
   },

--- a/browser/components/enterprisepolicies/helpers/moz.build
+++ b/browser/components/enterprisepolicies/helpers/moz.build
@@ -15,6 +15,7 @@ EXTRA_JS_MODULES.policies += [
 
 if CONFIG["MOZ_ENTERPRISE"]:
     EXTRA_JS_MODULES.policies += [
+        "SecurityLoggingPolicy.sys.mjs",
         "SyncPolicy.sys.mjs",
         "WatermarkChild.sys.mjs",
         "WatermarkParent.sys.mjs",

--- a/browser/components/enterprisepolicies/schemas/policies-schema.json
+++ b/browser/components/enterprisepolicies/schemas/policies-schema.json
@@ -4034,6 +4034,9 @@
       "description": "Enable and configure security logging/telemetry for security-relevant events.",
       "examples": [
         {
+          "AddonInstall": {
+            "Enabled": true
+          },
           "Download": {
             "Enabled": true,
             "UrlLogging": "full",
@@ -4072,6 +4075,14 @@
         }
       ],
       "properties": {
+        "AddonInstall": {
+          "type": "object",
+          "properties": {
+            "Enabled": {
+              "type": "boolean"
+            }
+          }
+        },
         "BlocklistDomainBrowsed": {
           "type": "object",
           "properties": {

--- a/browser/components/enterprisepolicies/schemas/policies-schema.json
+++ b/browser/components/enterprisepolicies/schemas/policies-schema.json
@@ -7,6 +7,26 @@
       "type": "string",
       "anyOf": [{ "format": "uri" }, { "maxLength": 0 }]
     },
+    "urlLoggingLevel": {
+      "type": "string",
+      "oneOf": [
+        {
+          "const": "full",
+          "title": "Full URLs",
+          "description": "Log complete URLs, including paths and parameters."
+        },
+        {
+          "const": "domain",
+          "title": "Domains only",
+          "description": "Log only URL hostnames."
+        },
+        {
+          "const": "none",
+          "title": "No URLs",
+          "description": "Do not log URL information."
+        }
+      ]
+    },
     "origin": {
       "type": "string",
       "format": "uri",
@@ -673,40 +693,6 @@
       "x-restart-required": false,
       "description": "Block access to Troubleshooting Information ('about:support').",
       "examples": [true]
-    },
-
-    "BlocklistDomainBrowsedTelemetry": {
-      "type": "object",
-      "x-category": "Cloud reporting",
-      "x-compatibility": {
-        "firefox": { "version_added": false },
-        "firefox_esr": { "version_added": false },
-        "firefox_enterprise": { "version_added": "149" }
-      },
-      "x-restart-required": false,
-      "description": "Enable and configure security logging when Firefox blocks a visit to a blocklisted domain.",
-      "examples": [
-        {
-          "Enabled": true,
-          "UrlLogging": "full"
-        },
-        {
-          "Enabled": false
-        },
-        {
-          "Enabled": true,
-          "UrlLogging": "none"
-        }
-      ],
-      "properties": {
-        "Enabled": {
-          "type": "boolean"
-        },
-        "UrlLogging": {
-          "type": "string",
-          "enum": ["full", "domain", "none"]
-        }
-      }
     },
 
     "Bookmarks": {
@@ -1979,46 +1965,6 @@
       "x-restart-required": true,
       "description": "Set and lock the download directory.",
       "examples": ["${home}/Downloads"]
-    },
-
-    "DownloadTelemetry": {
-      "type": "object",
-      "x-category": "Cloud reporting",
-      "x-compatibility": {
-        "firefox": { "version_added": false },
-        "firefox_esr": { "version_added": false },
-        "firefox_enterprise": { "version_added": "149" }
-      },
-      "x-restart-required": false,
-      "description": "Enable and configure security logging when a download is triggered. 'UrlLogging' and 'FileLogging' control how much detail about the download source and the file is included in the log.",
-      "examples": [
-        {
-          "Enabled": true,
-          "UrlLogging": "full",
-          "FileLogging": "metadata"
-        },
-        {
-          "Enabled": false
-        },
-        {
-          "Enabled": true,
-          "UrlLogging": "none",
-          "FileLogging": "none"
-        }
-      ],
-      "properties": {
-        "Enabled": {
-          "type": "boolean"
-        },
-        "UrlLogging": {
-          "type": "string",
-          "enum": ["full", "domain", "none"]
-        },
-        "FileLogging": {
-          "type": "string",
-          "enum": ["full", "metadata", "none"]
-        }
-      }
     },
 
     "EnableTrackingProtection": {
@@ -3604,40 +3550,6 @@
       "examples": [false]
     },
 
-    "PrintPageTelemetry": {
-      "type": "object",
-      "x-category": "Cloud reporting",
-      "x-compatibility": {
-        "firefox": { "version_added": false },
-        "firefox_esr": { "version_added": false },
-        "firefox_enterprise": { "version_added": "149" }
-      },
-      "x-restart-required": false,
-      "description": "Enable and configure security logging when a page is printed. 'UrlLogging' controls how much detail about the printed page's address is included in the log.",
-      "examples": [
-        {
-          "Enabled": true,
-          "UrlLogging": "domain"
-        },
-        {
-          "Enabled": false
-        },
-        {
-          "Enabled": true,
-          "UrlLogging": "none"
-        }
-      ],
-      "properties": {
-        "Enabled": {
-          "type": "boolean"
-        },
-        "UrlLogging": {
-          "type": "string",
-          "enum": ["full", "domain", "none"]
-        }
-      }
-    },
-
     "PrivateBrowsingModeAvailability": {
       "type": "number",
       "x-category": "Browsing restrictions",
@@ -4105,6 +4017,124 @@
           "type": "array",
           "items": {
             "type": "string"
+          }
+        }
+      }
+    },
+
+    "SecurityLogging": {
+      "type": "object",
+      "x-category": "Cloud reporting",
+      "x-compatibility": {
+        "firefox": { "version_added": false },
+        "firefox_esr": { "version_added": false },
+        "firefox_enterprise": { "version_added": "156" }
+      },
+      "x-restart-required": false,
+      "description": "Enable and configure security logging/telemetry for security-relevant events.",
+      "examples": [
+        {
+          "Download": {
+            "Enabled": true,
+            "UrlLogging": "full",
+            "FileLogging": "full"
+          },
+          "PrintPage": {
+            "Enabled": true,
+            "UrlLogging": "domain"
+          },
+          "BlocklistDomainBrowsed": {
+            "Enabled": true,
+            "UrlLogging": "full"
+          },
+          "UnsafeSiteVisit": {
+            "Enabled": true,
+            "UrlLogging": "full"
+          },
+          "UnsafeDownload": {
+            "Enabled": true,
+            "UrlLogging": "full"
+          }
+        },
+        {
+          "Download": {
+            "Enabled": false
+          },
+          "PrintPage": {
+            "Enabled": false
+          }
+        },
+        {
+          "UnsafeSiteVisit": {
+            "Enabled": true,
+            "UrlLogging": "none"
+          }
+        }
+      ],
+      "properties": {
+        "BlocklistDomainBrowsed": {
+          "type": "object",
+          "properties": {
+            "Enabled": {
+              "type": "boolean"
+            },
+            "UrlLogging": { "$ref": "#/definitions/urlLoggingLevel" }
+          }
+        },
+        "Download": {
+          "type": "object",
+          "properties": {
+            "Enabled": {
+              "type": "boolean"
+            },
+            "UrlLogging": { "$ref": "#/definitions/urlLoggingLevel" },
+            "FileLogging": {
+              "type": "string",
+              "oneOf": [
+                {
+                  "const": "full",
+                  "title": "Full file information",
+                  "description": "Log filenames, file paths, extensions, and MIME types."
+                },
+                {
+                  "const": "metadata",
+                  "title": "File metadata only",
+                  "description": "Log only file extensions and MIME types."
+                },
+                {
+                  "const": "none",
+                  "title": "No file information",
+                  "description": "Do not log file information."
+                }
+              ]
+            }
+          }
+        },
+        "PrintPage": {
+          "type": "object",
+          "properties": {
+            "Enabled": {
+              "type": "boolean"
+            },
+            "UrlLogging": { "$ref": "#/definitions/urlLoggingLevel" }
+          }
+        },
+        "UnsafeDownload": {
+          "type": "object",
+          "properties": {
+            "Enabled": {
+              "type": "boolean"
+            },
+            "UrlLogging": { "$ref": "#/definitions/urlLoggingLevel" }
+          }
+        },
+        "UnsafeSiteVisit": {
+          "type": "object",
+          "properties": {
+            "Enabled": {
+              "type": "boolean"
+            },
+            "UrlLogging": { "$ref": "#/definitions/urlLoggingLevel" }
           }
         }
       }

--- a/browser/components/enterprisepolicies/tests/browser/browser_policy_websitefilter_telemetry.js
+++ b/browser/components/enterprisepolicies/tests/browser/browser_policy_websitefilter_telemetry.js
@@ -24,19 +24,14 @@ add_task(async function test_policy_enterprise_telemetry() {
       WebsiteFilter: `{
         "Block": ["*://mochi.test/*policy_websitefilter_block*"]
       }`,
+      SecurityLogging: {
+        BlocklistDomainBrowsed: { Enabled: true, UrlLogging: "full" },
+      },
     },
   });
   await SpecialPowers.pushPrefEnv({
     set: [
       ["browser.policies.enterprise.telemetry.testing.disableSubmit", true],
-      [
-        "browser.policies.enterprise.telemetry.blocklistDomainBrowsed.enabled",
-        true,
-      ],
-      [
-        "browser.policies.enterprise.telemetry.blocklistDomainBrowsed.urlLogging",
-        "full",
-      ],
     ],
   });
 

--- a/browser/components/enterprisepolicies/tests/xpcshell/test_security_logging.js
+++ b/browser/components/enterprisepolicies/tests/xpcshell/test_security_logging.js
@@ -4,6 +4,7 @@
 "use strict";
 
 const SECURITY_LOGGING_PREFS = {
+  "extensions.enterprise.telemetry.addonInstall.enabled": true,
   "browser.policies.enterprise.telemetry.blocklistDomainBrowsed.enabled": true,
   "browser.policies.enterprise.telemetry.blocklistDomainBrowsed.urlLogging":
     "domain",
@@ -39,6 +40,7 @@ add_task(async function test_all_events_configured_through_policy_engine() {
   await setupPolicyEngineWithJson({
     policies: {
       SecurityLogging: {
+        AddonInstall: { Enabled: true },
         BlocklistDomainBrowsed: { Enabled: true, UrlLogging: "domain" },
         Download: {
           Enabled: true,

--- a/browser/components/enterprisepolicies/tests/xpcshell/test_security_logging.js
+++ b/browser/components/enterprisepolicies/tests/xpcshell/test_security_logging.js
@@ -1,0 +1,88 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+const SECURITY_LOGGING_PREFS = {
+  "browser.policies.enterprise.telemetry.blocklistDomainBrowsed.enabled": true,
+  "browser.policies.enterprise.telemetry.blocklistDomainBrowsed.urlLogging":
+    "domain",
+  "browser.download.enterprise.telemetry.enabled": true,
+  "browser.download.enterprise.telemetry.urlLogging": "full",
+  "browser.download.enterprise.telemetry.fileLogging": "metadata",
+  "print.enterprise.telemetry.printPage.enabled": false,
+  "print.enterprise.telemetry.printPage.urlLogging": "none",
+  "browser.safebrowsing.enterprise.telemetry.unsafeDownload.enabled": true,
+  "browser.safebrowsing.enterprise.telemetry.unsafeDownload.urlLogging":
+    "domain",
+  "browser.safebrowsing.enterprise.telemetry.unsafeSiteVisit.enabled": true,
+  "browser.safebrowsing.enterprise.telemetry.unsafeSiteVisit.urlLogging":
+    "full",
+};
+
+function lockPrefElsewhere(prefName, prefValue) {
+  const defaults = Services.prefs.getDefaultBranch("");
+  if (typeof prefValue === "boolean") {
+    defaults.setBoolPref(prefName, prefValue);
+  } else {
+    defaults.setStringPref(prefName, prefValue);
+  }
+  Services.prefs.lockPref(prefName);
+}
+
+function clearPrefLockedElsewhere(prefName) {
+  Services.prefs.unlockPref(prefName);
+  Services.prefs.getDefaultBranch("").deleteBranch(prefName);
+}
+
+add_task(async function test_all_events_configured_through_policy_engine() {
+  await setupPolicyEngineWithJson({
+    policies: {
+      SecurityLogging: {
+        BlocklistDomainBrowsed: { Enabled: true, UrlLogging: "domain" },
+        Download: {
+          Enabled: true,
+          UrlLogging: "full",
+          FileLogging: "metadata",
+        },
+        PrintPage: { Enabled: false, UrlLogging: "none" },
+        UnsafeDownload: { Enabled: true, UrlLogging: "domain" },
+        UnsafeSiteVisit: { Enabled: true, UrlLogging: "full" },
+      },
+    },
+  });
+
+  for (const [pref, value] of Object.entries(SECURITY_LOGGING_PREFS)) {
+    checkLockedPref(pref, value);
+  }
+
+  await setupPolicyEngineWithJson("");
+
+  for (const pref of Object.keys(SECURITY_LOGGING_PREFS)) {
+    checkUnsetPref(pref);
+  }
+});
+
+add_task(async function test_unmentioned_settings_are_untouched() {
+  const externalPref = "print.enterprise.telemetry.printPage.enabled";
+  const downloadPref = "browser.download.enterprise.telemetry.enabled";
+  lockPrefElsewhere(externalPref, true);
+
+  try {
+    await setupPolicyEngineWithJson({
+      policies: {
+        SecurityLogging: { Download: { Enabled: true } },
+      },
+    });
+
+    checkLockedPref(downloadPref, true);
+    checkLockedPref(externalPref, true);
+
+    await setupPolicyEngineWithJson("");
+
+    checkUnsetPref(downloadPref);
+    checkLockedPref(externalPref, true);
+  } finally {
+    clearPrefLockedElsewhere(externalPref);
+  }
+});

--- a/browser/components/enterprisepolicies/tests/xpcshell/test_security_logging.js
+++ b/browser/components/enterprisepolicies/tests/xpcshell/test_security_logging.js
@@ -21,21 +21,6 @@ const SECURITY_LOGGING_PREFS = {
     "full",
 };
 
-function lockPrefElsewhere(prefName, prefValue) {
-  const defaults = Services.prefs.getDefaultBranch("");
-  if (typeof prefValue === "boolean") {
-    defaults.setBoolPref(prefName, prefValue);
-  } else {
-    defaults.setStringPref(prefName, prefValue);
-  }
-  Services.prefs.lockPref(prefName);
-}
-
-function clearPrefLockedElsewhere(prefName) {
-  Services.prefs.unlockPref(prefName);
-  Services.prefs.getDefaultBranch("").deleteBranch(prefName);
-}
-
 add_task(async function test_all_events_configured_through_policy_engine() {
   await setupPolicyEngineWithJson({
     policies: {
@@ -56,35 +41,5 @@ add_task(async function test_all_events_configured_through_policy_engine() {
 
   for (const [pref, value] of Object.entries(SECURITY_LOGGING_PREFS)) {
     checkLockedPref(pref, value);
-  }
-
-  await setupPolicyEngineWithJson("");
-
-  for (const pref of Object.keys(SECURITY_LOGGING_PREFS)) {
-    checkUnsetPref(pref);
-  }
-});
-
-add_task(async function test_unmentioned_settings_are_untouched() {
-  const externalPref = "print.enterprise.telemetry.printPage.enabled";
-  const downloadPref = "browser.download.enterprise.telemetry.enabled";
-  lockPrefElsewhere(externalPref, true);
-
-  try {
-    await setupPolicyEngineWithJson({
-      policies: {
-        SecurityLogging: { Download: { Enabled: true } },
-      },
-    });
-
-    checkLockedPref(downloadPref, true);
-    checkLockedPref(externalPref, true);
-
-    await setupPolicyEngineWithJson("");
-
-    checkUnsetPref(downloadPref);
-    checkLockedPref(externalPref, true);
-  } finally {
-    clearPrefLockedElsewhere(externalPref);
   }
 });

--- a/browser/components/enterprisepolicies/tests/xpcshell/xpcshell.toml
+++ b/browser/components/enterprisepolicies/tests/xpcshell/xpcshell.toml
@@ -83,6 +83,9 @@ skip-if = ["enterprise"] # Bug 2065476: skip tests for enterprise builds ; re-en
 
 ["test_security_devices.js"]
 
+["test_security_logging.js"]
+run-if = ["enterprise"]
+
 ["test_simple_pref_policies.js"]
 
 ["test_sitepolicies.js"]

--- a/browser/locales/en-US/browser/enterprise/enterprise-policies-descriptions.ftl
+++ b/browser/locales/en-US/browser/enterprise/enterprise-policies-descriptions.ftl
@@ -4,13 +4,11 @@
 
 policy-AccessConnector2 = Configure the { -enterprise-feature-access-connector } for proxying web traffic.
 policy-AIChatbot = Configure available AI chatbot providers, default provider, and prompt features.
-policy-BlocklistDomainBrowsedTelemetry = Enable and configure security logging/telemetry when { -brand-short-name } blocks a visit to a blocklisted domain.
 policy-ContentAnalysisTelemetry = Enable and configure security logging/telemetry when a data loss prevention (DLP) rule is triggered.
 policy-DataLossPrevention = Enable and configure built-in data loss prevention (DLP) engine.
 policy-DisableLocalPolicies = Disable all local policy sources (policies.json, Windows GPO and macOS plist).
-policy-DownloadTelemetry = Enable and configure security logging/telemetry when a download is triggered.
 policy-EnterpriseStorageEncryption = Enable enterprise-managed primary password for encrypted storage.
-policy-PrintPageTelemetry = Enable and configure security logging/telemetry when a page is printed.
+policy-SecurityLogging = Enable and configure security logging/telemetry for security-relevant events.
 policy-Sync = Enable or disable sync and define which data to include.
 policy-CrashReportsSubmit = Configure crash report submission settings.
 policy-Watermark = Display a tiled, diagonal watermark over a list of websites.

--- a/toolkit/components/enterprisepolicies/tests/xpcshell/live/test_live_policy_SecurityLogging.js
+++ b/toolkit/components/enterprisepolicies/tests/xpcshell/live/test_live_policy_SecurityLogging.js
@@ -9,10 +9,23 @@ const { DownloadsTelemetryEnterprise } = ChromeUtils.importESModule(
 
 const ADDON_INSTALL_ENABLED_PREF =
   "extensions.enterprise.telemetry.addonInstall.enabled";
+const BLOCKLIST_ENABLED_PREF =
+  "browser.policies.enterprise.telemetry.blocklistDomainBrowsed.enabled";
+const BLOCKLIST_URL_PREF =
+  "browser.policies.enterprise.telemetry.blocklistDomainBrowsed.urlLogging";
 const DOWNLOAD_ENABLED_PREF = "browser.download.enterprise.telemetry.enabled";
 const DOWNLOAD_URL_PREF = "browser.download.enterprise.telemetry.urlLogging";
 const DOWNLOAD_FILE_PREF = "browser.download.enterprise.telemetry.fileLogging";
 const PRINT_ENABLED_PREF = "print.enterprise.telemetry.printPage.enabled";
+const PRINT_URL_PREF = "print.enterprise.telemetry.printPage.urlLogging";
+const UNSAFE_DOWNLOAD_ENABLED_PREF =
+  "browser.safebrowsing.enterprise.telemetry.unsafeDownload.enabled";
+const UNSAFE_DOWNLOAD_URL_PREF =
+  "browser.safebrowsing.enterprise.telemetry.unsafeDownload.urlLogging";
+const UNSAFE_SITE_ENABLED_PREF =
+  "browser.safebrowsing.enterprise.telemetry.unsafeSiteVisit.enabled";
+const UNSAFE_SITE_URL_PREF =
+  "browser.safebrowsing.enterprise.telemetry.unsafeSiteVisit.urlLogging";
 const TEST_URL = "https://example.com/path/file.pdf";
 
 async function updatePolicies(policy) {
@@ -27,12 +40,15 @@ add_task(async function test_security_logging_applied_updated_removed_live() {
       policies: {
         SecurityLogging: {
           AddonInstall: { Enabled: true },
+          BlocklistDomainBrowsed: { Enabled: true, UrlLogging: "domain" },
           Download: {
             Enabled: true,
             UrlLogging: "domain",
             FileLogging: "metadata",
           },
-          PrintPage: { Enabled: true },
+          PrintPage: { Enabled: true, UrlLogging: "none" },
+          UnsafeDownload: { Enabled: true, UrlLogging: "domain" },
+          UnsafeSiteVisit: { Enabled: true, UrlLogging: "full" },
         },
       },
     },
@@ -44,10 +60,25 @@ add_task(async function test_security_logging_applied_updated_removed_live() {
     true,
     true
   );
+  EnterprisePolicyTesting.checkPolicyPref(BLOCKLIST_ENABLED_PREF, true, true);
+  EnterprisePolicyTesting.checkPolicyPref(BLOCKLIST_URL_PREF, "domain", true);
   EnterprisePolicyTesting.checkPolicyPref(DOWNLOAD_ENABLED_PREF, true, true);
   EnterprisePolicyTesting.checkPolicyPref(DOWNLOAD_URL_PREF, "domain", true);
   EnterprisePolicyTesting.checkPolicyPref(DOWNLOAD_FILE_PREF, "metadata", true);
   EnterprisePolicyTesting.checkPolicyPref(PRINT_ENABLED_PREF, true, true);
+  EnterprisePolicyTesting.checkPolicyPref(PRINT_URL_PREF, "none", true);
+  EnterprisePolicyTesting.checkPolicyPref(
+    UNSAFE_DOWNLOAD_ENABLED_PREF,
+    true,
+    true
+  );
+  EnterprisePolicyTesting.checkPolicyPref(
+    UNSAFE_DOWNLOAD_URL_PREF,
+    "domain",
+    true
+  );
+  EnterprisePolicyTesting.checkPolicyPref(UNSAFE_SITE_ENABLED_PREF, true, true);
+  EnterprisePolicyTesting.checkPolicyPref(UNSAFE_SITE_URL_PREF, "full", true);
   Assert.ok(DownloadsTelemetryEnterprise._isEnabled());
   Assert.equal(
     DownloadsTelemetryEnterprise._processSourceUrl(TEST_URL),
@@ -91,7 +122,34 @@ add_task(async function test_security_logging_applied_updated_removed_live() {
   EnterprisePolicyTesting.checkPolicyPref(DOWNLOAD_ENABLED_PREF, false, true);
   EnterprisePolicyTesting.checkPolicyPref(DOWNLOAD_URL_PREF, "none", true);
   EnterprisePolicyTesting.checkPolicyPref(DOWNLOAD_FILE_PREF, "none", true);
+  EnterprisePolicyTesting.checkPolicyPref(
+    BLOCKLIST_ENABLED_PREF,
+    undefined,
+    false
+  );
+  EnterprisePolicyTesting.checkPolicyPref(BLOCKLIST_URL_PREF, undefined, false);
   EnterprisePolicyTesting.checkPolicyPref(PRINT_ENABLED_PREF, undefined, false);
+  EnterprisePolicyTesting.checkPolicyPref(PRINT_URL_PREF, undefined, false);
+  EnterprisePolicyTesting.checkPolicyPref(
+    UNSAFE_DOWNLOAD_ENABLED_PREF,
+    undefined,
+    false
+  );
+  EnterprisePolicyTesting.checkPolicyPref(
+    UNSAFE_DOWNLOAD_URL_PREF,
+    undefined,
+    false
+  );
+  EnterprisePolicyTesting.checkPolicyPref(
+    UNSAFE_SITE_ENABLED_PREF,
+    undefined,
+    false
+  );
+  EnterprisePolicyTesting.checkPolicyPref(
+    UNSAFE_SITE_URL_PREF,
+    undefined,
+    false
+  );
   Assert.ok(!DownloadsTelemetryEnterprise._isEnabled());
   Assert.equal(
     DownloadsTelemetryEnterprise._processSourceUrl(TEST_URL),
@@ -129,4 +187,33 @@ add_task(async function test_security_logging_applied_updated_removed_live() {
     TEST_URL,
     "the download recorder returns to its default after policy removal"
   );
+});
+
+add_task(async function test_unmentioned_settings_are_untouched_live() {
+  const defaults = Services.prefs.getDefaultBranch("");
+  defaults.setBoolPref(PRINT_ENABLED_PREF, true);
+  Services.prefs.lockPref(PRINT_ENABLED_PREF);
+
+  try {
+    await updatePolicies({
+      policies: {
+        SecurityLogging: { Download: { Enabled: true } },
+      },
+    });
+
+    EnterprisePolicyTesting.checkPolicyPref(DOWNLOAD_ENABLED_PREF, true, true);
+    EnterprisePolicyTesting.checkPolicyPref(PRINT_ENABLED_PREF, true, true);
+
+    await updatePolicies({ policies: {} });
+
+    EnterprisePolicyTesting.checkPolicyPref(
+      DOWNLOAD_ENABLED_PREF,
+      undefined,
+      false
+    );
+    EnterprisePolicyTesting.checkPolicyPref(PRINT_ENABLED_PREF, true, true);
+  } finally {
+    Services.prefs.unlockPref(PRINT_ENABLED_PREF);
+    defaults.deleteBranch(PRINT_ENABLED_PREF);
+  }
 });

--- a/toolkit/components/enterprisepolicies/tests/xpcshell/live/test_live_policy_SecurityLogging.js
+++ b/toolkit/components/enterprisepolicies/tests/xpcshell/live/test_live_policy_SecurityLogging.js
@@ -7,6 +7,8 @@ const { DownloadsTelemetryEnterprise } = ChromeUtils.importESModule(
   "moz-src:///browser/components/downloads/DownloadsTelemetry.enterprise.sys.mjs"
 );
 
+const ADDON_INSTALL_ENABLED_PREF =
+  "extensions.enterprise.telemetry.addonInstall.enabled";
 const DOWNLOAD_ENABLED_PREF = "browser.download.enterprise.telemetry.enabled";
 const DOWNLOAD_URL_PREF = "browser.download.enterprise.telemetry.urlLogging";
 const DOWNLOAD_FILE_PREF = "browser.download.enterprise.telemetry.fileLogging";
@@ -24,6 +26,7 @@ add_task(async function test_security_logging_applied_updated_removed_live() {
     {
       policies: {
         SecurityLogging: {
+          AddonInstall: { Enabled: true },
           Download: {
             Enabled: true,
             UrlLogging: "domain",
@@ -36,6 +39,11 @@ add_task(async function test_security_logging_applied_updated_removed_live() {
     null
   );
 
+  EnterprisePolicyTesting.checkPolicyPref(
+    ADDON_INSTALL_ENABLED_PREF,
+    true,
+    true
+  );
   EnterprisePolicyTesting.checkPolicyPref(DOWNLOAD_ENABLED_PREF, true, true);
   EnterprisePolicyTesting.checkPolicyPref(DOWNLOAD_URL_PREF, "domain", true);
   EnterprisePolicyTesting.checkPolicyPref(DOWNLOAD_FILE_PREF, "metadata", true);
@@ -65,6 +73,7 @@ add_task(async function test_security_logging_applied_updated_removed_live() {
   await updatePolicies({
     policies: {
       SecurityLogging: {
+        AddonInstall: { Enabled: false },
         Download: {
           Enabled: false,
           UrlLogging: "none",
@@ -74,6 +83,11 @@ add_task(async function test_security_logging_applied_updated_removed_live() {
     },
   });
 
+  EnterprisePolicyTesting.checkPolicyPref(
+    ADDON_INSTALL_ENABLED_PREF,
+    false,
+    true
+  );
   EnterprisePolicyTesting.checkPolicyPref(DOWNLOAD_ENABLED_PREF, false, true);
   EnterprisePolicyTesting.checkPolicyPref(DOWNLOAD_URL_PREF, "none", true);
   EnterprisePolicyTesting.checkPolicyPref(DOWNLOAD_FILE_PREF, "none", true);
@@ -97,6 +111,11 @@ add_task(async function test_security_logging_applied_updated_removed_live() {
 
   await updatePolicies({ policies: {} });
 
+  EnterprisePolicyTesting.checkPolicyPref(
+    ADDON_INSTALL_ENABLED_PREF,
+    undefined,
+    false
+  );
   EnterprisePolicyTesting.checkPolicyPref(
     DOWNLOAD_ENABLED_PREF,
     undefined,

--- a/toolkit/components/enterprisepolicies/tests/xpcshell/live/test_live_policy_SecurityLogging.js
+++ b/toolkit/components/enterprisepolicies/tests/xpcshell/live/test_live_policy_SecurityLogging.js
@@ -1,0 +1,113 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+const { DownloadsTelemetryEnterprise } = ChromeUtils.importESModule(
+  "moz-src:///browser/components/downloads/DownloadsTelemetry.enterprise.sys.mjs"
+);
+
+const DOWNLOAD_ENABLED_PREF = "browser.download.enterprise.telemetry.enabled";
+const DOWNLOAD_URL_PREF = "browser.download.enterprise.telemetry.urlLogging";
+const DOWNLOAD_FILE_PREF = "browser.download.enterprise.telemetry.fileLogging";
+const PRINT_ENABLED_PREF = "print.enterprise.telemetry.printPage.enabled";
+const TEST_URL = "https://example.com/path/file.pdf";
+
+async function updatePolicies(policy) {
+  const updateApplied = EnterprisePolicyTesting.awaitNextPolicyUpdate();
+  EnterprisePolicyTesting.stubRemotePolicies(policy);
+  await updateApplied;
+}
+
+add_task(async function test_security_logging_applied_updated_removed_live() {
+  await EnterprisePolicyTesting.setupEngineWithRemotePolicies(
+    {
+      policies: {
+        SecurityLogging: {
+          Download: {
+            Enabled: true,
+            UrlLogging: "domain",
+            FileLogging: "metadata",
+          },
+          PrintPage: { Enabled: true },
+        },
+      },
+    },
+    null
+  );
+
+  EnterprisePolicyTesting.checkPolicyPref(DOWNLOAD_ENABLED_PREF, true, true);
+  EnterprisePolicyTesting.checkPolicyPref(DOWNLOAD_URL_PREF, "domain", true);
+  EnterprisePolicyTesting.checkPolicyPref(DOWNLOAD_FILE_PREF, "metadata", true);
+  EnterprisePolicyTesting.checkPolicyPref(PRINT_ENABLED_PREF, true, true);
+  Assert.ok(DownloadsTelemetryEnterprise._isEnabled());
+  Assert.equal(
+    DownloadsTelemetryEnterprise._processSourceUrl(TEST_URL),
+    "example.com",
+    "the download recorder observes the applied URL logging level"
+  );
+  Assert.deepEqual(
+    DownloadsTelemetryEnterprise._processFileInfo(
+      "file.pdf",
+      "/tmp/file.pdf",
+      "pdf",
+      "application/pdf"
+    ),
+    {
+      filename: "",
+      file_path: "",
+      extension: "pdf",
+      mime_type: "application/pdf",
+    },
+    "the download recorder observes the applied file logging level"
+  );
+
+  await updatePolicies({
+    policies: {
+      SecurityLogging: {
+        Download: {
+          Enabled: false,
+          UrlLogging: "none",
+          FileLogging: "none",
+        },
+      },
+    },
+  });
+
+  EnterprisePolicyTesting.checkPolicyPref(DOWNLOAD_ENABLED_PREF, false, true);
+  EnterprisePolicyTesting.checkPolicyPref(DOWNLOAD_URL_PREF, "none", true);
+  EnterprisePolicyTesting.checkPolicyPref(DOWNLOAD_FILE_PREF, "none", true);
+  EnterprisePolicyTesting.checkPolicyPref(PRINT_ENABLED_PREF, undefined, false);
+  Assert.ok(!DownloadsTelemetryEnterprise._isEnabled());
+  Assert.equal(
+    DownloadsTelemetryEnterprise._processSourceUrl(TEST_URL),
+    null,
+    "the download recorder observes a live URL logging update"
+  );
+  Assert.deepEqual(
+    DownloadsTelemetryEnterprise._processFileInfo(
+      "file.pdf",
+      "/tmp/file.pdf",
+      "pdf",
+      "application/pdf"
+    ),
+    { filename: "", file_path: "", extension: "", mime_type: "" },
+    "the download recorder observes a live file logging update"
+  );
+
+  await updatePolicies({ policies: {} });
+
+  EnterprisePolicyTesting.checkPolicyPref(
+    DOWNLOAD_ENABLED_PREF,
+    undefined,
+    false
+  );
+  EnterprisePolicyTesting.checkPolicyPref(DOWNLOAD_URL_PREF, undefined, false);
+  EnterprisePolicyTesting.checkPolicyPref(DOWNLOAD_FILE_PREF, undefined, false);
+  Assert.ok(DownloadsTelemetryEnterprise._isEnabled());
+  Assert.equal(
+    DownloadsTelemetryEnterprise._processSourceUrl(TEST_URL),
+    TEST_URL,
+    "the download recorder returns to its default after policy removal"
+  );
+});

--- a/toolkit/components/enterprisepolicies/tests/xpcshell/live/xpcshell.toml
+++ b/toolkit/components/enterprisepolicies/tests/xpcshell/live/xpcshell.toml
@@ -5,4 +5,6 @@ run-if = ["enterprise"]
 
 ["test_live_policy_Proxy.js"]
 
+["test_live_policy_SecurityLogging.js"]
+
 ["test_live_policy_Sync.js"]

--- a/toolkit/components/printing/metrics.yaml
+++ b/toolkit/components/printing/metrics.yaml
@@ -109,9 +109,7 @@ printing:
     extra_keys:
       source_url:
         description: >
-          The printed page source URL. Collection level configurable via
-          enterprise policy DownloadTelemetryUrlLogging: "full" (default),
-          "domain", or "none".
+          The printed page source URL.
         type: string
       content_title:
         description: >
@@ -120,9 +118,7 @@ printing:
       top_level_source_url:
         description: >
           The printed page top level source URL. May differ from
-          source_url when printing a selection. Collection level
-          configurable via enterprise policy DownloadTelemetryUrlLogging:
-          "full" (default), "domain", or "none".
+          source_url when printing a selection.
         type: string
       top_level_content_title:
         description: >

--- a/toolkit/components/reputationservice/metrics.yaml
+++ b/toolkit/components/reputationservice/metrics.yaml
@@ -333,11 +333,8 @@ safebrowsing:
     extra_keys:
       url:
         description: >
-          The source URL the download originated from. Collection level is
-          configurable via the
-          browser.safebrowsing.enterprise.telemetry.unsafeDownload.urlLogging
-          pref: "full" (default), "domain", or "none". In "full" mode any
-          password in the URL is masked.
+          The source URL the download originated from. When the complete URL is
+          recorded, any password in it is masked.
         type: string
       verdict:
         description: >

--- a/toolkit/components/url-classifier/metrics.yaml
+++ b/toolkit/components/url-classifier/metrics.yaml
@@ -774,19 +774,14 @@ safebrowsing:
     extra_keys:
       url:
         description: >
-          The URL of the unsafe site that was blocked. Collection level is
-          configurable via the
-          browser.safebrowsing.enterprise.telemetry.unsafeSiteVisit.urlLogging
-          pref: "full" (default), "domain", or "none". In "full" mode any
-          password in the URL is masked.
+          The URL of the unsafe site that was blocked. When the complete URL is
+          recorded, any password in it is masked.
         type: string
       referrer:
         description: >
           The referrer of the blocked load, i.e. the page that embedded or
           linked to the unsafe resource. Empty when there is no referrer.
-          Redacted with the same collection level as the url key, per the
-          browser.safebrowsing.enterprise.telemetry.unsafeSiteVisit.urlLogging
-          pref.
+          Collected at the same level of detail as the url key.
         type: string
       threat_type:
         description: >

--- a/toolkit/mozapps/extensions/AddonManager.sys.mjs
+++ b/toolkit/mozapps/extensions/AddonManager.sys.mjs
@@ -5847,8 +5847,12 @@ AMTelemetry = {
     );
     if (
       AppConstants.MOZ_ENTERPRISE &&
-      eventMethod == "install" &&
-      extraVars?.step == "completed"
+      Services.prefs.getBoolPref(
+        "extensions.enterprise.telemetry.addonInstall.enabled",
+        true
+      ) &&
+      eventMethod === "install" &&
+      extraVars?.step === "completed"
     ) {
       Glean.addonsManager.installComplete.record(
         this.formatExtraVars({
@@ -5868,7 +5872,14 @@ AMTelemetry = {
           site_permission: install.newSitePerm,
         })
       );
-      GleanPings.enterprise.submit();
+      if (
+        !Services.prefs.getBoolPref(
+          "extensions.enterprise.telemetry.testing.disableSubmit",
+          false
+        )
+      ) {
+        GleanPings.enterprise.submit();
+      }
     }
   },
 

--- a/toolkit/mozapps/extensions/test/xpcshell/test_enterprise_install_telemetry_policy.js
+++ b/toolkit/mozapps/extensions/test/xpcshell/test_enterprise_install_telemetry_policy.js
@@ -1,0 +1,83 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+const { EnterprisePolicyTesting, PoliciesPrefTracker } =
+  ChromeUtils.importESModule(
+    "resource://testing-common/EnterprisePolicyTesting.sys.mjs"
+  );
+
+const PREF_ENABLED = "extensions.enterprise.telemetry.addonInstall.enabled";
+const PREF_DISABLE_SUBMIT =
+  "extensions.enterprise.telemetry.testing.disableSubmit";
+
+async function installExtension(id) {
+  Services.fog.testResetFOG();
+  const extension = ExtensionTestUtils.loadExtension({
+    manifest: {
+      browser_specific_settings: { gecko: { id } },
+    },
+    useAddonManager: "permanent",
+    amInstallTelemetryInfo: {
+      source: "about:addons",
+      method: "install-from-file",
+    },
+  });
+
+  await extension.startup();
+  const events = Glean.addonsManager.installComplete.testGetValue("enterprise");
+  await extension.unload();
+  return events;
+}
+
+add_setup(async function () {
+  do_get_profile();
+  Services.fog.initializeFOG();
+  Services.prefs.setBoolPref(PREF_DISABLE_SUBMIT, true);
+  Services.policies; // eslint-disable-line no-unused-expressions
+  PoliciesPrefTracker.start();
+  createAppInfo("xpcshell@tests.mozilla.org", "XPCShell", "1", "1.9.2");
+  await promiseStartupManager();
+
+  registerCleanupFunction(async () => {
+    await EnterprisePolicyTesting.setupPolicyEngineWithJson("");
+    Services.prefs.clearUserPref(PREF_DISABLE_SUBMIT);
+    PoliciesPrefTracker.stop();
+    await promiseShutdownManager();
+  });
+});
+
+add_task(async function test_addon_install_telemetry_policy() {
+  await EnterprisePolicyTesting.setupPolicyEngineWithJson({
+    policies: {
+      SecurityLogging: { AddonInstall: { Enabled: true } },
+    },
+  });
+
+  EnterprisePolicyTesting.checkPolicyPref(PREF_ENABLED, true, true);
+  let events = await installExtension("enabled@example.com");
+  Assert.equal(events?.length, 1, "the enabled policy records an installation");
+
+  await EnterprisePolicyTesting.setupPolicyEngineWithJson({
+    policies: {
+      SecurityLogging: { AddonInstall: { Enabled: false } },
+    },
+  });
+
+  EnterprisePolicyTesting.checkPolicyPref(PREF_ENABLED, false, true);
+  events = await installExtension("disabled@example.com");
+  Assert.ok(
+    !events?.length,
+    "the disabled policy suppresses installation telemetry"
+  );
+
+  await EnterprisePolicyTesting.setupPolicyEngineWithJson("");
+
+  Assert.ok(
+    !Services.prefs.prefIsLocked(PREF_ENABLED),
+    "the preference is unlocked"
+  );
+  events = await installExtension("default@example.com");
+  Assert.equal(events?.length, 1, "removing the policy restores collection");
+});

--- a/toolkit/mozapps/extensions/test/xpcshell/xpcshell.toml
+++ b/toolkit/mozapps/extensions/test/xpcshell/xpcshell.toml
@@ -149,6 +149,9 @@ run-if = [
 
 ["test_embedderDisabled.js"]
 
+["test_enterprise_install_telemetry_policy.js"]
+run-if = ["enterprise"]
+
 ["test_error.js"]
 skip-if = [
   "os == 'win'", # Bug 1508482


### PR DESCRIPTION
### Description

Bugzilla: [Bug 2058036](https://bugzilla.mozilla.org/show_bug.cgi?id=2058036)

Consolidates `DownloadTelemetry`, `PrintPageTelemetry`, and
`BlocklistDomainBrowsedTelemetry` into a single `SecurityLogging` policy with a
sub-object for each security event. A separate second commit adds control over
the existing enterprise add-on installation event.

```json
{
  "policies": {
    "SecurityLogging": {
      "AddonInstall": { "Enabled": true },
      "BlocklistDomainBrowsed": { "Enabled": true, "UrlLogging": "full" },
      "Download": {
        "Enabled": true,
        "UrlLogging": "full",
        "FileLogging": "metadata"
      },
      "PrintPage": { "Enabled": true, "UrlLogging": "domain" },
      "UnsafeDownload": { "Enabled": true, "UrlLogging": "full" },
      "UnsafeSiteVisit": { "Enabled": true, "UrlLogging": "full" }
    }
  }
}
```

The original telemetry preferences remain unchanged.
`AddonInstall.Enabled` uses a new preference and preserves existing collection
behavior when the policy is absent. The three superseded policy names were not
customer-facing and are removed without compatibility aliases.

### Implementation

`SecurityLoggingPolicy.sys.mjs` maps explicitly configured settings to locked
preferences after schema validation. Live updates remove settings from the
previous policy before applying the new configuration, so unrelated or omitted
preferences remain untouched.

The schema supports enterprise version 156 and marks the policy as not requiring
a restart. Nested objects work with the existing Windows GPO and macOS plist
parsers.

### Testing

Tests configure values through the enterprise policy engine and cover:

- applying and removing every `SecurityLogging` setting;
- live remote-policy updates and their effect on download telemetry;
- enabled, disabled, and removed add-on installation states through a real
  Addon Manager installation flow; and
- WebsiteFilter telemetry using the consolidated policy.

Validation on the final rebased stack:

- `./mach format`
- `./mach lint` (0 errors; one unrelated existing warning)
