### PR TITLE
Bug-2064518 - Add Glean app id override

### DIFF
--- a/browser/components/StartupTelemetry.sys.mjs
+++ b/browser/components/StartupTelemetry.sys.mjs
@@ -136,11 +136,7 @@ export let StartupTelemetry = {
     // completed.  See comments in `TelemetryReportingPolicy`.
     await lazy.TelemetryReportingPolicy.ensureUserIsNotified();
 
-    if (AppConstants.MOZ_ENTERPRISE) {
-      Services.fog.initializeFOG(undefined, "firefox.enterprise.desktop");
-    } else {
-      Services.fog.initializeFOG();
-    }
+    Services.fog.initializeFOG();
 
     // Register Glean to listen for experiment updates releated to the
     // "gleanInternalSdk" feature defined in the t/c/nimbus/FeatureManifest.yaml

--- a/browser/components/StartupTelemetry.sys.mjs
+++ b/browser/components/StartupTelemetry.sys.mjs
@@ -136,7 +136,11 @@ export let StartupTelemetry = {
     // completed.  See comments in `TelemetryReportingPolicy`.
     await lazy.TelemetryReportingPolicy.ensureUserIsNotified();
 
-    Services.fog.initializeFOG();
+    if (AppConstants.MOZ_ENTERPRISE) {
+      Services.fog.initializeFOG(undefined, "firefox.enterprise.desktop");
+    } else {
+      Services.fog.initializeFOG();
+    }
 
     // Register Glean to listen for experiment updates releated to the
     // "gleanInternalSdk" feature defined in the t/c/nimbus/FeatureManifest.yaml

--- a/toolkit/xre/nsAppRunner.cpp
+++ b/toolkit/xre/nsAppRunner.cpp
@@ -4942,7 +4942,11 @@ int XREMain::XRE_mainInit(bool* aExitFlag,
   // We do NOT set one for `firefox`.
   // FOG uses a default one,
   // background tasks overwrite it using `initializeFOG`.
-  FOG::SetApplicationID("thunderbird.desktop"_ns);
+  #if !defined(MOZ_ENTERPRISE)
+    FOG::SetApplicationID("thunderbird.desktop"_ns);
+  #else
+    FOG::SetApplicationID("thunderbird.enterprise.desktop"_ns);
+  #endif
 #endif  // MOZ_THUNDERBIRD
 
 #ifdef MOZ_ENTERPRISE

--- a/toolkit/xre/nsAppRunner.cpp
+++ b/toolkit/xre/nsAppRunner.cpp
@@ -4945,6 +4945,10 @@ int XREMain::XRE_mainInit(bool* aExitFlag,
   FOG::SetApplicationID("thunderbird.desktop"_ns);
 #endif  // MOZ_THUNDERBIRD
 
+#ifdef MOZ_ENTERPRISE
+  FOG::SetApplicationID("firefox.enterprise.desktop"_ns);
+#endif
+
   nsCOMPtr<nsIFile> xreBinDirectory;
   xreBinDirectory = mDirProvider.GetGREBinDir();
 


### PR DESCRIPTION
### Description 

Bugzilla: Bug-2064518

In the review of [PR 1035](https://github.com/mozilla/probe-scraper/pull/1035), which sets up the Glean telemetry pipeline for Firefox Enterprise, it was noticed that we currently report the default [`firefox.desktop`](https://searchfox.org/enterprise-main/rev/436f6d89f0be99c3f18609b7540a4e7c922dfa6e/toolkit/components/glean/src/init/mod.rs#154) application id to Glean. This means that all enterprise telemetry data would end up in the default Firefox Big Query tables (not what we want). To fix this, we need to provide an app id override [here](https://searchfox.org/enterprise-main/rev/cfa24ba45043d4a41da13315e03e043dc09d977e/browser/components/StartupTelemetry.sys.mjs#139) (or change the default for an enterprise build).

---

### Steps to verify changes:

1. Clone [https://github.com/fiji-flo/oidc-rock.git](https://github.com/fiji-flo/oidc-rock.git).
2. `cd` into the repository and run `cargo run config.yaml`. Keep it running.
3. Clone [https://github.com/mozilla/enterprise-console.git](https://github.com/mozilla/enterprise-console.git) and `cd` into the repository.
4. Make sure a PostgreSQL instance is running. If Docker is installed, you can run:

   ```bash
   docker run -d \
       --name enterprise-console-postgres \
       -e POSTGRES_DB=ec \
       -e POSTGRES_USER=ec \
       -e POSTGRES_PASSWORD=abcd1234 \
       -p 5432:5432 \
       postgres:18
   ```
5. Start the Enterprise Console:

   ```bash
   APP_WEB__TLS__ENABLED=false RUST_LOG=debug APP_CONFIG=config/dev.example.yaml cargo run -p ec_webserver_bin
   ```
6. Build Firefox with this patch and run it against the local console, for example:

   ```bash
   mach run --setpref="enterprise.console.address=http://localhost:8000"
   ```
7. Login using the mock OIDC provider (credentials are in the login screen, email can be anything).

**Expected result:**

You should see a log message similar to:

```bash
2026-08-18T22:29:47.046516+02:00 DEBUG request: started processing request method=POST uri=https://localhost:8000/api/browser/telemetry/submit/firefox-enterprise-desktop/baseline/1/44701608-2407-4b6a-9686-9d14befea0af version=HTTP/2.0
```

Note that the application ID is `firefox-enterprise-desktop`. Without this patch, it would be `firefox-desktop`.
