### PR TITLE
Bug 2065476 - Disable failing xpcshell tests

### DIFF
--- a/browser/components/enterprisepolicies/tests/xpcshell/xpcshell.toml
+++ b/browser/components/enterprisepolicies/tests/xpcshell/xpcshell.toml
@@ -57,12 +57,14 @@ run-if = [
 ]
 
 ["test_permissions.js"]
+skip-if = ["enterprise"] # Bug 2065476: skip tests for enterprise builds ; re-enable in bug 2065477
 
 ["test_policies_schema.js"]
 support-files = [
   "../../schemas/policies-schema.json",
   "../../schemas/policies-schema.meta.json",
 ]
+skip-if = ["enterprise"] # Bug 2065476: skip tests for enterprise builds ; re-enable in bug 2065477
 
 ["test_policy_descriptions.js"]
 
@@ -70,6 +72,7 @@ support-files = [
 
 ["test_popups_cookies_addons.js"]
 support-files = ["config_popups_cookies_addons.json"]
+skip-if = ["enterprise"] # Bug 2065476: skip tests for enterprise builds ; re-enable in bug 2065477
 
 ["test_preferences.js"]
 

--- a/browser/components/newtab/test/xpcshell/xpcshell.toml
+++ b/browser/components/newtab/test/xpcshell/xpcshell.toml
@@ -37,6 +37,7 @@ prefs = ["browser.newtabpage.disableNewTabAsAddon=true"]
 head = "../../../../extensions/newtab/test/xpcshell/head.js head_nimbus_trainhop.js"
 skip-if = [
   "os == 'linux' && os_version == '24.04' && arch == 'x86_64' && display == 'x11' && tsan", # Bug 1989373
+  "enterprise", # Bug 2065476: skip tests for enterprise builds ; re-enable in bug 2065477
 ]
 
 ["test_nimbus_newtabTrainhopAddon_firstStartup.js"]

--- a/dom/quota/test/xpcshell/upgrades/xpcshell.toml
+++ b/dom/quota/test/xpcshell/upgrades/xpcshell.toml
@@ -85,3 +85,4 @@ prefs = ["security.storage.encryption.sqlite.enabled=false"]
 ["test_upgradeStorageFrom2_2.js"]
 
 ["test_upgradeStorageFrom3to4.js"]
+skip-if = ["enterprise"] # Bug 2065476: skip tests for enterprise builds ; re-enable in bug 2065477

--- a/security/manager/ssl/tests/unit/xpcshell.toml
+++ b/security/manager/ssl/tests/unit/xpcshell.toml
@@ -160,6 +160,7 @@ run-if = [
 run-if = [
   "debug", # Requires hard-coded debug-only data
 ]
+skip-if = ["enterprise"] # Bug 2065476: skip tests for enterprise builds ; re-enable in bug 2065477
 
 ["test_ct.js"]
 run-if = [

--- a/taskcluster/gecko_taskgraph/target_tasks.py
+++ b/taskcluster/gecko_taskgraph/target_tasks.py
@@ -585,9 +585,7 @@ def target_tasks_enterprise_firefox_with_tests(
         if test_platform and "macos" in test_platform:
             if "enterprise" in test_platform:
                 # For enterprise builds, keep what is green at least
-                if "test" in task.kind and (
-                    "browser-chrome" in task.label or "xpcshell" in task.label
-                ):
+                if "test" in task.kind and ("browser-chrome" in task.label):
                     return False
             else:
                 # For non enterprise builds do not run macOS tests.

--- a/toolkit/components/backgroundtasks/tests/xpcshell/xpcshell.toml
+++ b/toolkit/components/backgroundtasks/tests/xpcshell/xpcshell.toml
@@ -64,6 +64,7 @@ skip-if = [
   "os == 'win' && os_version == '10.2009' && arch == 'x86_64'", # Bug 1937351
   "os == 'win' && os_version == '11.26100'", # Bug 1937351
   "os == 'win' && os_version == '11.26200'", # Bug 1937351
+  "enterprise", # Bug 2065476: skip tests for enterprise builds
 ]
 
 ["test_backgroundtask_simultaneous_instances.js"]


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2065476

Green try: https://treeherder.mozilla.org/jobs?repo=enterprise-firefox-try&revision=f3b81db4cba37887d715243e7b5bf990f067454f