### PR TITLE
Bug 2065842 - Expect enterprise actions before the share button

### DIFF
--- a/toolkit/components/enterprise/tests/browser/browser_lockdown_mode_page_action.js
+++ b/toolkit/components/enterprise/tests/browser/browser_lockdown_mode_page_action.js
@@ -165,8 +165,8 @@ add_task(async function test_button_position() {
     );
     Assert.equal(
       enterpriseActions.nextElementSibling?.id,
-      "pageActionButton",
-      "Enterprise urlbar actions container should be positioned just before the page action button"
+      "share-button",
+      "Enterprise urlbar actions container should be positioned just before the share button"
     );
   });
 });


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2065842

- Updates the expected next sibling of `#enterprise-urlbar-actions` after Bug-2052258 added a share-button between and `#pageActionButton` and `#enterprise-urlbar-actions`.
