### PR TITLE
Bug 2065851 - Fix stale CrashSubmit.sys.mjs import 

### DIFF
--- a/browser/base/content/test/tabcrashed/browser_policyDisabled.js
+++ b/browser/base/content/test/tabcrashed/browser_policyDisabled.js
@@ -38,7 +38,7 @@ add_task(async function test_policyDisabled_hides_report_ui() {
 
   let submitCalls = 0;
   let { CrashSubmit } = ChromeUtils.importESModule(
-    "resource://gre/modules/CrashSubmit.sys.mjs"
+    "moz-src:///toolkit/crashreporter/CrashSubmit.sys.mjs"
   );
   let originalSubmit = CrashSubmit.submit;
   CrashSubmit.submit = function () {


### PR DESCRIPTION


<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2065851

Updates the stale `CrashSubmit.sys.mjs` import after it was migrated to `moz-src` in Bug-2052740.

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Testing <!-- OPTIONAL -->

* [X] Added tests (restored)
* [ ] Manual testing performed

<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
