### PR TITLE
Bug 2064655 - Add test coverage for live policies that simplify debugging

### DIFF
--- a/browser/components/enterprisepolicies/Policies.sys.mjs
+++ b/browser/components/enterprisepolicies/Policies.sys.mjs
@@ -571,8 +571,8 @@ export var Policies = {
         lazy.blockAboutPage(manager, "about:config");
         lazy.PoliciesUtils.setAndLockPref("devtools.chrome.enabled", false);
       } else {
+        // Only unblocking about:config; not-force enabling devtools.chrome.enabled
         lazy.unblockAboutPage(manager, "about:config");
-        lazy.PoliciesUtils.setAndLockPref("devtools.chrome.enabled", true);
       }
     },
     onRemove(manager, _) {
@@ -1317,8 +1317,8 @@ export var Policies = {
         lazy.blockAboutPage(manager, "about:devtools-toolbox");
         lazy.blockAboutPage(manager, "about:profiling");
       } else {
+        // Only unblocking devtools; not-force enabling devtools.chrome.enabled
         lazy.PoliciesUtils.setAndLockPref("devtools.policy.disabled", false);
-        lazy.PoliciesUtils.setAndLockPref("devtools.chrome.enabled", true);
 
         manager.allowFeature("devtools");
         lazy.unblockAboutPage(manager, "about:debugging");

--- a/browser/components/enterprisepolicies/tests/browser/browser_policy_websitefilter.js
+++ b/browser/components/enterprisepolicies/tests/browser/browser_policy_websitefilter.js
@@ -29,29 +29,41 @@ add_task(async function test_http() {
     },
   });
 
-  await checkBlockedPage(SUPPORT_FILES_PATH + BLOCKED_PAGE, true);
-  await checkBlockedPage(
+  await EnterprisePolicyTesting.checkBlockedPage(
+    SUPPORT_FILES_PATH + BLOCKED_PAGE,
+    true
+  );
+  await EnterprisePolicyTesting.checkBlockedPage(
     "view-source:" + SUPPORT_FILES_PATH + BLOCKED_PAGE,
     true
   );
-  await checkBlockedPage(
+  await EnterprisePolicyTesting.checkBlockedPage(
     "about:reader?url=" + SUPPORT_FILES_PATH + BLOCKED_PAGE,
     true
   );
-  await checkBlockedPage(
+  await EnterprisePolicyTesting.checkBlockedPage(
     "about:READER?url=" + SUPPORT_FILES_PATH + BLOCKED_PAGE,
     true
   );
-  await checkBlockedPage(
+  await EnterprisePolicyTesting.checkBlockedPage(
     "about:reader?e=1&url=" +
       encodeURIComponent(SUPPORT_FILES_PATH + BLOCKED_PAGE),
     true
   );
-  await checkBlockedPage(SUPPORT_FILES_PATH + EXCEPTION_PAGE, false);
+  await EnterprisePolicyTesting.checkBlockedPage(
+    SUPPORT_FILES_PATH + EXCEPTION_PAGE,
+    false
+  );
 
-  await checkBlockedPage(SUPPORT_FILES_PATH + "301.sjs", true);
+  await EnterprisePolicyTesting.checkBlockedPage(
+    SUPPORT_FILES_PATH + "301.sjs",
+    true
+  );
 
-  await checkBlockedPage(SUPPORT_FILES_PATH + "302.sjs", true);
+  await EnterprisePolicyTesting.checkBlockedPage(
+    SUPPORT_FILES_PATH + "302.sjs",
+    true
+  );
   await clearWebsiteFilter();
 });
 
@@ -65,8 +77,11 @@ add_task(async function test_http_mixed_case() {
     },
   });
 
-  await checkBlockedPage(SUPPORT_FILES_PATH + BLOCKED_PAGE.toUpperCase(), true);
-  await checkBlockedPage(
+  await EnterprisePolicyTesting.checkBlockedPage(
+    SUPPORT_FILES_PATH + BLOCKED_PAGE.toUpperCase(),
+    true
+  );
+  await EnterprisePolicyTesting.checkBlockedPage(
     SUPPORT_FILES_PATH + EXCEPTION_PAGE.toUpperCase(),
     false
   );
@@ -82,7 +97,10 @@ add_task(async function test_file() {
     },
   });
 
-  await checkBlockedPage("file:///this_should_be_blocked", true);
+  await EnterprisePolicyTesting.checkBlockedPage(
+    "file:///this_should_be_blocked",
+    true
+  );
   await clearWebsiteFilter();
 });
 
@@ -169,23 +187,35 @@ add_task(async function test_http_json_policy() {
     },
   });
 
