### PR TITLE
Bug 2035186 - Clean up consumer VPN messages in Enterprise

### DIFF
--- a/browser/components/ipprotection/IPProtectionHelpers.sys.mjs
+++ b/browser/components/ipprotection/IPProtectionHelpers.sys.mjs
@@ -103,7 +103,9 @@ IPProtectionActivator.addHelpers([
   IPPUsageHelper,
   new UIHelper(),
   IPPOptOutHelper,
-  IPProtectionAlertManager,
+  // The alert manager's ERROR/PAUSED prompts are consumer VPN UX; in enterprise
+  // the proxy is policy-locked always-on and IPPAlwaysOn recovers from errors.
+  ...(AppConstants.MOZ_ENTERPRISE ? [] : [IPProtectionAlertManager]),
   IPProtectionInfobarManager,
   ...authProvider.helpers,
 ]);

--- a/browser/extensions/ipp-activator/extension/api/parent/ext-ipp.js
+++ b/browser/extensions/ipp-activator/extension/api/parent/ext-ipp.js
@@ -90,6 +90,9 @@ this.ippActivator = class extends ExtensionAPI {
         isIPPActive() {
           return lazy.IPPProxyManager.state === lazy.IPPProxyStates.ACTIVE;
         },
+        isEnterpriseAccessConnector() {
+          return !!Services.policies.getActivePolicies()?.AccessConnector;
+        },
         getRegion() {
           return lazy.Region.home;
         },

--- a/browser/extensions/ipp-activator/extension/api/schemas/ipp.json
+++ b/browser/extensions/ipp-activator/extension/api/schemas/ipp.json
@@ -61,6 +61,13 @@
         "parameters": []
       },
       {
+        "name": "isEnterpriseAccessConnector",
+        "type": "function",
+        "description": "Return whether the AccessConnector policy is active (enterprise always-on).",
+        "async": true,
+        "parameters": []
+      },
+      {
         "name": "getRegion",
         "type": "function",
         "description": "Return the user's home region as an ISO 3166-1 alpha-2 code (uppercase), or null if unknown.",

--- a/browser/extensions/ipp-activator/extension/bg.js
+++ b/browser/extensions/ipp-activator/extension/bg.js
@@ -31,15 +31,23 @@ class IPPAddonActivator {
     this.onRequest = this.#onRequest.bind(this);
     this.ippExceptionsChanged = this.#ippExceptionsChanged.bind(this);
 
-    this.#loadAndRebuildBreakages().then(() => {
-      browser.ippActivator.onDynamicTabBreakagesUpdated.addListener(() =>
-        this.#loadAndRebuildBreakages()
-      );
-      browser.ippActivator.onDynamicWebRequestBreakagesUpdated.addListener(() =>
-        this.#loadAndRebuildBreakages()
-      );
+    // Breakage bars are consumer VPN UX; under AccessConnector the proxy is
+    // policy-locked always-on, so the "turn VPN off" advice doesn't apply.
+    browser.ippActivator.isEnterpriseAccessConnector().then(isEnterprise => {
+      if (isEnterprise) {
+        return;
+      }
 
-      this.#init();
+      this.#loadAndRebuildBreakages().then(() => {
+        browser.ippActivator.onDynamicTabBreakagesUpdated.addListener(() =>
+          this.#loadAndRebuildBreakages()
+        );
+        browser.ippActivator.onDynamicWebRequestBreakagesUpdated.addListener(
+          () => this.#loadAndRebuildBreakages()
+        );
+
+        this.#init();
+      });
     });
   }
 


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2035186

Enterprise reuses the IP Protection plumbing via the AccessConnector policy but ships its own UI. Two pieces of consumer FxVPN messaging leaked into the Enterprise build and should not be shown.

- **IPProtection breakage bar** ("This website may not work with a VPN. Try turning VPN off...") on sites like youtube.com/reddit.com. 
  - `tab.json` is a curated list of sites known to break on Mozilla's shared VPN exit nodes (sign-in friction, geo-blocking) which are breakages specific to that shared consumer infrastructure. An Enterprise AccessConnector is the org's own server with a different traffic profile, so the list doesn't apply. 
  - ~The activator add-on is now pointed at a separate, empty `tab-enterprise.json` via the existing `extensions.ippactivator.tabBreakagesUrl` override, set from the AccessConnector policy.~ 
    - This did not work due to disallowed duplicate import of the empty json: https://treeherder.mozilla.org/jobs?repo=enterprise-firefox-pr&revision=4d621461e5d9181f9ca7780d8ce389f092dae42e&selectedTaskRun=ETHZxjlcTc-oTDL-D6AoVw.0
  - The add-on is gated by the AccessConnector policy. When the policy is set, the breakage bar is disabled. We can revert this in favor of an enterprise-maintained `tab.json` when we have valid breakages to populate an `enterprise-tab.json` 
- **The "VPN isn't working right now" / "VPN paused" modals** (`IPProtectionAlertManager`).
  - The paused state occurs when the user's data quota is hit. AccessConnector does not operate with a quota, so this is not relevant.
  - The error state is meant for auth token errors or connectivity errors. AccessConnector auth is obtained from FELT, which manages auth and signs out when the token is invalidated; and AccessConnector has its own handling for proxy connection issues (the `accessConnectorFailure` net-error page). Neither path warrants this consumer modal, whose "Continue without VPN" action would also defeat the policy-locked always-on connector.

---

### Testing

* [x] Added tests
* [x] Manual testing performed

**Steps to verify changes:**
1. Open a browser with an AccessConnector policy which includes `<all_urls>`.
2. Navigate to a website in the breakage [tab.json](https://searchfox.org/enterprise-main/source/browser/extensions/ipp-activator/extension/breakages/tab.json) (e.g. youtube.com)
3. Ensure AccessConnector is active

**Expected result:**

No breakage bar is displayed. Error modal should not be displayed after continuous use (not easy to reproduce). 