### PR TITLE
Bug 2005206 - OS session event detection + logout

### DIFF
--- a/browser/components/BrowserComponents.manifest
+++ b/browser/components/BrowserComponents.manifest
@@ -48,6 +48,7 @@ category browser-window-domcontentloaded chrome://browser/content/browser.js Fir
 #ifdef MOZ_ENTERPRISE
 category browser-window-domcontentloaded resource://gre/modules/enterprise/EnterpriseHandler.sys.mjs EnterpriseHandler.init
 category browser-window-domcontentloaded resource:///modules/enterprise/AccessConnectorButton.sys.mjs AccessConnectorButtonHandler.init
+category browser-window-domcontentloaded resource://gre/modules/enterprise/EnterpriseSessionObserver.sys.mjs EnterpriseSessionObserver.init
 #endif
 
 category browser-window-load-before-sessionstore-init chrome://browser/content/browser-captivePortal.js CaptivePortalWatcher.init
@@ -225,6 +226,7 @@ category browser-quit-application-granted moz-src:///browser/components/ipprotec
 
 #ifdef MOZ_ENTERPRISE
 category browser-quit-application-granted resource://gre/modules/enterprise/EnterpriseHandler.sys.mjs EnterpriseHandler.uninit
+category browser-quit-application-granted resource://gre/modules/enterprise/EnterpriseSessionObserver.sys.mjs EnterpriseSessionObserver.uninit
 #endif
 
 category search-service-notification moz-src:///browser/components/search/SearchUIUtils.sys.mjs SearchUIUtils.showSearchServiceNotification

--- a/testing/enterprise/manifest.toml
+++ b/testing/enterprise/manifest.toml
@@ -80,6 +80,8 @@ run-if = [
   "buildapp == 'browser'",
 ]
 
