### PR TITLE
Bug 2063598 - Revert setting app.update.auto=true for enterprise XP_WIN

### DIFF
--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -161,7 +161,7 @@ pref("app.update.notifyDuringDownload", false);
 // (which is in a file in the update directory). Because of this, this pref
 // should no longer be used directly. Instead, getAppUpdateAutoEnabled and
 // getAppUpdateAutoEnabled from UpdateUtils.sys.mjs should be used.
-#if !defined(XP_WIN) || defined(MOZ_ENTERPRISE)
+#ifndef XP_WIN
   pref("app.update.auto", true);
 #endif
 


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2063598

Reverts setting `app.update.auto=true` for enterprise `XP_WIN`.