### PR TITLE
Bug 2062723 - Update policy schema to make tests passing

### DIFF
--- a/browser/components/enterprisepolicies/Policies.sys.mjs
+++ b/browser/components/enterprisepolicies/Policies.sys.mjs
@@ -1570,10 +1570,6 @@ export var Policies = {
     },
   },
 
-  // The policy got applied by the policy engine when building the CombinedPoliciesProvider.
-  // It skipped any local policy provider (policies.json, Windows GPO and macOS plist)
-  DisableLocalPolicies: {},
-
   DisableLaunchOnLogin: {
     onBeforeAddons(manager, param) {
       if (!param || AppConstants.platform !== "win") {
@@ -1587,6 +1583,10 @@ export var Policies = {
       lazy.WindowsLaunchOnLogin.removeLaunchOnLogin();
     },
   },
+
+  // The policy got applied by the policy engine when building the CombinedPoliciesProvider.
+  // It skipped any local policy provider (policies.json, Windows GPO and macOS plist)
+  DisableLocalPolicies: {},
 
   DisableMasterPasswordCreation: {
     onBeforeUIStartup(manager, param) {

--- a/browser/components/enterprisepolicies/schemas/policies-schema.json
+++ b/browser/components/enterprisepolicies/schemas/policies-schema.json
@@ -1835,7 +1835,7 @@
         "firefox_enterprise": { "version_added": "149" }
       },
       "description": "Enable an enterprise-managed primary password so that stored credentials and other sensitive profile data are kept encrypted at rest.",
-      "examples": [true, false]
+      "examples": [true]
     },
 
     "ExemptDomainFileTypePairsFromFileTypeDownloadWarnings": {

--- a/browser/components/enterprisepolicies/schemas/policies-schema.json
+++ b/browser/components/enterprisepolicies/schemas/policies-schema.json
@@ -107,7 +107,7 @@
         "firefox_esr": { "version_added": false },
         "firefox_enterprise": { "version_added": "151" }
       },
-      "description": "Controls access to AI chat services. The built-in providers are Anthropic Claude, ChatGPT, Copilot, Google Gemini, HuggingChat, Le Chat Mistral, and a locally running AI chatbot, all of which can be enabled individually.",
+      "description": "Controls access to AI chat services. Built-in providers can be enabled individually. For custom providers, add them to the 'Add' array. The 'Default' field specifies which provider is used by default.",
       "examples": [
         {
           "Providers": {
@@ -1835,7 +1835,6 @@
         "firefox_enterprise": { "version_added": "149" }
       },
       "description": "Enable an enterprise-managed primary password so that stored credentials and other sensitive profile data are kept encrypted at rest.",
-      "default": false,
       "examples": [true, false]
     },
 

--- a/browser/components/enterprisepolicies/schemas/policies-schema.json
+++ b/browser/components/enterprisepolicies/schemas/policies-schema.json
@@ -64,7 +64,7 @@
       "x-compatibility": {
         "firefox": { "version_added": false },
         "firefox_esr": { "version_added": false },
-        "firefox_enterprise": { "version_added": "151" }
+        "firefox_enterprise": { "version_added": "149" }
       },
       "description": "Configures an Access Connector for proxying web traffic. Traffic is routed through the server by 'Host' and 'Port'. If 'MatchPatterns' is set, only URLs matching those patterns are routed through the connector.",
       "examples": [
@@ -105,7 +105,7 @@
       "x-compatibility": {
         "firefox": { "version_added": false },
         "firefox_esr": { "version_added": false },
-        "firefox_enterprise": { "version_added": "151" }
+        "firefox_enterprise": { "version_added": "149" }
       },
       "description": "Controls access to AI chat services. Built-in providers can be enabled individually. For custom providers, add them to the 'Add' array. The 'Default' field specifies which provider is used by default.",
       "examples": [
@@ -1045,7 +1045,7 @@
       "x-compatibility": {
         "firefox": { "version_added": false },
         "firefox_esr": { "version_added": false },
-        "firefox_enterprise": { "version_added": "151" }
+        "firefox_enterprise": { "version_added": "154" }
       },
       "description": "Configure crash report submission settings.",
       "examples": [
@@ -1422,7 +1422,7 @@
       "x-compatibility": {
         "firefox": { "version_added": false },
         "firefox_esr": { "version_added": false },
-        "firefox_enterprise": { "version_added": "154" }
+        "firefox_enterprise": { "version_added": "155" }
       },
       "description": "Disable all local policy sources (policies.json, Windows GPO and macOS plist).",
       "examples": [true, false]
@@ -3661,7 +3661,7 @@
       "x-compatibility": {
         "firefox": { "version_added": false },
         "firefox_esr": { "version_added": false },
-        "firefox_enterprise": { "version_added": "149" }
+        "firefox_enterprise": { "version_added": "150" }
       },
       "description": "Enable or disable sync and define which data to include.",
       "examples": [

--- a/browser/components/enterprisepolicies/schemas/policies-schema.json
+++ b/browser/components/enterprisepolicies/schemas/policies-schema.json
@@ -61,7 +61,12 @@
     "AccessConnector": {
       "type": "object",
       "x-category": "Network",
-      "description": "AccessConnector",
+      "x-compatibility": {
+        "firefox": { "version_added": false },
+        "firefox_esr": { "version_added": false },
+        "firefox_enterprise": { "version_added": "151" }
+      },
+      "description": "Configures an Access Connector for proxying web traffic. Traffic is routed through the server by 'Host' and 'Port'. If 'MatchPatterns' is set, only URLs matching those patterns are routed through the connector.",
       "examples": [
         {
           "Host": "company-hq.company.com",
@@ -97,7 +102,12 @@
     "AIChatbot": {
       "type": "object",
       "x-category": "Content settings",
-      "description": "Controls access to AI chat services. The built-in providers are Anthropic Claude, ChatGPT, Copilot, Google Gemini, HuggingChat, Le Chat Mistral, and a locally running AI chatbot. These can be enabled individually. For custom providers, add them to the 'Add' array. The 'Default' field specifies which provider is used by default.",
+      "x-compatibility": {
+        "firefox": { "version_added": false },
+        "firefox_esr": { "version_added": false },
+        "firefox_enterprise": { "version_added": "151" }
+      },
+      "description": "Controls access to AI chat services. The built-in providers are Anthropic Claude, ChatGPT, Copilot, Google Gemini, HuggingChat, Le Chat Mistral, and a locally running AI chatbot, all of which can be enabled individually.",
       "examples": [
         {
           "Providers": {
@@ -573,7 +583,12 @@
     "BlocklistDomainBrowsedTelemetry": {
       "type": "object",
       "x-category": "Cloud reporting",
-      "description": "Enable and configure security logging/telemetry when Firefox blocks a visit to a blocklisted domain.",
+      "x-compatibility": {
+        "firefox": { "version_added": false },
+        "firefox_esr": { "version_added": false },
+        "firefox_enterprise": { "version_added": "149" }
+      },
+      "description": "Enable and configure security logging when Firefox blocks a visit to a blocklisted domain.",
       "examples": [
         {
           "Enabled": true,
@@ -926,7 +941,12 @@
     "ContentAnalysisTelemetry": {
       "type": "object",
       "x-category": "Cloud reporting",
-      "description": "Enable and configure security logging/telemetry when a DLP rule is triggered.",
+      "x-compatibility": {
+        "firefox": { "version_added": false },
+        "firefox_esr": { "version_added": false },
+        "firefox_enterprise": { "version_added": "155" }
+      },
+      "description": "Enable and configure security logging when a DLP rule is triggered.",
       "examples": [
         {
           "Enabled": true,
@@ -1022,6 +1042,11 @@
     "CrashReportsSubmit": {
       "type": "object",
       "x-category": "Cloud reporting",
+      "x-compatibility": {
+        "firefox": { "version_added": false },
+        "firefox_esr": { "version_added": false },
+        "firefox_enterprise": { "version_added": "151" }
+      },
       "description": "Configure crash report submission settings.",
       "examples": [
         {
@@ -1041,6 +1066,11 @@
     "DataLossPrevention": {
       "type": "object",
       "x-category": "Cloud reporting",
+      "x-compatibility": {
+        "firefox": { "version_added": false },
+        "firefox_esr": { "version_added": false },
+        "firefox_enterprise": { "version_added": "155" }
+      },
       "description": "Configure built-in Data Loss Prevention rules that warn on or block data actions (paste, copy, upload, download, print) per domain.",
       "examples": [
         {
@@ -1389,6 +1419,11 @@
     "DisableLocalPolicies": {
       "type": "boolean",
       "x-category": "Miscellaneous",
+      "x-compatibility": {
+        "firefox": { "version_added": false },
+        "firefox_esr": { "version_added": false },
+        "firefox_enterprise": { "version_added": "154" }
+      },
       "description": "Disable all local policy sources (policies.json, Windows GPO and macOS plist).",
       "examples": [true, false]
     },
@@ -1671,8 +1706,27 @@
     "DownloadTelemetry": {
       "type": "object",
       "x-category": "Cloud reporting",
-      "description": "DownloadTelemetry",
-      "examples": [],
+      "x-compatibility": {
+        "firefox": { "version_added": false },
+        "firefox_esr": { "version_added": false },
+        "firefox_enterprise": { "version_added": "149" }
+      },
+      "description": "Enable and configure security logging when a download is triggered. 'UrlLogging' and 'FileLogging' control how much detail about the download source and the file is included in the log.",
+      "examples": [
+        {
+          "Enabled": true,
+          "UrlLogging": "full",
+          "FileLogging": "metadata"
+        },
+        {
+          "Enabled": false
+        },
+        {
+          "Enabled": true,
+          "UrlLogging": "none",
+          "FileLogging": "none"
+        }
+      ],
       "properties": {
         "Enabled": {
           "type": "boolean"
@@ -1775,8 +1829,14 @@
     "EnterpriseStorageEncryption": {
       "type": "boolean",
       "x-category": "Miscellaneous",
-      "description": "EnterpriseStorageEncryption",
-      "examples": []
+      "x-compatibility": {
+        "firefox": { "version_added": false },
+        "firefox_esr": { "version_added": false },
+        "firefox_enterprise": { "version_added": "149" }
+      },
+      "description": "Enable an enterprise-managed primary password so that stored credentials and other sensitive profile data are kept encrypted at rest.",
+      "default": false,
+      "examples": [true, false]
     },
 
     "ExemptDomainFileTypePairsFromFileTypeDownloadWarnings": {
@@ -3028,8 +3088,25 @@
     "PrintPageTelemetry": {
       "type": "object",
       "x-category": "Cloud reporting",
-      "description": "PrintPageTelemetry",
-      "examples": [],
+      "x-compatibility": {
+        "firefox": { "version_added": false },
+        "firefox_esr": { "version_added": false },
+        "firefox_enterprise": { "version_added": "149" }
+      },
+      "description": "Enable and configure security logging when a page is printed. 'UrlLogging' controls how much detail about the printed page's address is included in the log.",
+      "examples": [
+        {
+          "Enabled": true,
+          "UrlLogging": "domain"
+        },
+        {
+          "Enabled": false
+        },
+        {
+          "Enabled": true,
+          "UrlLogging": "none"
+        }
+      ],
       "properties": {
         "Enabled": {
           "type": "boolean"
@@ -3582,6 +3659,11 @@
     "Sync": {
       "type": "object",
       "x-category": "Local data storage",
+      "x-compatibility": {
+        "firefox": { "version_added": false },
+        "firefox_esr": { "version_added": false },
+        "firefox_enterprise": { "version_added": "149" }
+      },
       "description": "Enable or disable sync and define which data to include.",
       "examples": [
         {
@@ -3721,6 +3803,11 @@
     "Watermark": {
       "type": "object",
       "x-category": "Miscellaneous",
+      "x-compatibility": {
+        "firefox": { "version_added": false },
+        "firefox_esr": { "version_added": false },
+        "firefox_enterprise": { "version_added": "154" }
+      },
       "description": "Display a tiled, diagonal watermark over a list of websites.",
       "examples": [
         {


### PR DESCRIPTION
### Description <!-- REQUIRED -->

Bugzilla: Bug-2062723

Updating the schema to provide some missing fields.

<strike>I'm going to set as draft at the moment and wait for the linked PR (#1261) to be merged.</strike>

### Dependencies / Related Issues <!-- OPTIONAL -->

* Related to: 

- [ ] https://github.com/mozilla/enterprise-firefox/pull/1261

### Testing <!-- OPTIONAL -->

* [ ] Added tests
* [x] Manual testing performed

1. `./mach test browser/components/enterprisepolicies/tests/xpcshell/test_policies_schema.js`

**Expected result:**

No failures
