### PR TITLE
Bug 2065840 - Capture the active theme in browser_theme_undo.js

### DIFF
--- a/toolkit/mozapps/extensions/test/browser/browser_theme_undo.js
+++ b/toolkit/mozapps/extensions/test/browser/browser_theme_undo.js
@@ -9,10 +9,6 @@ const { AppMenuNotifications } = ChromeUtils.importESModule(
   "resource://gre/modules/AppMenuNotifications.sys.mjs"
 );
 
-const { AddonSettings } = ChromeUtils.importESModule(
-  "resource://gre/modules/addons/AddonSettings.sys.mjs"
-);
-
 function promisePostInstallNotificationShown() {
   // The themes are unsigned, so we need to confirm we're okay with that first
   // This is why we need to accept a prompt, and then continue to the prompt
@@ -91,6 +87,12 @@ async function promisePostInstallShown() {
 // Test that clicking the undo button on the post install notification reverts
 // the theme
 add_task(async function test_undoTheme() {
+  // Capture the theme active at the start of the test
+  // as the browser's default theme.
+  const INITIAL_THEME_ID = Services.prefs.getCharPref(
+    "extensions.activeThemeID"
+  );
+
   const RED_THEME_ID = "red@test.mozilla.org";
   let redTheme = await AddonTestUtils.createTempWebExtensionFile({
     manifest: {
@@ -149,8 +151,8 @@ add_task(async function test_undoTheme() {
   );
   Assert.strictEqual(
     (await AddonManager.getAddonByID(RED_THEME_ID)).previousActiveThemeID,
-    AddonSettings.DEFAULT_THEME_ID,
-    "Expected previous active theme ID to be the default theme"
+    INITIAL_THEME_ID,
+    "Expected previous active theme ID to be the initial (default) theme"
   );
 
   // After first theme is installed, trigger a second install but "undo" it


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2065840

- Captures the active theme instead of testing with upstream's default theme in `test_undoTheme`.

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Testing <!-- OPTIONAL -->

* [X] Added tests (restored)
* [ ] Manual testing performed

<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