-  await checkBlockedPage(SUPPORT_FILES_PATH + BLOCKED_PAGE, true);
-  await checkBlockedPage(
+  await EnterprisePolicyTesting.checkBlockedPage(
+    SUPPORT_FILES_PATH + BLOCKED_PAGE,
+    true
+  );
+  await EnterprisePolicyTesting.checkBlockedPage(
     "view-source:" + SUPPORT_FILES_PATH + BLOCKED_PAGE,
     true
   );
-  await checkBlockedPage(
+  await EnterprisePolicyTesting.checkBlockedPage(
     "about:reader?url=" + SUPPORT_FILES_PATH + BLOCKED_PAGE,
     true
   );
-  await checkBlockedPage(
+  await EnterprisePolicyTesting.checkBlockedPage(
     "about:READER?url=" + SUPPORT_FILES_PATH + BLOCKED_PAGE,
     true
   );
-  await checkBlockedPage(SUPPORT_FILES_PATH + EXCEPTION_PAGE, false);
+  await EnterprisePolicyTesting.checkBlockedPage(
+    SUPPORT_FILES_PATH + EXCEPTION_PAGE,
+    false
+  );
 
-  await checkBlockedPage(SUPPORT_FILES_PATH + "301.sjs", true);
+  await EnterprisePolicyTesting.checkBlockedPage(
+    SUPPORT_FILES_PATH + "301.sjs",
+    true
+  );
 
-  await checkBlockedPage(SUPPORT_FILES_PATH + "302.sjs", true);
+  await EnterprisePolicyTesting.checkBlockedPage(
+    SUPPORT_FILES_PATH + "302.sjs",
+    true
+  );
   await clearWebsiteFilter();
 });

--- a/browser/components/enterprisepolicies/tests/browser/head.js
+++ b/browser/components/enterprisepolicies/tests/browser/head.js
@@ -25,36 +25,6 @@ function checkUnlockedPref(prefName, prefValue) {
   EnterprisePolicyTesting.checkPolicyPref(prefName, prefValue, false);
 }
 
-// Checks that a page was blocked by seeing if it was replaced with about:neterror
-async function checkBlockedPage(url, expectedBlocked) {
-  let newTab = BrowserTestUtils.addTab(gBrowser);
-  gBrowser.selectedTab = newTab;
-
-  if (expectedBlocked) {
-    let promise = BrowserTestUtils.waitForErrorPage(gBrowser.selectedBrowser);
-    BrowserTestUtils.startLoadingURIString(gBrowser, url);
-    await promise;
-    is(
-      newTab.linkedBrowser.documentURI.spec.startsWith(
-        "about:neterror?e=blockedByPolicy"
-      ),
-      true,
-      "Should be blocked by policy"
-    );
-  } else {
-    let promise = BrowserTestUtils.browserStopped(gBrowser, url);
-    BrowserTestUtils.startLoadingURIString(gBrowser, url);
-    await promise;
-
-    is(
-      newTab.linkedBrowser.documentURI.spec,
-      url,
-      "Should not be blocked by policy"
-    );
-  }
-  BrowserTestUtils.removeTab(newTab);
-}
-
 async function check_homepage({
   expectedURL,
   expectedPageVal = -1,

--- a/toolkit/components/enterprisepolicies/tests/EnterprisePolicyTesting.sys.mjs
+++ b/toolkit/components/enterprisepolicies/tests/EnterprisePolicyTesting.sys.mjs
@@ -6,8 +6,11 @@ import { Preferences } from "resource://gre/modules/Preferences.sys.mjs";
 
 import { Assert } from "resource://testing-common/Assert.sys.mjs";
 
+import { AppConstants } from "resource://gre/modules/AppConstants.sys.mjs";
+
 const lazy = {};
 ChromeUtils.defineESModuleGetters(lazy, {
+  BrowserTestUtils: "resource://testing-common/BrowserTestUtils.sys.mjs",
   FileTestUtils: "resource://testing-common/FileTestUtils.sys.mjs",
   SearchService: "moz-src:///toolkit/components/search/SearchService.sys.mjs",
   SearchTestUtils: "resource://testing-common/SearchTestUtils.sys.mjs",
@@ -208,6 +211,50 @@ export var EnterprisePolicyTesting = {
       expectedValue,
       `Pref ${prefName} has the correct value`
     );
+  },
+
+  /**
+   * Load a URL in a new tab of the most recent browser window and assert
+   * whether the policy engine blocked it, i.e. replaced the page with
+   * about:neterror?e=blockedByPolicy. Browser-chrome only.
+   *
+   * @param {string} url page to load
+   * @param {boolean} expectedBlocked whether the load is expected to be blocked
+   * @returns {Promise<void>} resolves once the assertion has been made
+   */
+  async checkBlockedPage(url, expectedBlocked) {
+    let gBrowser =
+      Services.wm.getMostRecentWindow("navigator:browser").gBrowser;
+    let newTab = lazy.BrowserTestUtils.addTab(gBrowser);
+    gBrowser.selectedTab = newTab;
+
+    if (expectedBlocked) {
+      let promise = lazy.BrowserTestUtils.waitForErrorPage(
+        gBrowser.selectedBrowser
+      );
+      lazy.BrowserTestUtils.startLoadingURIString(gBrowser, url);
+      await promise;
+
+      const errorPage = AppConstants.MOZ_ENTERPRISE
+        ? "blockedByPolicyEnterprise"
+        : "blockedByPolicy";
+      Assert.ok(
+        newTab.linkedBrowser.documentURI.spec.startsWith(
+          `about:neterror?e=${errorPage}`
+        ),
+        "Should be blocked by policy"
+      );
+    } else {
+      let promise = lazy.BrowserTestUtils.browserStopped(gBrowser, url);
+      lazy.BrowserTestUtils.startLoadingURIString(gBrowser, url);
+      await promise;
+      Assert.equal(
+        newTab.linkedBrowser.documentURI.spec,
+        url,
+        "Should not be blocked by policy"
+      );
+    }
+    lazy.BrowserTestUtils.removeTab(newTab);
   },
 
   resetRunOnceState: function resetRunOnceState() {

--- a/toolkit/components/enterprisepolicies/tests/browser/live/browser.toml
+++ b/toolkit/components/enterprisepolicies/tests/browser/live/browser.toml
@@ -23,6 +23,8 @@ run-if = [
 
 ["browser_live_policy_BlockAboutConfig.js"]
 
+["browser_live_policy_BlockAboutSupport.js"]
+
 ["browser_live_policy_Cookies.js"]
 
 ["browser_live_policy_ExtensionSettings.js"]

--- a/toolkit/components/enterprisepolicies/tests/browser/live/browser.toml
+++ b/toolkit/components/enterprisepolicies/tests/browser/live/browser.toml
@@ -21,6 +21,8 @@ run-if = [
 
 ["browser_live_policies_restoring_preference_state.js"]
 
+["browser_live_policy_BlockAboutConfig.js"]
+
 ["browser_live_policy_Cookies.js"]
 
 ["browser_live_policy_ExtensionSettings.js"]

--- a/toolkit/components/enterprisepolicies/tests/browser/live/browser.toml
+++ b/toolkit/components/enterprisepolicies/tests/browser/live/browser.toml
@@ -27,6 +27,8 @@ run-if = [
 
 ["browser_live_policy_Cookies.js"]
 
+["browser_live_policy_DisableDeveloperTools.js"]
+
 ["browser_live_policy_ExtensionSettings.js"]
 
 ["browser_live_policy_HttpsOnlyMode.js"]

--- a/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_policy_BlockAboutConfig.js
+++ b/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_policy_BlockAboutConfig.js
@@ -1,0 +1,28 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+const ABOUT_CONFIG_PAGE = "about:config";
+
+// Driving BlockAboutConfig through its full lifecycle live
+add_task(async function test_block_about_config_live_lifecycle() {
+  info("Starting with no policies");
+  await EnterprisePolicyTesting.setupEngineWithRemotePolicies(
+    { policies: {} },
+    null
+  );
+  await EnterprisePolicyTesting.checkBlockedPage(ABOUT_CONFIG_PAGE, false);
+
+  info("Applying BlockAboutConfig: true");
+  await waitForLivePolicyUpdate({ BlockAboutConfig: true });
+  await EnterprisePolicyTesting.checkBlockedPage(ABOUT_CONFIG_PAGE, true);
+
+  info("Live-updating BlockAboutConfig to false");
+  await waitForLivePolicyUpdate({ BlockAboutConfig: false });
+  await EnterprisePolicyTesting.checkBlockedPage(ABOUT_CONFIG_PAGE, false);
+
+  info("Removing BlockAboutConfig");
+  await waitForLivePolicyUpdate({});
+  await EnterprisePolicyTesting.checkBlockedPage(ABOUT_CONFIG_PAGE, false);
+});

--- a/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_policy_BlockAboutSupport.js
+++ b/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_policy_BlockAboutSupport.js
@@ -1,0 +1,40 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+const ABOUT_SUPPORT_PAGE = "about:support";
+
+function checkAboutSupportState(blocked) {
+  Assert.equal(
+    Services.policies.isAllowed("aboutSupport"),
+    !blocked,
+    `aboutSupport feature is ${blocked ? "disallowed" : "allowed"}`
+  );
+}
+
+// Driving BlockAboutSupport through its full lifecycle live
+add_task(async function test_block_about_support_live_lifecycle() {
+  info("Starting with no policies");
+  await EnterprisePolicyTesting.setupEngineWithRemotePolicies(
+    { policies: {} },
+    null
+  );
+  await EnterprisePolicyTesting.checkBlockedPage(ABOUT_SUPPORT_PAGE, false);
+  checkAboutSupportState(false);
+
+  info("Applying BlockAboutSupport: true");
+  await waitForLivePolicyUpdate({ BlockAboutSupport: true });
+  await EnterprisePolicyTesting.checkBlockedPage(ABOUT_SUPPORT_PAGE, true);
+  checkAboutSupportState(true);
+
+  info("Live-updating BlockAboutSupport to false");
+  await waitForLivePolicyUpdate({ BlockAboutSupport: false });
+  await EnterprisePolicyTesting.checkBlockedPage(ABOUT_SUPPORT_PAGE, false);
+  checkAboutSupportState(false);
+
+  info("Removing BlockAboutSupport");
+  await waitForLivePolicyUpdate({});
+  await EnterprisePolicyTesting.checkBlockedPage(ABOUT_SUPPORT_PAGE, false);
+  checkAboutSupportState(false);
+});

--- a/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_policy_DisableDeveloperTools.js
+++ b/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_policy_DisableDeveloperTools.js
@@ -1,0 +1,81 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+// Covers what is specific to applying DisableDeveloperTools through the live
+// policy engine: the dedicated pref (value + lock), the "devtools" feature
+// gate, and the about: pages the policy blocks via the content policy.
+//
+// The pref-driven DevTools behavior is covered in:
+// - devtools/startup/tests/browser/browser_disable_devtools_live.js
+// - devtools/startup/tests/browser/browser_disable_devtools_live_browser_console.js
+// - devtools/startup/tests/browser/browser_disable_devtools_live_browser_toolbox.js
+
+const PREF_DEVTOOLS_DISABLED = "devtools.policy.disabled";
+
+// The about: pages that DisableDeveloperTools blocks via the content policy.
+const DEVTOOLS_ABOUT_PAGES = [
+  "about:debugging",
+  "about:devtools-toolbox",
+  "about:profiling",
+];
+
+async function checkDevToolsAboutPages(blocked) {
+  for (const page of DEVTOOLS_ABOUT_PAGES) {
+    await EnterprisePolicyTesting.checkBlockedPage(page, blocked);
+  }
+}
+
+function checkPref(locked, disabled) {
+  Assert.equal(
+    Services.prefs.prefIsLocked(PREF_DEVTOOLS_DISABLED),
+    locked,
+    `${PREF_DEVTOOLS_DISABLED} is ${locked ? "locked" : "unlocked"}`
+  );
+  Assert.strictEqual(
+    Services.prefs.getBoolPref(PREF_DEVTOOLS_DISABLED),
+    disabled,
+    `${PREF_DEVTOOLS_DISABLED} is ${disabled}`
+  );
+}
+
+function checkFeature(disabled) {
+  Assert.equal(
+    Services.policies.isAllowed("devtools"),
+    !disabled,
+    `devtools feature is ${disabled ? "disallowed" : "allowed"}`
+  );
+}
+
+// Drive DisableDeveloperTools through its full lifecycle live
+add_task(async function test_disable_developer_tools_live_lifecycle() {
+  info("No policy: DevTools are fully available");
+  await EnterprisePolicyTesting.setupEngineWithRemotePolicies(
+    { policies: {} },
+    null
+  );
+  checkPref(false, false);
+  checkFeature(false);
+  await checkDevToolsAboutPages(false);
+
+  info("Applying DisableDeveloperTools: true");
+  await waitForLivePolicyUpdate({ DisableDeveloperTools: true });
+  checkPref(true, true);
+  checkFeature(true);
+  await checkDevToolsAboutPages(true);
+
+  info("Live-updating DisableDeveloperTools to false (explicit allow)");
+  await waitForLivePolicyUpdate({ DisableDeveloperTools: false });
+  // Explicitly allowing keeps the pref locked, but to false.
+  checkPref(true, false);
+  checkFeature(false);
+  await checkDevToolsAboutPages(false);
+
+  info("Removing DisableDeveloperTools");
+  await waitForLivePolicyUpdate({});
+  // Removal unlocks the pref and leaves everything available.
+  checkPref(false, false);
+  checkFeature(false);
+  await checkDevToolsAboutPages(false);
+});


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2064655

- Adds test coverage for the live support of the policies `BlockAboutConfig` and `BlockAboutSupport`, `DisableDeveloperTools`

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Dependencies

- Bug-2028825; [9252d3e](https://github.com/mozilla/enterprise-firefox/pull/1302/commits/9252d3e96cf3994b8ed0a91b18dd2708e2eb4a17) needs to land in upstream first.

### Testing <!-- OPTIONAL -->

* [X] Added tests
* [ ] Manual testing performed

<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
