### PR TITLE
Bug 2061810 - Disable the about:addons recommendations in enterprise …

### DIFF
--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -55,6 +55,11 @@ pref("extensions.getAddons.link.url", "https://addons.mozilla.org/%LOCALE%/firef
 pref("extensions.getAddons.langpacks.url", "https://services.addons.mozilla.org/api/v4/addons/language-tools/?app=firefox&type=language&appversion=%VERSION%");
 pref("extensions.getAddons.discovery.api_url", "https://services.addons.mozilla.org/api/v4/discovery/?lang=%LOCALE%&edition=%DISTRIBUTION%");
 pref("extensions.getAddons.browserMappings.url", "https://services.addons.mozilla.org/api/v5/addons/browser-mappings/?browser=%BROWSER%");
+#ifdef MOZ_ENTERPRISE
+// Hide the about:addons Recommendations tab. AMO recommendations are not
+// relevant where add-ons are managed by policy.
+pref("extensions.getAddons.showPane", false);
+#endif
 
 // The URL for the privacy policy related to recommended extensions.
 pref("extensions.recommendations.privacyPolicyUrl", "https://www.mozilla.org/privacy/firefox/?utm_source=firefox-browser&utm_medium=firefox-browser&utm_content=privacy-policy-link#addons");

--- a/browser/components/extensions/test/browser/browser_unified_extensions_empty_panel.js
+++ b/browser/components/extensions/test/browser/browser_unified_extensions_empty_panel.js
@@ -123,6 +123,10 @@ async function checkManageExtensionsText(elem) {
 }
 
 add_task(async function test_button_opens_discopane_when_no_extension() {
+  await SpecialPowers.pushPrefEnv({
+    set: [["extensions.getAddons.showPane", true]],
+  });
+
   await BrowserTestUtils.withNewTab(
     { gBrowser, url: "about:robots" },
     async () => {
@@ -157,6 +161,8 @@ add_task(async function test_button_opens_discopane_when_no_extension() {
       BrowserTestUtils.removeTab(tab);
     }
   );
+
+  await SpecialPowers.popPrefEnv();
 });
 
 add_task(async function test_button_opens_extlist_when_all_exts_pinned() {

--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -3157,8 +3157,14 @@ pref("extensions.webextensions.ExtensionStorageIDB.enabled", true);
 
 // Whether to allow the inline options browser in HTML about:addons page.
 pref("extensions.htmlaboutaddons.inline-options.enabled", true);
-// Show recommendations on the extension and theme list views.
+
+// Show recommendations on the extension and theme list views. AMO
+// recommendations are not relevant where add-ons are managed by policy.
+#ifdef MOZ_ENTERPRISE
+pref("extensions.htmlaboutaddons.recommendations.enabled", false);
+#else
 pref("extensions.htmlaboutaddons.recommendations.enabled", true);
+#endif
 
 // Whether the Nova Themes picker should be enabled in the about:addons page.
 // (disabled by default here, so that other applications embedding Gecko

--- a/testing/profiles/mochitest/user.js
+++ b/testing/profiles/mochitest/user.js
@@ -44,9 +44,3 @@ user_pref("dom.push.serverURL", "wss://push.services.mozilla.com/");
 // Set a breakpad URL for mochitest runs. In enterprise builds the
 // default is an empty string, but push tests need a non-empty value.
 user_pref("breakpad.reportURL", "https://crash-stats.mozilla.org/report/index/");
-
-// Show the about:addons recommendations for mochitest runs. In enterprise
-// builds both default to false, but the discovery pane and list view
-// recommendation tests need them enabled.
-user_pref("extensions.getAddons.showPane", true);
-user_pref("extensions.htmlaboutaddons.recommendations.enabled", true);

--- a/testing/profiles/mochitest/user.js
+++ b/testing/profiles/mochitest/user.js
@@ -44,3 +44,9 @@ user_pref("dom.push.serverURL", "wss://push.services.mozilla.com/");
 // Set a breakpad URL for mochitest runs. In enterprise builds the
 // default is an empty string, but push tests need a non-empty value.
 user_pref("breakpad.reportURL", "https://crash-stats.mozilla.org/report/index/");
+
+// Show the about:addons recommendations for mochitest runs. In enterprise
+// builds both default to false, but the discovery pane and list view
+// recommendation tests need them enabled.
+user_pref("extensions.getAddons.showPane", true);
+user_pref("extensions.htmlaboutaddons.recommendations.enabled", true);

--- a/toolkit/mozapps/extensions/test/browser/browser.toml
+++ b/toolkit/mozapps/extensions/test/browser/browser.toml
@@ -70,6 +70,9 @@ skip-if = [
   "true", # Bug 1626824
 ]
 
+["browser_enterprise_recommendations_prefs.js"]
+run-if = ["enterprise"]
+
 ["browser_file_xpi_no_process_switch.js"]
 
 ["browser_globalwarnings.js"]

--- a/toolkit/mozapps/extensions/test/browser/browser_enterprise_recommendations_prefs.js
+++ b/toolkit/mozapps/extensions/test/browser/browser_enterprise_recommendations_prefs.js
@@ -1,0 +1,47 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+const PREF_RECOMMENDATIONS_ENABLED =
+  "extensions.htmlaboutaddons.recommendations.enabled";
+
+// The mochitest profile re-enables both prefs on the user branch; clear those
+// overrides to get the defaults enterprise builds ship.
+add_setup(async function () {
+  await SpecialPowers.pushPrefEnv({
+    clear: [[PREF_DISCOVER_ENABLED], [PREF_RECOMMENDATIONS_ENABLED]],
+  });
+});
+
+add_task(async function testNoRecommendationsCategory() {
+  await SpecialPowers.pushPrefEnv({ clear: [[PREF_UI_LASTCATEGORY]] });
+
+  let win = await open_manager(null);
+  ok(
+    !AboutAddonsTestUtils.isCategoryVisible(win, "discover"),
+    "The Recommendations category is hidden"
+  );
+
+  await wait_for_view_load(win);
+  is(
+    AboutAddonsTestUtils.getSidebarSelectedCategory(win),
+    "extension",
+    "about:addons opens on the extension list instead"
+  );
+
+  await close_manager(win);
+  await SpecialPowers.popPrefEnv();
+});
+
+add_task(async function testNoRecommendationsInListViews() {
+  for (let type of ["extension", "theme"]) {
+    let win = await loadInitialView(type);
+    ok(
+      !win.document.querySelector("recommended-addon-list"),
+      `There are no recommendations in the ${type} list view`
+    );
+    await closeView(win);
+  }
+});

--- a/toolkit/mozapps/extensions/test/browser/browser_enterprise_recommendations_prefs.js
+++ b/toolkit/mozapps/extensions/test/browser/browser_enterprise_recommendations_prefs.js
@@ -4,17 +4,6 @@
 
 "use strict";
 
-const PREF_RECOMMENDATIONS_ENABLED =
-  "extensions.htmlaboutaddons.recommendations.enabled";
-
-// The mochitest profile re-enables both prefs on the user branch; clear those
-// overrides to get the defaults enterprise builds ship.
-add_setup(async function () {
-  await SpecialPowers.pushPrefEnv({
-    clear: [[PREF_DISCOVER_ENABLED], [PREF_RECOMMENDATIONS_ENABLED]],
-  });
-});
-
 add_task(async function testNoRecommendationsCategory() {
   await SpecialPowers.pushPrefEnv({ clear: [[PREF_UI_LASTCATEGORY]] });
 

--- a/toolkit/mozapps/extensions/test/browser/browser_history_navigation.js
+++ b/toolkit/mozapps/extensions/test/browser/browser_history_navigation.js
@@ -542,7 +542,11 @@ add_task(async function test_open_last_view() {
 // Tests that navigating the discovery page works when that was the first view
 add_task(async function test_discopane_first_history_entry() {
   await SpecialPowers.pushPrefEnv({
-    set: [["extensions.getAddons.discovery.api_url", DISCOAPI_URL]],
+    set: [
+      ["extensions.getAddons.discovery.api_url", DISCOAPI_URL],
+      // The discopane is not enabled by default in every build.
+      ["extensions.getAddons.showPane", true],
+    ],
   });
 
   let aManager = await open_manager("addons://discover/");
@@ -565,6 +569,13 @@ add_task(async function test_discopane_first_history_entry() {
 
 // Tests that navigating the discovery page works when that was the second view
 add_task(async function test_discopane_second_history_entry() {
+  await SpecialPowers.pushPrefEnv({
+    set: [
+      // The discopane is not enabled by default in every build.
+      ["extensions.getAddons.showPane", true],
+    ],
+  });
+
   let aManager = await open_manager("addons://list/plugin");
   is_in_list(aManager, "addons://list/plugin", false, false);
 

--- a/toolkit/mozapps/extensions/test/browser/browser_html_detail_view.js
+++ b/toolkit/mozapps/extensions/test/browser/browser_html_detail_view.js
@@ -1059,6 +1059,10 @@ add_task(async function testPrivateBrowsingExtension() {
 });
 
 add_task(async function testInvalidExtension() {
+  await SpecialPowers.pushPrefEnv({
+    set: [["extensions.getAddons.showPane", true]],
+  });
+
   let win = await open_manager("addons://detail/foo");
   is(
     AboutAddonsTestUtils.getSidebarSelectedCategory(win),
@@ -1069,6 +1073,7 @@ add_task(async function testInvalidExtension() {
   ok(!gBrowser.canGoBack, "The view has been replaced");
 
   await close_manager(win);
+  await SpecialPowers.popPrefEnv();
 });
 
 add_task(async function testInvalidExtensionNoDiscover() {

--- a/toolkit/mozapps/extensions/test/browser/browser_html_discover_view.js
+++ b/toolkit/mozapps/extensions/test/browser/browser_html_discover_view.js
@@ -212,6 +212,8 @@ add_setup(async function () {
         "extensions.getAddons.discovery.api_url",
         `http://${AMO_TEST_HOST}/discoapi`,
       ],
+      // The discopane is not enabled by default in every build.
+      ["extensions.getAddons.showPane", true],
       // Disable non-discopane recommendations to avoid unexpected discovery
       // API requests.
       ["extensions.htmlaboutaddons.recommendations.enabled", false],

--- a/toolkit/mozapps/extensions/test/browser/browser_html_discover_view_clientid.js
+++ b/toolkit/mozapps/extensions/test/browser/browser_html_discover_view_clientid.js
@@ -53,6 +53,8 @@ add_setup(async function () {
       ["datareporting.healthreport.uploadEnabled", true],
       ["extensions.getAddons.discovery.api_url", `${serverBaseUrl}discoapi`],
       ["app.support.baseURL", `${serverBaseUrl}sumo/`],
+      // The discopane is not enabled by default in every build.
+      ["extensions.getAddons.showPane", true],
       // Discovery API requests can be triggered by the discopane and the
       // recommendations in the list view. To make sure that the every test
       // checks the behavior of the view they're testing, ensure that only one

--- a/toolkit/mozapps/extensions/test/browser/browser_html_list_view_recommendations.js
+++ b/toolkit/mozapps/extensions/test/browser/browser_html_list_view_recommendations.js
@@ -52,6 +52,9 @@ add_setup(async function () {
     set: [
       // Disable personalized recommendations, they will break the data URI.
       ["browser.discovery.enabled", false],
+      // The list view recommendations are not enabled by default in every
+      // build.
+      ["extensions.htmlaboutaddons.recommendations.enabled", true],
       ["extensions.getAddons.discovery.api_url", `data:;base64,${results}`],
       [
         "extensions.recommendations.themeRecommendationUrl",

--- a/toolkit/mozapps/extensions/test/browser/browser_html_scroll_restoration.js
+++ b/toolkit/mozapps/extensions/test/browser/browser_html_scroll_restoration.js
@@ -38,7 +38,13 @@ server.registerPathHandler("/discoapi", (request, response) => {
 
 add_setup(async function () {
   await SpecialPowers.pushPrefEnv({
-    set: [["extensions.getAddons.discovery.api_url", TEST_API_URL]],
+    set: [
+      ["extensions.getAddons.discovery.api_url", TEST_API_URL],
+      // The discopane and the list view recommendations are not enabled by
+      // default in every build.
+      ["extensions.getAddons.showPane", true],
+      ["extensions.htmlaboutaddons.recommendations.enabled", true],
+    ],
   });
 
   let mockProvider = new MockProvider();


### PR DESCRIPTION
…builds

Default extensions.getAddons.showPane and
extensions.htmlaboutaddons.recommendations.enabled to false in the enterprise branding prefs, hiding the Recommendations tab and the recommendation cards in the extension and theme list views. Neither is relevant where add-ons are managed by policy.

They are defaults rather than locked values so that the mochitest profile can restore them on the user branch, which keeps the upstream discovery pane and list recommendation tests running.

Add an enterprise-only test that clears those overrides and checks the UI: the Recommendations category is hidden, about:addons falls back to the extension list, and neither list view renders recommendation cards.

<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2061810

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on:

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

---

### Testing <!-- OPTIONAL -->

* [x] Added tests
* [x] Manual testing performed

<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
