### PR TITLE
Bug 2017837 - Add tests for live policy SyncPolicy

### DIFF
--- a/browser/components/enterprisepolicies/helpers/SyncPolicy.sys.mjs
+++ b/browser/components/enterprisepolicies/helpers/SyncPolicy.sys.mjs
@@ -77,10 +77,6 @@ export const SyncPolicy = {
   async applySettings(manager, params) {
     lazy.log.debug("Apply Sync Settings");
 
-    // This might be an update to the Sync policy
-    // so restore previous sync settings
-    this.restoreSettings(manager);
-
     const {
       Enabled: shouldEnableSync,
       Locked: isIgnoringUserPreferences,
@@ -91,10 +87,10 @@ export const SyncPolicy = {
       const isSyncCurrentlyEnabled = this.isSyncCurrentlyEnabled();
       if (shouldEnableSync && !isSyncCurrentlyEnabled) {
         lazy.log.debug("Enable Sync");
-        await this.connectSync(manager);
+        await this.connectSync();
       } else if (shouldEnableSync === false && isSyncCurrentlyEnabled) {
         lazy.log.debug("Disable Sync");
-        await this.disconnectSync(manager);
+        await this.disconnectSync();
       }
     }
 

--- a/toolkit/components/enterprisepolicies/tests/browser/live/browser.toml
+++ b/toolkit/components/enterprisepolicies/tests/browser/live/browser.toml
@@ -29,4 +29,6 @@ run-if = [
 
 ["browser_live_policy_SitePolicies.js"]
 
+["browser_live_policy_Sync.js"]
+
 ["browser_live_policy_WebsiteFilter.js"]

--- a/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_policy_Sync.js
+++ b/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_policy_Sync.js
@@ -1,0 +1,176 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+// The feature the Sync policy disallows when it locks the sync state.
+const SYNC_FEATURE = "change-sync-state";
+
+function checkSyncFeatureAllowed(expectedAllowed) {
+  Assert.equal(
+    Services.policies.isAllowed(SYNC_FEATURE),
+    expectedAllowed,
+    `${SYNC_FEATURE} feature is ${expectedAllowed ? "allowed" : "disallowed"}`
+  );
+}
+
+async function updatePolicies(policies) {
+  const updateApplied = EnterprisePolicyTesting.awaitNextPolicyUpdate();
+  EnterprisePolicyTesting.stubRemotePolicies(policies);
+  await updateApplied;
+}
+
+const { UIState } = ChromeUtils.importESModule(
+  "resource://services-sync/UIState.sys.mjs"
+);
+const { getFxAccountsSingleton } = ChromeUtils.importESModule(
+  "resource://gre/modules/FxAccounts.sys.mjs"
+);
+
+// The sync pane renders from UIState, so we mock it to reach the signed-in
+// states that expose the controls gated on the change-sync-state feature.
+const SIGNED_IN_SYNC_ON = {
+  status: UIState.STATUS_SIGNED_IN,
+  email: "test@example.com",
+  displayName: "Test User",
+  syncEnabled: true,
+};
+
+const SIGNED_IN_SYNC_OFF = {
+  status: UIState.STATUS_SIGNED_IN,
+  email: "test@example.com",
+  displayName: "Test User",
+  syncEnabled: false,
+};
+
+// Open the settings sync pane with a mocked UIState and run a check
+// against its document.
+async function withSyncPane(uiStateData, assertionCallback) {
+  const oldGet = UIState.get;
+  UIState.get = () => uiStateData;
+
+  const paneLoaded = TestUtils.topicObserved("sync-pane-loaded", () => true);
+  gBrowser.selectedTab = BrowserTestUtils.addTab(gBrowser, "about:blank", {
+    allowInheritPrincipal: true,
+  });
+  openPreferences("paneSync");
+  await paneLoaded;
+
+  const doc = gBrowser.contentDocument;
+
+  // The sync settings render from the mocked UIState during pane load; wait for
+  // the signed-in state to be reflected before asserting.
+  await TestUtils.waitForCondition(() => {
+    const signedIn = doc.getElementById("fxaSignedInGroup");
+    return signedIn && BrowserTestUtils.isVisible(signedIn);
+  }, "the signed-in account state is rendered");
+
+  try {
+    await assertionCallback(doc);
+  } finally {
+    UIState.get = oldGet;
+    BrowserTestUtils.removeTab(gBrowser.selectedTab);
+  }
+}
+
+function syncGroup(doc) {
+  return doc.querySelector('setting-group[groupid="sync"]');
+}
+
+// The Disconnect control only appears while Sync is on.
+async function checkDisconnect(expectedHidden) {
+  await withSyncPane(SIGNED_IN_SYNC_ON, doc => {
+    const group = syncGroup(doc);
+    ok(
+      !BrowserTestUtils.isHidden(group.querySelector("#syncConfigured")),
+      "The 'Sync is on' section is shown for a signed-in, syncing user."
+    );
+    is(
+      BrowserTestUtils.isHidden(group.querySelector("#syncDisconnect")),
+      expectedHidden,
+      `The Disconnect button is ${expectedHidden ? "hidden" : "shown"}.`
+    );
+  });
+}
+
+// The "Sync is off" section only appears while Sync is off.
+async function checkTurnOn(expectedHidden) {
+  await withSyncPane(SIGNED_IN_SYNC_OFF, doc => {
+    const group = syncGroup(doc);
+    is(
+      BrowserTestUtils.isHidden(group.querySelector("#syncNotConfigured")),
+      expectedHidden,
+      `The 'Sync is off' section is ${expectedHidden ? "hidden" : "shown"}.`
+    );
+    is(
+      BrowserTestUtils.isHidden(group.querySelector("#syncSetup")),
+      expectedHidden,
+      `The 'Turn on syncing' button is ${expectedHidden ? "hidden" : "shown"}.`
+    );
+  });
+}
+
+// Fake a signed-in FxA account with sync keys so the policy's connect path
+// (Service.configure) succeeds. Returns a function that restores the originals.
+function mockSignedInAccount() {
+  const fxAccounts = getFxAccountsSingleton();
+  const originalGetSignedInUser = fxAccounts.getSignedInUser;
+  const originalHasKeysForScope = fxAccounts.keys.hasKeysForScope;
+  fxAccounts.getSignedInUser = () =>
+    Promise.resolve({ email: "test@example.com", uid: "12345" });
+  fxAccounts.keys.hasKeysForScope = () => Promise.resolve(true);
+  return () => {
+    fxAccounts.getSignedInUser = originalGetSignedInUser;
+    fxAccounts.keys.hasKeysForScope = originalHasKeysForScope;
+  };
+}
+
+add_setup(async function () {
+  await SpecialPowers.pushPrefEnv({
+    // The mocked signed-in UIState has no real FxA account, so the urlbar trust
+    // panel's breach check logs NO_ACCOUNT errors on the tab switch into the sync
+    // pane. It is unrelated to these tests, so turn it off.
+    set: [["browser.urlbar.trustPanel.featureGate", false]],
+  });
+});
+
+// Sync locked and enabled: Hides the Disconnect control.
+// Sync locked and disabled: Hides the "Sync is off" section (info box + 'Turn on syncing' button).
+// Removing the policy hides no on/off controls.
+add_task(async function test_sync_controls_reflect_feature_lock() {
+  const restoreFxa = mockSignedInAccount();
+
+  try {
+    info("Enabled and Locked: the Disconnect control is hidden.");
+    await EnterprisePolicyTesting.setupEngineWithRemotePolicies(
+      { policies: { Sync: { Enabled: true, Locked: true } } },
+      null
+    );
+    // Enabling awaits connectSync before disallowFeature, so wait for the lock.
+    await TestUtils.waitForCondition(
+      () => !Services.policies.isAllowed(SYNC_FEATURE),
+      "the change-sync-state feature is locked"
+    );
+    await checkDisconnect(true);
+
+    info("Disabled and Locked: the 'Sync is off' controls are hidden.");
+    await updatePolicies({
+      policies: { Sync: { Enabled: false, Locked: true } },
+    });
+    // A prior connect means this may disconnect (async) before disallowFeature.
+    await TestUtils.waitForCondition(
+      () => !Services.policies.isAllowed(SYNC_FEATURE),
+      "the change-sync-state feature is locked"
+    );
+    await checkTurnOn(true);
+
+    info("Removed: the controls are shown again.");
+    await updatePolicies({ policies: {} });
+    checkSyncFeatureAllowed(true);
+    await checkDisconnect(false);
+    await checkTurnOn(false);
+  } finally {
+    restoreFxa();
+    Services.prefs.clearUserPref("services.sync.username");
+  }
+});

--- a/toolkit/components/enterprisepolicies/tests/xpcshell/live/test_live_policy_Sync.js
+++ b/toolkit/components/enterprisepolicies/tests/xpcshell/live/test_live_policy_Sync.js
@@ -1,0 +1,271 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+// Testing the Sync policy in an xpcshell test because exercising the Sync
+// policy's real connection changes needs the services-sync testing harness to
+// fake a signed-in state.
+
+// The services-sync modules read the profile directory at import time.
+do_get_profile();
+
+const { TestUtils } = ChromeUtils.importESModule(
+  "resource://testing-common/TestUtils.sys.mjs"
+);
+const { Service } = ChromeUtils.importESModule(
+  "resource://services-sync/service.sys.mjs"
+);
+const { configureIdentity } = ChromeUtils.importESModule(
+  "resource://testing-common/services/sync/utils.sys.mjs"
+);
+const { STATUS_OK, CLIENT_NOT_CONFIGURED } = ChromeUtils.importESModule(
+  "resource://services-sync/constants.sys.mjs"
+);
+const { getFxAccountsSingleton } = ChromeUtils.importESModule(
+  "resource://gre/modules/FxAccounts.sys.mjs"
+);
+
+const SYNC_FEATURE = "change-sync-state";
+
+// Engine prefs the Sync policy drives, keyed by their policy property name.
+const ENGINE_PREFS = {
+  Bookmarks: "services.sync.engine.bookmarks",
+  History: "services.sync.engine.history",
+  Passwords: "services.sync.engine.passwords",
+  Addresses: "services.sync.engine.addresses",
+};
+
+function checkEnginePref(pref, expectedValue, expectedLocked) {
+  Assert.strictEqual(
+    Services.prefs.getBoolPref(pref),
+    expectedValue,
+    `${pref} has the expected value`
+  );
+  Assert.equal(
+    Services.prefs.prefIsLocked(pref),
+    expectedLocked,
+    `${pref} lock status is as expected`
+  );
+}
+
+function checkSyncFeatureAllowed(expectedAllowed) {
+  Assert.equal(
+    Services.policies.isAllowed(SYNC_FEATURE),
+    expectedAllowed,
+    `${SYNC_FEATURE} feature is ${expectedAllowed ? "allowed" : "disallowed"}`
+  );
+}
+
+async function updatePolicies(policies) {
+  const updateApplied = EnterprisePolicyTesting.awaitNextPolicyUpdate();
+  EnterprisePolicyTesting.stubRemotePolicies(policies);
+  await updateApplied;
+}
+
+// Fake a signed-in FxA account with sync keys so the policy's connect path
+// (Service.configure) succeeds. Returns a function that restores the originals.
+function mockSignedInAccount() {
+  const fxAccounts = getFxAccountsSingleton();
+  const originalGetSignedInUser = fxAccounts.getSignedInUser;
+  const originalHasKeysForScope = fxAccounts.keys.hasKeysForScope;
+  fxAccounts.getSignedInUser = () =>
+    Promise.resolve({ email: "test@example.com", uid: "12345" });
+  fxAccounts.keys.hasKeysForScope = () => Promise.resolve(true);
+  return () => {
+    fxAccounts.getSignedInUser = originalGetSignedInUser;
+    fxAccounts.keys.hasKeysForScope = originalHasKeysForScope;
+  };
+}
+
+registerCleanupFunction(() => {
+  Services.prefs.clearUserPref("services.sync.username");
+});
+
+// ---- Unlocked Sync policy does not change the connection ----
+
+// Enabled without Locked doesn't change the connection,
+// so a disconnected Sync stays disconnected.
+add_task(async function test_unlocked_enabled_does_not_connect() {
+  await Service.startOver();
+  Assert.ok(
+    !Services.prefs.prefHasUserValue("services.sync.username"),
+    "Sync is disconnected before the policy applies"
+  );
+
+  await EnterprisePolicyTesting.setupEngineWithRemotePolicies(
+    { policies: { Sync: { Enabled: true } } },
+    null
+  );
+
+  Assert.ok(
+    "Sync" in Services.policies.getActivePolicies(),
+    "the Sync policy was applied"
+  );
+  Assert.equal(
+    Service.status.checkSetup(),
+    CLIENT_NOT_CONFIGURED,
+    "Sync stays disconnected because the policy is not locked"
+  );
+  checkSyncFeatureAllowed(true);
+
+  await updatePolicies({ policies: {} });
+});
+
+// Disabled without Locked doesn't change the connection,
+// so a connected Sync stays connected.
+add_task(async function test_unlocked_disabled_does_not_disconnect() {
+  await Service.startOver();
+  await configureIdentity();
+  Assert.equal(
+    Service.status.checkSetup(),
+    STATUS_OK,
+    "Sync is connected before the policy applies"
+  );
+
+  await EnterprisePolicyTesting.setupEngineWithRemotePolicies(
+    { policies: { Sync: { Enabled: false } } },
+    null
+  );
+
+  Assert.ok(
+    Services.prefs.prefHasUserValue("services.sync.username"),
+    "the Sync account is still configured"
+  );
+  Assert.equal(
+    Service.status.checkSetup(),
+    STATUS_OK,
+    "Sync stays connected because the policy is not locked"
+  );
+  checkSyncFeatureAllowed(true);
+
+  await updatePolicies({ policies: {} });
+});
+
+// Enabled and Locked connects a disconnected Sync and locks the feature.
+add_task(async function test_locked_enabled_connects_and_locks_feature() {
+  await Service.startOver();
+  Assert.ok(
+    !Services.prefs.prefHasUserValue("services.sync.username"),
+    "Sync is disconnected before the policy applies"
+  );
+
+  const restoreFxa = mockSignedInAccount();
+  try {
+    await EnterprisePolicyTesting.setupEngineWithRemotePolicies(
+      { policies: { Sync: { Enabled: true, Locked: true } } },
+      null
+    );
+
+    // applySettings drives connectSync asynchronously; wait for the connection.
+    await TestUtils.waitForCondition(
+      () =>
+        Services.prefs.getStringPref("services.sync.username", "") ===
+        "test@example.com",
+      "the signed-in account was connected to Sync"
+    );
+    checkSyncFeatureAllowed(false);
+  } finally {
+    restoreFxa();
+  }
+
+  await updatePolicies({ policies: {} });
+  checkSyncFeatureAllowed(true);
+});
+
+// Disabled and Locked disconnects a connected Sync and locks the feature.
+add_task(async function test_locked_disabled_disconnects_and_locks_feature() {
+  await Service.startOver();
+  await configureIdentity();
+  Assert.equal(
+    Service.status.checkSetup(),
+    STATUS_OK,
+    "Sync is connected before the policy applies"
+  );
+
+  await EnterprisePolicyTesting.setupEngineWithRemotePolicies(
+    { policies: { Sync: { Enabled: false, Locked: true } } },
+    null
+  );
+
+  // applySettings drives disconnectSync asynchronously; wait for the teardown.
+  await TestUtils.waitForCondition(
+    () => !Services.prefs.prefHasUserValue("services.sync.username"),
+    "the Sync account was torn down"
+  );
+  Assert.equal(
+    Service.status.checkSetup(),
+    CLIENT_NOT_CONFIGURED,
+    "Sync setup state was reset"
+  );
+  checkSyncFeatureAllowed(false);
+
+  await updatePolicies({ policies: {} });
+  checkSyncFeatureAllowed(true);
+});
+
+// An unlocked Sync policy only changes the engine setting's default values;
+// the preference stay unlocked and the sync feature stays allowed.
+add_task(async function test_unlocked_engine_pref_sets_default() {
+  const initialPasswords = Services.prefs.getBoolPref(ENGINE_PREFS.Passwords);
+
+  await EnterprisePolicyTesting.setupEngineWithRemotePolicies(
+    { policies: { Sync: { Passwords: false } } },
+    null
+  );
+
+  checkEnginePref(ENGINE_PREFS.Passwords, false, false);
+  checkSyncFeatureAllowed(true);
+
+  await updatePolicies({ policies: {} });
+
+  checkEnginePref(ENGINE_PREFS.Passwords, initialPasswords, false);
+  checkSyncFeatureAllowed(true);
+});
+
+// A locked Sync policy overrides the engine settings and locks the prefs.
+// A live update reconciles them, and removal reverts to the initial values.
+add_task(async function test_locked_engine_prefs_override_and_revert() {
+  const initialBookmarks = Services.prefs.getBoolPref(ENGINE_PREFS.Bookmarks);
+  const initialHistory = Services.prefs.getBoolPref(ENGINE_PREFS.History);
+
+  info("Applying a locked engine configuration.");
+  await EnterprisePolicyTesting.setupEngineWithRemotePolicies(
+    {
+      policies: {
+        Sync: {
+          Locked: true,
+          Bookmarks: false,
+          History: false,
+        },
+      },
+    },
+    null
+  );
+
+  checkEnginePref(ENGINE_PREFS.Bookmarks, false, true);
+  checkEnginePref(ENGINE_PREFS.History, false, true);
+  checkSyncFeatureAllowed(true);
+
+  info("Live-updating the locked engine configuration.");
+  await updatePolicies({
+    policies: {
+      Sync: {
+        Locked: true,
+        Bookmarks: true,
+      },
+    },
+  });
+
+  // Bookmarks flips to locked true; History was dropped from the config so it
+  // reverts to its unlocked default.
+  checkEnginePref(ENGINE_PREFS.Bookmarks, true, true);
+  checkEnginePref(ENGINE_PREFS.History, initialHistory, false);
+
+  info("Removing the Sync policy.");
+  await updatePolicies({ policies: {} });
+
+  checkEnginePref(ENGINE_PREFS.Bookmarks, initialBookmarks, false);
+  checkEnginePref(ENGINE_PREFS.History, initialHistory, false);
+  checkSyncFeatureAllowed(true);
+});

--- a/toolkit/components/enterprisepolicies/tests/xpcshell/live/xpcshell.toml
+++ b/toolkit/components/enterprisepolicies/tests/xpcshell/live/xpcshell.toml
@@ -4,3 +4,5 @@ head = "head.js"
 run-if = ["enterprise"]
 
 ["test_live_policy_Proxy.js"]
+
+["test_live_policy_Sync.js"]


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2017837

- Removes restoring the settings in `applySettings()` since this is now already done by the remove-then-reapply logic on any policy update.
- Adds missing test coverage for the live policy `SyncPolicy`

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Testing <!-- OPTIONAL -->

* [X] Added tests

<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
