### PR TITLE
Bug 2063734 - Remove app.update.auto from basic checks

### DIFF
--- a/testing/enterprise/test_felt_updates_basic.py
+++ b/testing/enterprise/test_felt_updates_basic.py
@@ -35,7 +35,6 @@ class FeltUpdatesBasicChecks(FeltTests):
 
     def get_app_update_prefs(self, env):
         prefs = [
-            "app.update.auto",
             "app.update.channel",
             "app.update.checkOnlyInstance.enabled",
             "app.update.background.enabled",
@@ -63,7 +62,6 @@ class FeltUpdatesBasicChecks(FeltTests):
     def run_verify_browser_prefs(self):
         prefs = self.get_app_update_prefs(Environment.FIREFOX)
 
-        assert prefs["app.update.auto"], "Auto updates enabled"
         # TODO: Do we care about the update channel ? The update URL is already
         # controlled ...
         # assert prefs["app.update.channel"] == "", "No update channel"


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2063734

Forcing the pref true on our builds was removed in bug 2063598 but the test was not updated.

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->