### PR TITLE
Bug 2064662 - Move from run-if to skip-if for manifest-browser.toml

### DIFF
--- a/testing/enterprise/manifest-browser.toml
+++ b/testing/enterprise/manifest-browser.toml
@@ -2,8 +2,8 @@
 
 subsuite = "enterprise"
 
-run-if = [
-  "buildapp == 'browser'",
+skip-if = [
+  "buildapp != 'browser'",
 ]
 
 ["test_browsing_child_encryption_mismatch.py"]


### PR DESCRIPTION
Bugzilla: Bug-2064662

`run-if` does not get merged, let's make sure we skip properly tests depending on the build app