### PR TITLE
Bug 2063728 - Drain launched browser's stdout and stderr

### DIFF
--- a/testing/enterprise/manifest.toml
+++ b/testing/enterprise/manifest.toml
@@ -8,6 +8,8 @@ run-if = [
   "buildapp == 'browser'",
 ]
 
+["test_felt_app_pipe.py"]
+
 ["test_felt_back_button.py"]
 
 ["test_felt_browser_about_config_blocked.py"]

--- a/testing/enterprise/test_felt_app_pipe.py
+++ b/testing/enterprise/test_felt_app_pipe.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import os
+import platform
+import sys
+
+sys.path.append(os.path.dirname(__file__))
+
+from felt_tests import FeltTests
+
+
+class FeltAppPipe(FeltTests):
+    def test_felt_app_pipe(self):
+        read_fd, write_fd = os.pipe()
+        read_bytes = self.get_pipe_capacity(read_fd)
+        write_bytes = self.get_pipe_capacity(write_fd)
+        print(f"Platform: {platform.system()}")
+        print(f"Read-end capacity:  {read_bytes}")
+        print(f"Write-end capacity: {write_bytes}")
+        os.close(read_fd)
+        os.close(write_fd)
+
+        self.run_felt_base()
+        self.connect_child_browser()
+        self.dump_kilobytes(sys.stdout.fileno(), 2 * write_bytes)
+        self.dump_kilobytes(sys.stderr.fileno(), 2 * write_bytes)
+
+    def get_pipe_capacity(self, fd):
+        """
+        Return the capacity (in bytes) of the pipe referred to by file
+        descriptor `fd`, as best as each platform allows it to be queried.
+
+        Returns None if the platform provides no way to determine it.
+        """
+        system = platform.system()
+
+        if system == "Linux":
+            return self._linux_pipe_capacity(fd)
+        elif system == "Darwin":
+            return self._macos_pipe_capacity()
+        elif system == "Windows":
+            return self._windows_pipe_capacity(fd)
+        else:
+            raise NotImplementedError(f"Unsupported platform: {system}")
+
+    def _linux_pipe_capacity(self, fd):
+        import fcntl
+
+        F_GETPIPE_SZ = 1032  # from <linux/fcntl.h>, stable since kernel 2.6.35
+        return fcntl.fcntl(fd, F_GETPIPE_SZ)
+
+    def _macos_pipe_capacity(self):
+        # No F_GETPIPE_SZ equivalent on macOS/BSD. PC_PIPE_BUF is the closest
+        # standard value the OS will report (usually 512), and it reflects the
+        # atomic-write limit, not the actual kernel buffer size (often larger,
+        # commonly 16 KiB on modern XNU, but that number isn't queryable).
+        # This 16 KiB limit gets pushed dynamically by the kernel according to
+        # various sources, usually to 64 KiB. Some mentions that "writing a lot
+        # at once" can increase even more. Stick to hard-coded 64 KiB.
+        return 65536
+
+    def _windows_pipe_capacity(self, fd):
+        import ctypes
+        import msvcrt
+        from ctypes import wintypes
+
+        handle = msvcrt.get_osfhandle(fd)
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+
+        flags = wintypes.DWORD()
+        out_buf_size = wintypes.DWORD()
+        in_buf_size = wintypes.DWORD()
+        max_instances = wintypes.DWORD()
+
+        ok = kernel32.GetNamedPipeInfo(
+            wintypes.HANDLE(handle),
+            ctypes.byref(flags),
+            ctypes.byref(out_buf_size),
+            ctypes.byref(in_buf_size),
+            ctypes.byref(max_instances),
+        )
+        if not ok:
+            raise ctypes.WinError(ctypes.get_last_error())
+
+        # For os.pipe() pipes, the read end reports in_buf_size and the write
+        # end reports out_buf_size; take whichever is nonzero/larger.
+        return max(out_buf_size.value, in_buf_size.value)
+
+    def dump_kilobytes(self, target_fd, target_bytes, line_size: int = 1024) -> int:
+        num_lines = max(1, target_bytes // line_size)
+
+        self._logger.info(f"Writing {target_bytes} bytes to stdout")
+        self._child_driver.set_context("chrome")
+        total_dumped = self._child_driver.execute_script(
+            """
+            const { ctypes } = ChromeUtils.importESModule("resource://gre/modules/ctypes.sys.mjs");
+
+            function writeToSomeStd(fd, str) {
+              const bytes = str;
+              if (Services.appinfo.OS === "WINNT") {
+                const kernel32 = ctypes.open("kernel32.dll");
+                const GetStdHandle = kernel32.declare(
+                  "GetStdHandle", ctypes.winapi_abi, ctypes.voidptr_t, ctypes.int32_t
+                );
+                const WriteFile = kernel32.declare(
+                  "WriteFile", ctypes.winapi_abi, ctypes.bool,
+                  ctypes.voidptr_t, ctypes.char.ptr, ctypes.uint32_t,
+                  ctypes.uint32_t.ptr, ctypes.voidptr_t
+                );
+                // From https://learn.microsoft.com/en-us/windows/console/getstdhandle
+                const STD_OUTPUT_HANDLE = -11;
+                const STD_ERROR_HANDLE = -12;
+                const handle = GetStdHandle(fd == 1 ? STD_OUTPUT_HANDLE : STD_ERROR_HANDLE);
+                const buf = ctypes.char.array()(bytes);
+                const written = ctypes.uint32_t(0);
+                WriteFile(handle, buf, bytes.length, written.address(), null);
+                kernel32.close();
+              } else {
+                const libName = Services.appinfo.OS === "Darwin" ? "libSystem.B.dylib" : "libc.so.6";
+                const lib = ctypes.open(libName);
+                const write = lib.declare(
+                  "write", ctypes.default_abi, ctypes.ssize_t,
+                  ctypes.int, ctypes.char.ptr, ctypes.size_t
+                );
+                const buf = ctypes.char.array()(bytes);
+                write(fd, buf, bytes.length);
+                lib.close();
+              }
+            }
+
+            const [target, lineSize, numLines] = arguments;
+            const payload = "x".repeat(Math.max(0, lineSize - 1)) + "\\n";
+            let total = 0;
+            for (let i = 0; i < numLines; i++) {
+                writeToSomeStd(target, payload);
+                total += payload.length;
+            }
+            return total;
+        """,
+            [target_fd, line_size, num_lines],
+        )
+        self._child_driver.set_context("content")
+
+        self._logger.info(
+            f"Could sucessfully write {total_dumped} bytes, requested {target_bytes} bytes."
+        )
+        assert total_dumped == target_bytes, (
+            f"Pipe write bytes: total_dumped={total_dumped} with target_bytes={target_bytes}"
+        )
+
+        return total_dumped

--- a/toolkit/components/felt/content/FeltProcessParent.sys.mjs
+++ b/toolkit/components/felt/content/FeltProcessParent.sys.mjs
@@ -35,6 +35,10 @@ ChromeUtils.defineLazyGetter(lazy, "log", () => {
   return lazy.createEnterpriseLogger("FeltProcessParent");
 });
 
+ChromeUtils.defineLazyGetter(lazy, "logProcess", () => {
+  return lazy.createEnterpriseLogger("FeltBrowser");
+});
+
 const PROCESS_START_REASON = {
   INITIAL_START: "initial-start",
   RESTART: "restart",
@@ -788,8 +792,7 @@ export class FeltProcessParent extends JSProcessActorParent {
     const firefoxRun = {
       command: firefoxBin,
       arguments: firefoxRunArgs,
-      stdout: "stdout",
-      stderr: "stderr",
+      stderr: "pipe",
       /* environmentAppend: true,
       environment: env, */
     };
@@ -802,7 +805,79 @@ export class FeltProcessParent extends JSProcessActorParent {
       throw e;
     }
 
+    this.onPipeDataAvailable(this.proc.stdout, this.proc.pid, (pid, chunk) => {
+      lazy.logProcess.info(`[${pid}]: ${chunk}`);
+    });
+
+    this.onPipeDataAvailable(this.proc.stderr, this.proc.pid, (pid, chunk) => {
+      lazy.logProcess.error(`[${pid}]: ${chunk}`);
+    });
+
     Services.felt.ipcChannel();
+  }
+
+  /**
+   * Drain a pipe when data is available. Not draining may result in pipe
+   * being blocked on the write side, blocking the browser.
+   *
+   * @callback dataCallback
+   *
+   * @param {object} pipe - The pipe to work on, from Subprocess.call() return value
+   * @param {int} pid - The PID pf the process which will be drained
+   * @param {dataCallback} callback - The callback handling what to do with the data
+   */
+  async onPipeDataAvailable(pipe, pid, callback) {
+    if (!pipe) {
+      return;
+    }
+
+    const decoder = new TextDecoder("utf-8");
+    let lineBuffer = "";
+
+    try {
+      while (true) {
+        let buffer = await pipe.read();
+        if (!buffer || buffer.byteLength === 0) {
+          break;
+        }
+
+        lineBuffer += decoder.decode(buffer, { stream: true });
+
+        // Split by lines so logProcess receives complete log messages
+        let lines = lineBuffer.split("\n");
+        // Keep the last incomplete line in the buffer
+        lineBuffer = lines.pop();
+
+        for (let line of lines) {
+          if (line.trim()) {
+            try {
+              callback(pid, line);
+            } catch (e) {
+              lazy.log.error(`Error while callback for pipe draining`, e);
+            }
+          }
+        }
+      }
+
+      // Flush remaining buffer & decoder tail when stream closes
+      lineBuffer += decoder.decode();
+      if (lineBuffer.trim()) {
+        try {
+          callback(pid, lineBuffer);
+        } catch (e) {
+          lazy.log.error(`Error while callback for pipe drain finalization`, e);
+        }
+      }
+    } catch (e) {
+      // Pipe explicitly closed or process killed
+    } finally {
+      // Force release underlying stream resources
+      try {
+        await pipe.close();
+      } catch (e) {
+        // Ignore if already closed
+      }
+    }
   }
 
   /**


### PR DESCRIPTION

<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2063728

The Subprocess module creates a pipe for stdout, in which the launched browser will write. If not drained, it may end up full and thus blocking the main thread of the launched browser on e.g. dump() call from JS.

Uplift of #1286 