+["test_felt_browser_os_session.py"]
+
 ["test_felt_browser_shutdown_crash_exit.py"]
 run-if = [
   "buildapp == 'browser'", # open new tab

--- a/testing/enterprise/test_felt_browser_os_session.py
+++ b/testing/enterprise/test_felt_browser_os_session.py
@@ -61,6 +61,7 @@ class BrowserOsSession(FeltTests):
         self.fire_os_event_and_expect_quit("os-session-end")
 
         self.await_felt_auth_window()
+        self.force_window()
         self._driver.set_context("chrome")
         email = self.get_elem("#felt-form__email").get_property("value")
         assert email == signed_in_email, (
@@ -87,6 +88,7 @@ class BrowserOsSession(FeltTests):
         self.fire_os_event_and_expect_quit("os-user-switch")
 
         self.await_felt_auth_window()
+        self.force_window()
         self._driver.set_context("chrome")
         email = self.get_elem("#felt-form__email").get_property("value")
         assert email == signed_in_email, (
@@ -136,6 +138,7 @@ class BrowserOsSession(FeltTests):
         self.fire_os_event_and_expect_quit("screen-locked")
 
         self.await_felt_auth_window()
+        self.force_window()
         self._driver.set_context("chrome")
         email = self.get_elem("#felt-form__email").get_property("value")
         assert email == signed_in_email, (

--- a/testing/enterprise/test_felt_browser_os_session.py
+++ b/testing/enterprise/test_felt_browser_os_session.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import os
+import sys
+
+sys.path.append(os.path.dirname(__file__))
+
+from felt_tests import FeltTests
+from marionette_driver.errors import (
+    InvalidSessionIdException,
+    JavascriptException,
+    NoSuchWindowException,
+    UnknownException,
+)
+
+
+class BrowserOsSession(FeltTests):
+    def felt_whoami(self):
+        self._child_driver.set_context("chrome")
+        rv = self._child_driver.execute_script(
+            """
+            const { ConsoleClient } = ChromeUtils.importESModule("resource://gre/modules/enterprise/ConsoleClient.sys.mjs");
+            return ConsoleClient._get(ConsoleClient._paths.WHOAMI);
+            """,
+        )
+        self._child_driver.set_context("content")
+        return rv
+
+    def fire_os_event_and_expect_quit(self, topic):
+        """Fire an OS event observer topic on the child browser and expect
+        it to quit. Sets _manually_closed_child before firing to avoid
+        teardown errors."""
+        self._manually_closed_child = True
+        self._child_driver.set_context("chrome")
+        try:
+            self._child_driver.execute_script(
+                f'Services.obs.notifyObservers(null, "{topic}", null);'
+            )
+        except (
+            JavascriptException,
+            NoSuchWindowException,
+            InvalidSessionIdException,
+            UnknownException,
+            OSError,
+        ):
+            pass
+
+    def test_os_session_end_triggers_signout(self):
+        """Simulate os-session-end: verify tokens cleared, browser quits,
+        FELT shows login with pre-filled email."""
+        super().run_felt_base()
+        self.connect_child_browser()
+
+        whoami = self.felt_whoami()
+        assert whoami["email"], "User should be signed in"
+        signed_in_email = whoami["email"]
+
+        self.fire_os_event_and_expect_quit("os-session-end")
+
+        self.await_felt_auth_window()
+        self._driver.set_context("chrome")
+        email = self.get_elem("#felt-form__email").get_property("value")
+        assert email == signed_in_email, (
+            "Email should be pre-filled after OS-initiated signout"
+        )
+        self._driver.set_context("content")
+
+    def test_os_user_switch_triggers_signout_when_enabled(self):
+        """Simulate os-user-switch with pref enabled (default):
+        verify signout flow runs."""
+        super().run_felt_base()
+        self.connect_child_browser()
+        whoami = self.felt_whoami()
+        signed_in_email = whoami["email"]
+
+        self._child_driver.set_context("chrome")
+        self._child_driver.execute_script(
+            """
+            Services.prefs.setBoolPref("enterprise.signoutOnUserSwitch", true);
+            """
+        )
+        self._child_driver.set_context("content")
+
+        self.fire_os_event_and_expect_quit("os-user-switch")
+
+        self.await_felt_auth_window()
+        self._driver.set_context("chrome")
+        email = self.get_elem("#felt-form__email").get_property("value")
+        assert email == signed_in_email, (
+            "Email should be pre-filled after user-switch signout"
+        )
+        self._driver.set_context("content")
+
+    def test_os_user_switch_ignored_when_disabled(self):
+        """Simulate os-user-switch with pref disabled:
+        verify browser stays signed in."""
+        super().run_felt_base()
+        self.connect_child_browser()
+
+        self._child_driver.set_context("chrome")
+        self._child_driver.execute_script(
+            """
+            Services.prefs.setBoolPref("enterprise.signoutOnUserSwitch", false);
+            """
+        )
+
+        self._child_driver.execute_script(
+            """
+            Services.obs.notifyObservers(null, "os-user-switch", null);
+            """
+        )
+        self._child_driver.set_context("content")
+
+        whoami = self.felt_whoami()
+        assert whoami["email"], "User should still be signed in"
+
+    def test_screen_lock_triggers_signout_when_enabled(self):
+        """Simulate screen-locked with pref enabled:
+        verify signout flow runs."""
+        super().run_felt_base()
+        self.connect_child_browser()
+        whoami = self.felt_whoami()
+        signed_in_email = whoami["email"]
+
+        self._child_driver.set_context("chrome")
+        self._child_driver.execute_script(
+            """
+            Services.prefs.setBoolPref("enterprise.signoutOnScreenLock", true);
+            """
+        )
+        self._child_driver.set_context("content")
+
+        self.fire_os_event_and_expect_quit("screen-locked")
+
+        self.await_felt_auth_window()
+        self._driver.set_context("chrome")
+        email = self.get_elem("#felt-form__email").get_property("value")
+        assert email == signed_in_email, (
+            "Email should be pre-filled after screen-lock signout"
+        )
+        self._driver.set_context("content")
+
+    def test_screen_lock_ignored_when_disabled(self):
+        """Simulate screen-locked with pref disabled (default):
+        verify browser stays signed in."""
+        super().run_felt_base()
+        self.connect_child_browser()
+
+        self._child_driver.set_context("chrome")
+        self._child_driver.execute_script(
+            """
+            Services.prefs.setBoolPref("enterprise.signoutOnScreenLock", false);
+            """
+        )
+
+        self._child_driver.execute_script(
+            """
+            Services.obs.notifyObservers(null, "screen-locked", null);
+            """
+        )
+        self._child_driver.set_context("content")
+
+        whoami = self.felt_whoami()
+        assert whoami["email"], "User should still be signed in"

--- a/testing/enterprise/test_felt_browser_os_session.py
+++ b/testing/enterprise/test_felt_browser_os_session.py
@@ -80,7 +80,7 @@ class BrowserOsSession(FeltTests):
         self._child_driver.set_context("chrome")
         self._child_driver.execute_script(
             """
-            Services.prefs.setBoolPref("enterprise.signoutOnUserSwitch", true);
+            Services.prefs.setBoolPref("enterprise.signout.user_switch.enabled", true);
             """
         )
         self._child_driver.set_context("content")
@@ -105,7 +105,7 @@ class BrowserOsSession(FeltTests):
         self._child_driver.set_context("chrome")
         self._child_driver.execute_script(
             """
-            Services.prefs.setBoolPref("enterprise.signoutOnUserSwitch", false);
+            Services.prefs.setBoolPref("enterprise.signout.user_switch.enabled", false);
             """
         )
 
@@ -130,7 +130,7 @@ class BrowserOsSession(FeltTests):
         self._child_driver.set_context("chrome")
         self._child_driver.execute_script(
             """
-            Services.prefs.setBoolPref("enterprise.signoutOnScreenLock", true);
+            Services.prefs.setBoolPref("enterprise.signout.screen_lock.enabled", true);
             """
         )
         self._child_driver.set_context("content")
@@ -155,7 +155,7 @@ class BrowserOsSession(FeltTests):
         self._child_driver.set_context("chrome")
         self._child_driver.execute_script(
             """
-            Services.prefs.setBoolPref("enterprise.signoutOnScreenLock", false);
+            Services.prefs.setBoolPref("enterprise.signout.screen_lock.enabled", false);
             """
         )
 

--- a/toolkit/components/enterprise/modules/EnterpriseSessionObserver.sys.mjs
+++ b/toolkit/components/enterprise/modules/EnterpriseSessionObserver.sys.mjs
@@ -23,6 +23,7 @@ export const EnterpriseSessionObserver = {
   SIGNOUT_ON_SCREEN_LOCK_PREF: "enterprise.signoutOnScreenLock",
 
   _initialized: false,
+  _signingOut: false,
 
   init() {
     if (this._initialized) {
@@ -65,42 +66,45 @@ export const EnterpriseSessionObserver = {
   _SESSION_END_TIMEOUT_MS: 2000,
 
   _handleSessionEnd() {
-    // os-session-end fires during WM_ENDSESSION (Windows) or similar
-    // synchronous OS shutdown paths. The process will be killed shortly
-    // after this returns, so we spin the Gecko event loop briefly to
-    // give the server-side POST a chance to complete. The Windows
-    // message pump is blocked (we're inside a WndProc), but Gecko's
-    // event loop can still drain necko callbacks from background threads.
+    if (this._signingOut) {
+      return;
+    }
+    this._signingOut = true;
     lazy.log.debug("OS session end detected, signing out");
 
-    let finished = false;
-    const deadline = Date.now() + this._SESSION_END_TIMEOUT_MS;
+    // On Windows, WM_ENDSESSION is synchronous and the process will be killed
+    // shortly after returning. Spin the Gecko event loop briefly to give the
+    // server-side POST a chance to complete before the process is torn down.
+    // This is Windows-specific: on macOS and Linux the OS provides async
+    // shutdown hooks that don't require manual event loop pumping.
+    if (Services.appinfo.OS === "WINNT") {
+      let finished = false;
+      const deadline = Date.now() + this._SESSION_END_TIMEOUT_MS;
 
-    Promise.race([
-      lazy.ConsoleClient._post(lazy.ConsoleClient._paths.SIGNOUT),
-      new Promise((_resolve, reject) =>
-        lazy.setTimeout(
-          () => reject(new Error("Server signout timed out")),
-          this._SESSION_END_TIMEOUT_MS
-        )
-      ),
-    ])
-      .catch(e => {
-        lazy.log.warn("Server-side signout failed during session end", e);
-      })
-      .finally(() => {
-        finished = true;
-      });
+      Promise.race([
+        lazy.ConsoleClient._post(lazy.ConsoleClient._paths.SIGNOUT),
+        new Promise((_resolve, reject) =>
+          lazy.setTimeout(
+            () => reject(new Error("Server signout timed out")),
+            this._SESSION_END_TIMEOUT_MS
+          )
+        ),
+      ])
+        .catch(e => {
+          lazy.log.warn("Server-side signout failed during session end", e);
+        })
+        .finally(() => {
+          finished = true;
+        });
 
-    // Spin the Gecko event loop so necko can complete the POST.
-    // The Windows message pump is not involved here.
-    try {
-      Services.tm.spinEventLoopUntil(
-        "EnterpriseSessionObserver:os-session-end",
-        () => finished || Date.now() >= deadline
-      );
-    } catch (e) {
-      lazy.log.warn("Event loop spin failed during session end", e);
+      try {
+        Services.tm.spinEventLoopUntil(
+          "EnterpriseSessionObserver:os-session-end",
+          () => finished || Date.now() >= deadline
+        );
+      } catch (e) {
+        lazy.log.warn("Event loop spin failed during session end", e);
+      }
     }
 
     lazy.ConsoleClient.clearTokenData();
@@ -132,6 +136,10 @@ export const EnterpriseSessionObserver = {
   _SERVER_SIGNOUT_TIMEOUT_MS: 5000,
 
   async _performOsInitiatedSignout() {
+    if (this._signingOut) {
+      return;
+    }
+    this._signingOut = true;
     // Best-effort server-side revocation BEFORE clearing tokens.
     // ConsoleClient._post() calls getAccessToken() internally, which needs
     // the access token to still be present. Use a timeout to avoid stalling

--- a/toolkit/components/enterprise/modules/EnterpriseSessionObserver.sys.mjs
+++ b/toolkit/components/enterprise/modules/EnterpriseSessionObserver.sys.mjs
@@ -1,0 +1,163 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const lazy = {};
+
+ChromeUtils.defineESModuleGetters(lazy, {
+  ConsoleClient: "resource://gre/modules/enterprise/ConsoleClient.sys.mjs",
+  setTimeout: "resource://gre/modules/Timer.sys.mjs",
+});
+
+ChromeUtils.defineLazyGetter(lazy, "log", () => {
+  return console.createInstance({
+    prefix: "EnterpriseSessionObserver",
+    maxLogLevelPref: "enterprise.loglevel",
+  });
+});
+
+const TOPICS = ["os-session-end", "os-user-switch", "screen-locked"];
+
+export const EnterpriseSessionObserver = {
+  SIGNOUT_ON_USER_SWITCH_PREF: "enterprise.signoutOnUserSwitch",
+  SIGNOUT_ON_SCREEN_LOCK_PREF: "enterprise.signoutOnScreenLock",
+
+  _initialized: false,
+
+  init() {
+    if (this._initialized) {
+      return;
+    }
+    this._initialized = true;
+    for (const topic of TOPICS) {
+      Services.obs.addObserver(this, topic);
+    }
+  },
+
+  uninit() {
+    if (!this._initialized) {
+      return;
+    }
+    this._initialized = false;
+    for (const topic of TOPICS) {
+      try {
+        Services.obs.removeObserver(this, topic);
+      } catch (e) {
+        lazy.log.debug(`Failed to remove observer for ${topic}`, e);
+      }
+    }
+  },
+
+  observe(_subject, topic, _data) {
+    switch (topic) {
+      case "os-session-end":
+        this._handleSessionEnd();
+        break;
+      case "os-user-switch":
+        this._handleUserSwitch();
+        break;
+      case "screen-locked":
+        this._handleScreenLock();
+        break;
+    }
+  },
+
+  _SESSION_END_TIMEOUT_MS: 2000,
+
+  _handleSessionEnd() {
+    // os-session-end fires during WM_ENDSESSION (Windows) or similar
+    // synchronous OS shutdown paths. The process will be killed shortly
+    // after this returns, so we spin the Gecko event loop briefly to
+    // give the server-side POST a chance to complete. The Windows
+    // message pump is blocked (we're inside a WndProc), but Gecko's
+    // event loop can still drain necko callbacks from background threads.
+    lazy.log.debug("OS session end detected, signing out");
+
+    let finished = false;
+    const deadline = Date.now() + this._SESSION_END_TIMEOUT_MS;
+
+    Promise.race([
+      lazy.ConsoleClient._post(lazy.ConsoleClient._paths.SIGNOUT),
+      new Promise((_resolve, reject) =>
+        lazy.setTimeout(
+          () => reject(new Error("Server signout timed out")),
+          this._SESSION_END_TIMEOUT_MS
+        )
+      ),
+    ])
+      .catch(e => {
+        lazy.log.warn("Server-side signout failed during session end", e);
+      })
+      .finally(() => {
+        finished = true;
+      });
+
+    // Spin the Gecko event loop so necko can complete the POST.
+    // The Windows message pump is not involved here.
+    try {
+      Services.tm.spinEventLoopUntil(
+        "EnterpriseSessionObserver:os-session-end",
+        () => finished || Date.now() >= deadline
+      );
+    } catch (e) {
+      lazy.log.warn("Event loop spin failed during session end", e);
+    }
+
+    lazy.ConsoleClient.clearTokenData();
+    Services.felt.makeBackgroundProcess(true);
+    Services.felt.performSignout();
+
+    // On Windows WM_ENDSESSION, DoImmediateExit() runs after we return
+    // so this is a no-op. On macOS/Linux (and in tests), this ensures
+    // the browser actually quits.
+    Services.startup.quit(Ci.nsIAppStartup.eForceQuit);
+  },
+
+  _handleUserSwitch() {
+    if (!Services.prefs.getBoolPref(this.SIGNOUT_ON_USER_SWITCH_PREF, true)) {
+      return;
+    }
+    lazy.log.debug("OS user switch detected, signing out");
+    this._performOsInitiatedSignout();
+  },
+
+  _handleScreenLock() {
+    if (!Services.prefs.getBoolPref(this.SIGNOUT_ON_SCREEN_LOCK_PREF, false)) {
+      return;
+    }
+    lazy.log.debug("Screen lock detected, signing out");
+    this._performOsInitiatedSignout();
+  },
+
+  _SERVER_SIGNOUT_TIMEOUT_MS: 5000,
+
+  async _performOsInitiatedSignout() {
+    // Best-effort server-side revocation BEFORE clearing tokens.
+    // ConsoleClient._post() calls getAccessToken() internally, which needs
+    // the access token to still be present. Use a timeout to avoid stalling
+    // if the network is unreachable.
+    try {
+      await Promise.race([
+        lazy.ConsoleClient._post(lazy.ConsoleClient._paths.SIGNOUT),
+        new Promise((_resolve, reject) =>
+          lazy.setTimeout(
+            () => reject(new Error("Server signout timed out")),
+            this._SERVER_SIGNOUT_TIMEOUT_MS
+          )
+        ),
+      ]);
+    } catch (e) {
+      lazy.log.warn(
+        "Server-side signout failed, continuing with local cleanup",
+        e
+      );
+    }
+
+    lazy.ConsoleClient.clearTokenData();
+
+    Services.felt.makeBackgroundProcess(true);
+    Services.felt.performSignout();
+
+    Services.startup.quit(Ci.nsIAppStartup.eForceQuit);
+  },
+};

--- a/toolkit/components/enterprise/modules/EnterpriseSessionObserver.sys.mjs
+++ b/toolkit/components/enterprise/modules/EnterpriseSessionObserver.sys.mjs
@@ -132,37 +132,15 @@ export const EnterpriseSessionObserver = {
     this._performOsInitiatedSignout();
   },
 
-  _SERVER_SIGNOUT_TIMEOUT_MS: 5000,
-
-  async _performOsInitiatedSignout() {
+  _performOsInitiatedSignout() {
     if (this._signingOut) {
       return;
     }
     this._signingOut = true;
-    // Best-effort server-side revocation before handing off to FELT, which
-    // clears the local token store. _post() needs the access token to still
-    // be present, so this must run first. Timeout avoids stalling if the
-    // network is unreachable.
-    try {
-      await Promise.race([
-        lazy.ConsoleClient._post(lazy.ConsoleClient._paths.SIGNOUT),
-        new Promise((_resolve, reject) =>
-          lazy.setTimeout(
-            () => reject(new Error("Server signout timed out")),
-            this._SERVER_SIGNOUT_TIMEOUT_MS
-          )
-        ),
-      ]);
-    } catch (e) {
-      lazy.log.warn(
-        "Server-side signout failed, continuing with local cleanup",
-        e
-      );
-    }
-
+    // FELT owns the logout (server signout, token clearing, shutdown).
+    // Revoking the token here first would make FELT's signout fail on an
+    // already-revoked token and race our shutdown against FELT's.
     Services.felt.makeBackgroundProcess(true);
     Services.felt.performSignout();
-
-    Services.startup.quit(Ci.nsIAppStartup.eForceQuit);
   },
 };

--- a/toolkit/components/enterprise/modules/EnterpriseSessionObserver.sys.mjs
+++ b/toolkit/components/enterprise/modules/EnterpriseSessionObserver.sys.mjs
@@ -19,8 +19,8 @@ ChromeUtils.defineLazyGetter(lazy, "log", () => {
 const TOPICS = ["os-session-end", "os-user-switch", "screen-locked"];
 
 export const EnterpriseSessionObserver = {
-  SIGNOUT_ON_USER_SWITCH_PREF: "enterprise.signoutOnUserSwitch",
-  SIGNOUT_ON_SCREEN_LOCK_PREF: "enterprise.signoutOnScreenLock",
+  SIGNOUT_ON_USER_SWITCH_PREF: "enterprise.signout.user_switch.enabled",
+  SIGNOUT_ON_SCREEN_LOCK_PREF: "enterprise.signout.screen_lock.enabled",
 
   _initialized: false,
   _signingOut: false,

--- a/toolkit/components/enterprise/modules/EnterpriseSessionObserver.sys.mjs
+++ b/toolkit/components/enterprise/modules/EnterpriseSessionObserver.sys.mjs
@@ -107,7 +107,6 @@ export const EnterpriseSessionObserver = {
       }
     }
 
-    lazy.ConsoleClient.clearTokenData();
     Services.felt.makeBackgroundProcess(true);
     Services.felt.performSignout();
 
@@ -140,10 +139,10 @@ export const EnterpriseSessionObserver = {
       return;
     }
     this._signingOut = true;
-    // Best-effort server-side revocation BEFORE clearing tokens.
-    // ConsoleClient._post() calls getAccessToken() internally, which needs
-    // the access token to still be present. Use a timeout to avoid stalling
-    // if the network is unreachable.
+    // Best-effort server-side revocation before handing off to FELT, which
+    // clears the local token store. _post() needs the access token to still
+    // be present, so this must run first. Timeout avoids stalling if the
+    // network is unreachable.
     try {
       await Promise.race([
         lazy.ConsoleClient._post(lazy.ConsoleClient._paths.SIGNOUT),
@@ -160,8 +159,6 @@ export const EnterpriseSessionObserver = {
         e
       );
     }
-
-    lazy.ConsoleClient.clearTokenData();
 
     Services.felt.makeBackgroundProcess(true);
     Services.felt.performSignout();

--- a/toolkit/components/enterprise/moz.build
+++ b/toolkit/components/enterprise/moz.build
@@ -15,6 +15,7 @@ EXTRA_JS_MODULES.enterprise += [
     "modules/EnterpriseEndpoints.sys.mjs",
     "modules/EnterpriseHandler.sys.mjs",
     "modules/EnterpriseOSInfo.sys.mjs",
+    "modules/EnterpriseSessionObserver.sys.mjs",
     "modules/EnterpriseStorageEncryption.sys.mjs",
     "modules/Updates.sys.mjs",
 ]

--- a/widget/cocoa/nsAppShell.mm
+++ b/widget/cocoa/nsAppShell.mm
@@ -1068,6 +1068,22 @@ void nsAppShell::OnMemoryPressureChanged(
            selector:@selector(timezoneChanged:)
                name:NSSystemTimeZoneDidChangeNotification
              object:nil];
+
+    NSNotificationCenter* workspaceNC =
+        [[NSWorkspace sharedWorkspace] notificationCenter];
+    [workspaceNC addObserver:self
+                    selector:@selector(sessionDidResignActive:)
+                        name:NSWorkspaceSessionDidResignActiveNotification
+                      object:nil];
+    [workspaceNC addObserver:self
+                    selector:@selector(workspaceWillPowerOff:)
+                        name:NSWorkspaceWillPowerOffNotification
+                      object:nil];
+    [[NSDistributedNotificationCenter defaultCenter]
+        addObserver:self
+           selector:@selector(screenIsLocked:)
+               name:@"com.apple.screenIsLocked"
+             object:nil];
   }
 
   return self;
@@ -1080,6 +1096,7 @@ void nsAppShell::OnMemoryPressureChanged(
 
   [[NSNotificationCenter defaultCenter] removeObserver:self];
   [[NSDistributedNotificationCenter defaultCenter] removeObserver:self];
+  [[[NSWorkspace sharedWorkspace] notificationCenter] removeObserver:self];
   [super dealloc];
 
   NS_OBJC_END_TRY_IGNORE_BLOCK;
@@ -1126,6 +1143,42 @@ void nsAppShell::OnMemoryPressureChanged(
   NS_OBJC_BEGIN_TRY_IGNORE_BLOCK;
 
   nsBaseAppShell::OnSystemTimezoneChange();
+
+  NS_OBJC_END_TRY_IGNORE_BLOCK;
+}
+
+- (void)sessionDidResignActive:(NSNotification*)aNotification {
+  NS_OBJC_BEGIN_TRY_IGNORE_BLOCK;
+
+  nsCOMPtr<nsIObserverService> observerService = services::GetObserverService();
+  if (observerService) {
+    observerService->NotifyObservers(
+        nullptr, NS_WIDGET_OS_USER_SWITCH_OBSERVER_TOPIC, nullptr);
+  }
+
+  NS_OBJC_END_TRY_IGNORE_BLOCK;
+}
+
+- (void)workspaceWillPowerOff:(NSNotification*)aNotification {
+  NS_OBJC_BEGIN_TRY_IGNORE_BLOCK;
+
+  nsCOMPtr<nsIObserverService> observerService = services::GetObserverService();
+  if (observerService) {
+    observerService->NotifyObservers(
+        nullptr, NS_WIDGET_OS_SESSION_END_OBSERVER_TOPIC, nullptr);
+  }
+
+  NS_OBJC_END_TRY_IGNORE_BLOCK;
+}
+
+- (void)screenIsLocked:(NSNotification*)aNotification {
+  NS_OBJC_BEGIN_TRY_IGNORE_BLOCK;
+
+  nsCOMPtr<nsIObserverService> observerService = services::GetObserverService();
+  if (observerService) {
+    observerService->NotifyObservers(
+        nullptr, NS_WIDGET_SCREEN_LOCKED_OBSERVER_TOPIC, nullptr);
+  }
 
   NS_OBJC_END_TRY_IGNORE_BLOCK;
 }

--- a/widget/gtk/nsAppShell.cpp
+++ b/widget/gtk/nsAppShell.cpp
@@ -280,20 +280,39 @@ void nsAppShell::DBusTimedatePropertiesChangedCallback(GDBusProxy* aProxy,
 void nsAppShell::DBusSessionPropertiesChangedCallback(
     GDBusProxy* aProxy, GVariant* aChangedProperties,
     GStrv aInvalidatedProperties, gpointer aUserData) {
-  RefPtr<GVariant> activeVariant = dont_AddRef(g_variant_lookup_value(
-      aChangedProperties, "Active", G_VARIANT_TYPE_BOOLEAN));
-  if (!activeVariant) {
+  nsCOMPtr<nsIObserverService> observerService =
+      mozilla::services::GetObserverService();
+  if (!observerService) {
     return;
   }
 
-  if (!g_variant_get_boolean(activeVariant)) {
-    nsCOMPtr<nsIObserverService> observerService =
-        mozilla::services::GetObserverService();
-    if (observerService) {
-      observerService->NotifyObservers(
-          nullptr, NS_WIDGET_OS_USER_SWITCH_OBSERVER_TOPIC, nullptr);
-    }
+  // LockedHint=true means the session was locked via logind (more reliable
+  // than the ScreenSaver signal for actual lock state).
+  RefPtr<GVariant> lockedVariant = dont_AddRef(g_variant_lookup_value(
+      aChangedProperties, "LockedHint", G_VARIANT_TYPE_BOOLEAN));
+  if (lockedVariant && g_variant_get_boolean(lockedVariant)) {
+    observerService->NotifyObservers(
+        nullptr, NS_WIDGET_SCREEN_LOCKED_OBSERVER_TOPIC, nullptr);
+    return;
   }
+
+  // Active=false means this session lost the foreground. Check LockedHint
+  // to avoid misclassifying a screen lock as a user switch on desktops that
+  // deactivate the session when locking.
+  RefPtr<GVariant> activeVariant = dont_AddRef(g_variant_lookup_value(
+      aChangedProperties, "Active", G_VARIANT_TYPE_BOOLEAN));
+  if (!activeVariant || g_variant_get_boolean(activeVariant)) {
+    return;
+  }
+
+  RefPtr<GVariant> lockedHint = dont_AddRef(
+      g_dbus_proxy_get_cached_property(aProxy, "LockedHint"));
+  if (lockedHint && g_variant_get_boolean(lockedHint)) {
+    return;
+  }
+
+  observerService->NotifyObservers(
+      nullptr, NS_WIDGET_OS_USER_SWITCH_OBSERVER_TOPIC, nullptr);
 }
 
 void nsAppShell::DBusScreenSaverSignalCallback(GDBusProxy* aProxy,

--- a/widget/gtk/nsAppShell.cpp
+++ b/widget/gtk/nsAppShell.cpp
@@ -25,6 +25,7 @@
 #include "nsCRT.h"
 #include "nsIObserverService.h"
 #include "nsIPowerManagerService.h"
+#include "nsIWidget.h"
 #include "nsWindow.h"
 #include "prenv.h"
 #ifdef MOZ_ENABLE_DBUS
@@ -218,7 +219,9 @@ void nsAppShell::DBusSessionSleepCallback(GDBusProxy* aProxy,
                                           gchar* aSignalName,
                                           GVariant* aParameters,
                                           gpointer aUserData) {
-  if (g_strcmp0(aSignalName, "PrepareForSleep")) {
+  bool isSleep = !g_strcmp0(aSignalName, "PrepareForSleep");
+  bool isShutdown = !g_strcmp0(aSignalName, "PrepareForShutdown");
+  if (!isSleep && !isShutdown) {
     return;
   }
   nsCOMPtr<nsIObserverService> observerService =
@@ -245,15 +248,21 @@ void nsAppShell::DBusSessionSleepCallback(GDBusProxy* aProxy,
     return;
   }
 
-  gboolean suspend = g_variant_get_boolean(variant);
-  if (suspend) {
-    // Post sleep_notification
-    observerService->NotifyObservers(nullptr, NS_WIDGET_SLEEP_OBSERVER_TOPIC,
-                                     nullptr);
-  } else {
-    // Post wake_notification
-    observerService->NotifyObservers(nullptr, NS_WIDGET_WAKE_OBSERVER_TOPIC,
-                                     nullptr);
+  gboolean active = g_variant_get_boolean(variant);
+  if (isShutdown && active) {
+    observerService->NotifyObservers(
+        nullptr, NS_WIDGET_OS_SESSION_END_OBSERVER_TOPIC, nullptr);
+    return;
+  }
+
+  if (isSleep) {
+    if (active) {
+      observerService->NotifyObservers(nullptr, NS_WIDGET_SLEEP_OBSERVER_TOPIC,
+                                       nullptr);
+    } else {
+      observerService->NotifyObservers(nullptr, NS_WIDGET_WAKE_OBSERVER_TOPIC,
+                                       nullptr);
+    }
   }
 }
 
@@ -266,6 +275,54 @@ void nsAppShell::DBusTimedatePropertiesChangedCallback(GDBusProxy* aProxy,
     return;
   }
   nsBaseAppShell::OnSystemTimezoneChange();
+}
+
+void nsAppShell::DBusSessionPropertiesChangedCallback(
+    GDBusProxy* aProxy, GVariant* aChangedProperties,
+    GStrv aInvalidatedProperties, gpointer aUserData) {
+  RefPtr<GVariant> activeVariant = dont_AddRef(g_variant_lookup_value(
+      aChangedProperties, "Active", G_VARIANT_TYPE_BOOLEAN));
+  if (!activeVariant) {
+    return;
+  }
+
+  if (!g_variant_get_boolean(activeVariant)) {
+    nsCOMPtr<nsIObserverService> observerService =
+        mozilla::services::GetObserverService();
+    if (observerService) {
+      observerService->NotifyObservers(
+          nullptr, NS_WIDGET_OS_USER_SWITCH_OBSERVER_TOPIC, nullptr);
+    }
+  }
+}
+
+void nsAppShell::DBusScreenSaverSignalCallback(GDBusProxy* aProxy,
+                                               gchar* aSenderName,
+                                               gchar* aSignalName,
+                                               GVariant* aParameters,
+                                               gpointer aUserData) {
+  if (g_strcmp0(aSignalName, "ActiveChanged")) {
+    return;
+  }
+  if (!g_variant_is_of_type(aParameters, G_VARIANT_TYPE_TUPLE) ||
+      g_variant_n_children(aParameters) != 1) {
+    return;
+  }
+
+  RefPtr<GVariant> variant =
+      dont_AddRef(g_variant_get_child_value(aParameters, 0));
+  if (!g_variant_is_of_type(variant, G_VARIANT_TYPE_BOOLEAN)) {
+    return;
+  }
+
+  if (g_variant_get_boolean(variant)) {
+    nsCOMPtr<nsIObserverService> observerService =
+        mozilla::services::GetObserverService();
+    if (observerService) {
+      observerService->NotifyObservers(
+          nullptr, NS_WIDGET_SCREEN_LOCKED_OBSERVER_TOPIC, nullptr);
+    }
+  }
 }
 
 void nsAppShell::DBusConnectClientResponse(GObject* aObject,
@@ -284,10 +341,19 @@ void nsAppShell::DBusConnectClientResponse(GObject* aObject,
   }
 
   RefPtr self = static_cast<nsAppShell*>(aUserData);
-  if (!strcmp(g_dbus_proxy_get_name(proxyClient), "org.freedesktop.login1")) {
+  const gchar* iface = g_dbus_proxy_get_interface_name(proxyClient);
+  if (!strcmp(iface, "org.freedesktop.login1.Manager")) {
     self->mLogin1Proxy = std::move(proxyClient);
     g_signal_connect(self->mLogin1Proxy, "g-signal",
                      G_CALLBACK(DBusSessionSleepCallback), self);
+  } else if (!strcmp(iface, "org.freedesktop.login1.Session")) {
+    self->mSessionProxy = std::move(proxyClient);
+    g_signal_connect(self->mSessionProxy, "g-properties-changed",
+                     G_CALLBACK(DBusSessionPropertiesChangedCallback), self);
+  } else if (!strcmp(iface, "org.freedesktop.ScreenSaver")) {
+    self->mScreenSaverProxy = std::move(proxyClient);
+    g_signal_connect(self->mScreenSaverProxy, "g-signal",
+                     G_CALLBACK(DBusScreenSaverSignalCallback), self);
   } else {
     self->mTimedate1Proxy = std::move(proxyClient);
     g_signal_connect(self->mTimedate1Proxy, "g-signal",
@@ -332,6 +398,8 @@ void nsAppShell::StartDBusListening() {
 
   mLogin1ProxyCancellable = dont_AddRef(g_cancellable_new());
   mTimedate1ProxyCancellable = dont_AddRef(g_cancellable_new());
+  mSessionProxyCancellable = dont_AddRef(g_cancellable_new());
+  mScreenSaverProxyCancellable = dont_AddRef(g_cancellable_new());
 
   g_dbus_proxy_new_for_bus(
       G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE, nullptr,
@@ -343,6 +411,18 @@ void nsAppShell::StartDBusListening() {
       G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE, nullptr,
       "org.freedesktop.timedate1", "/org/freedesktop/timedate1",
       "org.freedesktop.DBus.Properties", mTimedate1ProxyCancellable,
+      reinterpret_cast<GAsyncReadyCallback>(DBusConnectClientResponse), this);
+
+  g_dbus_proxy_new_for_bus(
+      G_BUS_TYPE_SYSTEM, G_DBUS_PROXY_FLAGS_NONE, nullptr,
+      "org.freedesktop.login1", "/org/freedesktop/login1/session/auto",
+      "org.freedesktop.login1.Session", mSessionProxyCancellable,
+      reinterpret_cast<GAsyncReadyCallback>(DBusConnectClientResponse), this);
+
+  g_dbus_proxy_new_for_bus(
+      G_BUS_TYPE_SESSION, G_DBUS_PROXY_FLAGS_NONE, nullptr,
+      "org.freedesktop.ScreenSaver", "/org/freedesktop/ScreenSaver",
+      "org.freedesktop.ScreenSaver", mScreenSaverProxyCancellable,
       reinterpret_cast<GAsyncReadyCallback>(DBusConnectClientResponse), this);
 
   // Don't grab reference to DBus connect from xpcshell, it fails
@@ -412,6 +492,26 @@ void nsAppShell::StopDBusListening() {
     mTimedate1ProxyCancellable = nullptr;
   }
   mTimedate1Proxy = nullptr;
+
+  if (mSessionProxy) {
+    g_signal_handlers_disconnect_matched(mSessionProxy, G_SIGNAL_MATCH_DATA, 0,
+                                         0, nullptr, nullptr, this);
+  }
+  if (mSessionProxyCancellable) {
+    g_cancellable_cancel(mSessionProxyCancellable);
+    mSessionProxyCancellable = nullptr;
+  }
+  mSessionProxy = nullptr;
+
+  if (mScreenSaverProxy) {
+    g_signal_handlers_disconnect_matched(mScreenSaverProxy, G_SIGNAL_MATCH_DATA,
+                                         0, 0, nullptr, nullptr, this);
+  }
+  if (mScreenSaverProxyCancellable) {
+    g_cancellable_cancel(mScreenSaverProxyCancellable);
+    mScreenSaverProxyCancellable = nullptr;
+  }
+  mScreenSaverProxy = nullptr;
 
   DBusConnectionCheck();
   if (mDBusGetCancellableSession) {

--- a/widget/gtk/nsAppShell.h
+++ b/widget/gtk/nsAppShell.h
@@ -52,6 +52,15 @@ class nsAppShell : public nsBaseAppShell {
                                                     gchar* aSignalName,
                                                     GVariant* aParameters,
                                                     gpointer aUserData);
+  static void DBusSessionPropertiesChangedCallback(GDBusProxy* aProxy,
+                                                   GVariant* aChangedProperties,
+                                                   GStrv aInvalidatedProperties,
+                                                   gpointer aUserData);
+  static void DBusScreenSaverSignalCallback(GDBusProxy* aProxy,
+                                            gchar* aSenderName,
+                                            gchar* aSignalName,
+                                            GVariant* aParameters,
+                                            gpointer aUserData);
   static void DBusConnectClientResponse(GObject* aObject, GAsyncResult* aResult,
                                         gpointer aUserData);
   static void DBusConnectionCheck();
@@ -83,6 +92,10 @@ class nsAppShell : public nsBaseAppShell {
   RefPtr<GCancellable> mLogin1ProxyCancellable;
   RefPtr<GDBusProxy> mTimedate1Proxy;
   RefPtr<GCancellable> mTimedate1ProxyCancellable;
+  RefPtr<GDBusProxy> mSessionProxy;
+  RefPtr<GCancellable> mSessionProxyCancellable;
+  RefPtr<GDBusProxy> mScreenSaverProxy;
+  RefPtr<GCancellable> mScreenSaverProxyCancellable;
   RefPtr<GDBusConnection> mDBusConnectionSession;
   RefPtr<GDBusConnection> mDBusConnectionSystem;
   RefPtr<GCancellable> mDBusGetCancellableSession;

--- a/widget/nsIWidget.h
+++ b/widget/nsIWidget.h
@@ -304,6 +304,22 @@ enum nsCursor {  ///(normal cursor,       usually rendered as an arrow)
  */
 #define NS_WIDGET_MAC_APP_ACTIVATE_OBSERVER_TOPIC "mac_app_activate"
 
+/**
+ * When the OS ends the user's session (logout/shutdown), this topic is
+ * notified. Always triggers enterprise sign-out (non-configurable).
+ */
+#define NS_WIDGET_OS_SESSION_END_OBSERVER_TOPIC "os-session-end"
+
+/**
+ * When the OS switches to a different user session, this topic is notified.
+ */
+#define NS_WIDGET_OS_USER_SWITCH_OBSERVER_TOPIC "os-user-switch"
+
+/**
+ * When the screen is locked, this topic is notified.
+ */
+#define NS_WIDGET_SCREEN_LOCKED_OBSERVER_TOPIC "screen-locked"
+
 namespace mozilla::widget {
 
 /**

--- a/widget/windows/WinEventObserver.cpp
+++ b/widget/windows/WinEventObserver.cpp
@@ -159,7 +159,7 @@ static void OnSessionChange(WPARAM wParam, LPARAM lParam) {
         // WTS_CONSOLE_DISCONNECT fires on Fast User Switch and also on
         // some RDP/session-disconnect scenarios. This is intentionally
         // broad -- enterprise policy can disable it via the
-        // enterprise.signoutOnUserSwitch pref if needed.
+        // enterprise.signout.user_switch.enabled pref if needed.
         observerService->NotifyObservers(
             nullptr, NS_WIDGET_OS_USER_SWITCH_OBSERVER_TOPIC, nullptr);
       }

--- a/widget/windows/WinEventObserver.cpp
+++ b/widget/windows/WinEventObserver.cpp
@@ -13,6 +13,7 @@
 // clang-format on
 
 #include "InputDeviceUtils.h"
+#include "nsIWidget.h"
 #include "ScreenHelperWin.h"
 #include "WinWindowOcclusionTracker.h"
 #include "WindowsUIUtils.h"
@@ -24,7 +25,9 @@
 #include "mozilla/LookAndFeel.h"
 #include "mozilla/WindowsVersion.h"
 #include "nsLookAndFeel.h"
+#include "nsIObserverService.h"
 #include "nsStringFwd.h"
+#include "mozilla/Services.h"
 #include "nsWindowDbg.h"
 #include "nsXULAppAPI.h"
 #include "nsdefs.h"
@@ -81,10 +84,13 @@ void WinEventWindow::Ensure() {
 
   sDeviceNotifyHandle = InputDeviceUtils::RegisterNotification(sHiddenWindow);
 
+  ::WTSRegisterSessionNotification(sHiddenWindow, NOTIFY_FOR_THIS_SESSION);
+
   // It should be harmless to leak this window until destruction -- but other
   // parts of Gecko may expect all windows to be destroyed, so do that.
   mozilla::RunOnShutdown([]() {
     InputDeviceUtils::UnregisterNotification(sDeviceNotifyHandle);
+    ::WTSUnRegisterSessionNotification(sHiddenWindow);
 
     sHiddenWindowShutdown = true;
     ::DestroyWindow(sHiddenWindow);
@@ -107,7 +113,8 @@ static void NotifyThemeChanged(ThemeChangeKind aKind) {
 }
 
 static void OnSessionChange(WPARAM wParam, LPARAM lParam) {
-  if (wParam == WTS_SESSION_LOCK || wParam == WTS_SESSION_UNLOCK) {
+  if (wParam == WTS_SESSION_LOCK || wParam == WTS_SESSION_UNLOCK ||
+      wParam == WTS_CONSOLE_DISCONNECT) {
     DWORD currentSessionId;
     BOOL const rv =
         ::ProcessIdToSessionId(::GetCurrentProcessId(), &currentSessionId);
@@ -140,6 +147,22 @@ static void OnSessionChange(WPARAM wParam, LPARAM lParam) {
 
     if (auto* wwot = WinWindowOcclusionTracker::Get()) {
       wwot->OnSessionChange(wParam);
+    }
+
+    nsCOMPtr<nsIObserverService> observerService =
+        mozilla::services::GetObserverService();
+    if (observerService) {
+      if (wParam == WTS_SESSION_LOCK) {
+        observerService->NotifyObservers(
+            nullptr, NS_WIDGET_SCREEN_LOCKED_OBSERVER_TOPIC, nullptr);
+      } else if (wParam == WTS_CONSOLE_DISCONNECT) {
+        // WTS_CONSOLE_DISCONNECT fires on Fast User Switch and also on
+        // some RDP/session-disconnect scenarios. This is intentionally
+        // broad -- enterprise policy can disable it via the
+        // enterprise.signoutOnUserSwitch pref if needed.
+        observerService->NotifyObservers(
+            nullptr, NS_WIDGET_OS_USER_SWITCH_OBSERVER_TOPIC, nullptr);
+      }
     }
   }
 }

--- a/widget/windows/nsWindow.cpp
+++ b/widget/windows/nsWindow.cpp
@@ -4832,6 +4832,17 @@ bool nsWindow::ProcessMessageInternal(UINT msg, WPARAM& wParam, LPARAM& lParam,
         shutdownReason = AppShutdownReason::OSForceClose;
       }
 
+      // Notify enterprise observers before the shutdown sequence begins.
+      // This is synchronous, so JS observers complete before the process exits.
+      if (lParam == 0 || (lParam & ENDSESSION_LOGOFF)) {
+        nsCOMPtr<nsIObserverService> sessionObsServ =
+            mozilla::services::GetObserverService();
+        if (sessionObsServ) {
+          sessionObsServ->NotifyObservers(
+              nullptr, NS_WIDGET_OS_SESSION_END_OBSERVER_TOPIC, nullptr);
+        }
+      }
+
       // Let's fake a shutdown sequence without actually closing windows etc.
       // to avoid Windows killing us in the middle. A proper shutdown would
       // require having a chance to pump some messages. Unfortunately


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2005206

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

> This is a duplicate of #422 since that was created as a branch on this repo, not a fork, and is unable to be force pushed for rebasing.

This PR adds OS session event detection for triggering signouts on OS screen locks and user switching. The two triggers are controlled by two prefs: `enterprise.signout.screen_lock.enabled` and `enterprise.signout.user_switch.enabled`, which can be controlled by a future `SignOut` policy in Bug-2040292. 

> Note: Keeping this in draft since it is undetermined whether the policy-managed signouts are needed.

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Replaces: #422 
* Blocks: Bug-2040292

---

### Testing <!-- OPTIONAL -->

* [x] Added tests
* [x] Manual testing performed


**Steps to verify changes:**
1. Set `enterprise.signout.screen_lock.enabled` and `enterprise.signout.user_switch.enabled` to `true`
2. Lock screen or switch user
3. Check results
4. Repeat with prefs set to `false`

**Expected result:**

- Console shows browser as signed out, browser is closed and FELT is displayed when prefs are true.
- Browser remains open and logged in when prefs are false.
