### PR TITLE
Bug 2046462 -  Add x-restart-required flag for enterprise-only policies

### DIFF
--- a/browser/components/enterprisepolicies/schemas/policies-schema.json
+++ b/browser/components/enterprisepolicies/schemas/policies-schema.json
@@ -67,6 +67,7 @@
         "firefox_esr": { "version_added": false },
         "firefox_enterprise": { "version_added": "149" }
       },
+      "x-restart-required": false,
       "description": "Configures an Access Connector for proxying web traffic. Traffic is routed through the server by 'Host' and 'Port'. If 'MatchPatterns' is set, only URLs matching those patterns are routed through the connector.",
       "examples": [
         {
@@ -108,6 +109,7 @@
         "firefox_esr": { "version_added": false },
         "firefox_enterprise": { "version_added": "149" }
       },
+      "x-restart-required": true,
       "description": "Controls access to AI chat services. Built-in providers can be enabled individually. For custom providers, add them to the 'Add' array. The 'Default' field specifies which provider is used by default.",
       "examples": [
         {
@@ -681,6 +683,7 @@
         "firefox_esr": { "version_added": false },
         "firefox_enterprise": { "version_added": "149" }
       },
+      "x-restart-required": false,
       "description": "Enable and configure security logging when Firefox blocks a visit to a blocklisted domain.",
       "examples": [
         {
@@ -1057,6 +1060,7 @@
         "firefox_esr": { "version_added": false },
         "firefox_enterprise": { "version_added": "155" }
       },
+      "x-restart-required": false,
       "description": "Enable and configure security logging when a DLP rule is triggered.",
       "examples": [
         {
@@ -1231,6 +1235,7 @@
         "firefox_esr": { "version_added": false },
         "firefox_enterprise": { "version_added": "154" }
       },
+      "x-restart-required": false,
       "description": "Configure crash report submission settings.",
       "examples": [
         {
@@ -1255,6 +1260,7 @@
         "firefox_esr": { "version_added": false },
         "firefox_enterprise": { "version_added": "155" }
       },
+      "x-restart-required": false,
       "description": "Configure built-in Data Loss Prevention rules that warn on or block data actions (paste, copy, upload, download, print) per domain.",
       "examples": [
         {
@@ -1636,6 +1642,7 @@
         "firefox_esr": { "version_added": false },
         "firefox_enterprise": { "version_added": "155" }
       },
+      "x-restart-required": true,
       "description": "Disable all local policy sources (policies.json, Windows GPO and macOS plist).",
       "examples": [true, false]
     },
@@ -1982,6 +1989,7 @@
         "firefox_esr": { "version_added": false },
         "firefox_enterprise": { "version_added": "149" }
       },
+      "x-restart-required": false,
       "description": "Enable and configure security logging when a download is triggered. 'UrlLogging' and 'FileLogging' control how much detail about the download source and the file is included in the log.",
       "examples": [
         {
@@ -2118,6 +2126,7 @@
         "firefox_esr": { "version_added": false },
         "firefox_enterprise": { "version_added": "149" }
       },
+      "x-restart-required": true,
       "description": "Enable an enterprise-managed primary password so that stored credentials and other sensitive profile data are kept encrypted at rest.",
       "examples": [true]
     },
@@ -3603,6 +3612,7 @@
         "firefox_esr": { "version_added": false },
         "firefox_enterprise": { "version_added": "149" }
       },
+      "x-restart-required": false,
       "description": "Enable and configure security logging when a page is printed. 'UrlLogging' controls how much detail about the printed page's address is included in the log.",
       "examples": [
         {
@@ -4279,6 +4289,7 @@
         "firefox_esr": { "version_added": false },
         "firefox_enterprise": { "version_added": "150" }
       },
+      "x-restart-required": false,
       "description": "Enable or disable sync and define which data to include.",
       "examples": [
         {
@@ -4427,6 +4438,7 @@
         "firefox_esr": { "version_added": false },
         "firefox_enterprise": { "version_added": "154" }
       },
+      "x-restart-required": false,
       "description": "Display a tiled, diagonal watermark over a list of websites.",
       "examples": [
         {

--- a/browser/components/enterprisepolicies/tests/xpcshell/xpcshell.toml
+++ b/browser/components/enterprisepolicies/tests/xpcshell/xpcshell.toml
@@ -64,7 +64,6 @@ support-files = [
   "../../schemas/policies-schema.json",
   "../../schemas/policies-schema.meta.json",
 ]
-skip-if = ["enterprise"] # Bug 2065476: skip tests for enterprise builds ; re-enable in bug 2065477
 
 ["test_policy_descriptions.js"]
 

--- a/toolkit/components/enterprisepolicies/EnterprisePoliciesParent.sys.mjs
+++ b/toolkit/components/enterprisepolicies/EnterprisePoliciesParent.sys.mjs
@@ -149,9 +149,15 @@ EnterprisePoliciesManager.prototype = {
   // Caches latest set of parsed policies
   _parsedPolicies: {},
 
-  // Per-policy hash of the raw parameters last applied,
-  // used to skip re-parsing individual unchanged policies on an update.
-  _lastParamsHashes: new Map(),
+  // Per-policy hash of the raw parameters seen on the last update. Used to skip
+  // re-parsing and re-validating a policy whose parameters are unchanged since last poll.
+  _seenParamHashes: new Map(),
+
+  // Per-policy hash of the raw parameters currently in effect. Differs from
+  // _seenParamHashes when the latest parameters were ignored (startup policy)
+  // or rejected (invalid); used to avoid tearing down and re-applying a policy
+  // when its parameters revert to what is already applied.
+  _appliedParamHashes: new Map(),
 
   _cleanupPolicies() {
     if (Services.prefs.getBoolPref(PREF_POLICIES_APPLIED, false)) {
@@ -343,8 +349,10 @@ EnterprisePoliciesManager.prototype = {
       }
 
       lazy.log.debug(`Parsed startup policy ${policyName}.`);
+      const paramsHash = hashValue(policyParams);
       this._parsedPolicies[policyName] = parsedParams;
-      this._lastParamsHashes.set(policyName, hashValue(policyParams));
+      this._seenParamHashes.set(policyName, paramsHash);
+      this._appliedParamHashes.set(policyName, paramsHash);
 
       const policyImpl = lazy.Policies[policyName];
       this._schedulePolicyActivations(policyName, policyImpl, parsedParams);
@@ -389,9 +397,16 @@ EnterprisePoliciesManager.prototype = {
       }
     }
 
+    const previousSeenParamHashes = this._seenParamHashes;
+    const previousAppliedParamHashes = this._appliedParamHashes;
+
     this._schedulePolicyUpdates(previousPolicies);
 
-    this._schedulePolicyRemovals(previousPolicies);
+    this._schedulePolicyRemovals(
+      previousPolicies,
+      previousSeenParamHashes,
+      previousAppliedParamHashes
+    );
 
     // Run removals first so that an updated policy is torn down (with its
     // previous parameters) before it is re-applied with the new ones.
@@ -422,34 +437,24 @@ EnterprisePoliciesManager.prototype = {
    */
   _schedulePolicyUpdates(previousPolicies) {
     const parsedPolicies = {};
-    const paramsHashes = new Map();
+    const seenHashes = new Map();
+    const appliedHashes = new Map();
 
     for (const [policyName, policyParams] of Object.entries(
       this._effectivePolicies()
     )) {
       const paramsHash = hashValue(policyParams);
+      seenHashes.set(policyName, paramsHash);
 
-      if (this._isStartupPolicy(policyName)) {
-        // This policy cannot be updated as it needs to be applied during a startup.
-        lazy.log.warn(
-          `Policy ${policyName} requires a restart; the change will not be applied before the next restart.`
-        );
-        paramsHashes.set(policyName, paramsHash);
+      if (this._seenParamHashes.get(policyName) === paramsHash) {
+        lazy.log.debug(`Policy ${policyName} unchanged.`);
         if (policyName in previousPolicies) {
           parsedPolicies[policyName] = previousPolicies[policyName];
+          appliedHashes.set(
+            policyName,
+            this._appliedParamHashes.get(policyName)
+          );
         }
-        continue;
-      }
-
-      if (
-        this._lastParamsHashes.get(policyName) === paramsHash &&
-        policyName in previousPolicies
-      ) {
-        // Skip re-parsing a policy whose raw parameters are unchanged.
-        // Instead reuse the previously parsed value and leave it applied.
-        lazy.log.debug(`Policy ${policyName} unchanged.`);
-        parsedPolicies[policyName] = previousPolicies[policyName];
-        paramsHashes.set(policyName, paramsHash);
         continue;
       }
 
@@ -463,16 +468,43 @@ EnterprisePoliciesManager.prototype = {
       if (!isValid) {
         lazy.log.debug(`Updated policy params for ${policyName} are invalid.`);
         if (policyName in previousPolicies) {
-          // The updated policy params are invalid. Keep the previously applied policy version.
+          // Keep the previously applied policy version in effect.
           parsedPolicies[policyName] = previousPolicies[policyName];
-          paramsHashes.set(policyName, this._lastParamsHashes.get(policyName));
+          appliedHashes.set(
+            policyName,
+            this._appliedParamHashes.get(policyName)
+          );
           lazy.log.debug(`Skipping policy update for ${policyName}.`);
         }
         continue;
       }
 
+      if (this._isStartupPolicy(policyName)) {
+        // This policy cannot be updated as it needs to be applied during a startup.
+        lazy.log.warn(
+          `Policy ${policyName} requires a restart; the change will not be applied before the next restart.`
+        );
+        if (policyName in previousPolicies) {
+          parsedPolicies[policyName] = previousPolicies[policyName];
+          appliedHashes.set(
+            policyName,
+            this._appliedParamHashes.get(policyName)
+          );
+        }
+        continue;
+      }
+
+      if (this._appliedParamHashes.get(policyName) === paramsHash) {
+        // The parameters reverted to what is already applied (e.g. after an
+        // ignored or rejected update). Leave the policy in place rather than
+        // tearing it down and re-applying the same value.
+        parsedPolicies[policyName] = previousPolicies[policyName];
+        appliedHashes.set(policyName, paramsHash);
+        continue;
+      }
+
       parsedPolicies[policyName] = parsedParams;
-      paramsHashes.set(policyName, paramsHash);
+      appliedHashes.set(policyName, paramsHash);
 
       if (policyName in previousPolicies) {
         // Parameters changed: remove the policy (with its previous
@@ -485,7 +517,8 @@ EnterprisePoliciesManager.prototype = {
     }
 
     this._parsedPolicies = parsedPolicies;
-    this._lastParamsHashes = paramsHashes;
+    this._seenParamHashes = seenHashes;
+    this._appliedParamHashes = appliedHashes;
   },
 
   /**
@@ -494,8 +527,16 @@ EnterprisePoliciesManager.prototype = {
    *
    * @param {object} previousPolicies the set of policies parsed and applied
    *   before this update
+   * @param {Map} previousSeenParamHashes seen-parameter hashes from before this
+   *   update
+   * @param {Map} previousAppliedParamHashes applied-parameter hashes from before this
+   *   update
    */
-  _schedulePolicyRemovals(previousPolicies) {
+  _schedulePolicyRemovals(
+    previousPolicies,
+    previousSeenParamHashes,
+    previousAppliedParamHashes
+  ) {
     for (const [policyName, policyParams] of Object.entries(previousPolicies)) {
       if (this._parsedPolicies[policyName] !== undefined) {
         // Policy remains active.
@@ -510,7 +551,14 @@ EnterprisePoliciesManager.prototype = {
           `Policy ${policyName} requires a restart; its removal will not take effect before the next restart.`
         );
         this._parsedPolicies[policyName] = policyParams;
-        this._lastParamsHashes.set(policyName, hashValue(policyParams));
+        this._seenParamHashes.set(
+          policyName,
+          previousSeenParamHashes.get(policyName)
+        );
+        this._appliedParamHashes.set(
+          policyName,
+          previousAppliedParamHashes.get(policyName)
+        );
         continue;
       }
 
@@ -739,7 +787,8 @@ EnterprisePoliciesManager.prototype = {
 
     this.status = Ci.nsIEnterprisePolicies.UNINITIALIZED;
     this._parsedPolicies = {};
-    this._lastParamsHashes = new Map();
+    this._seenParamHashes = new Map();
+    this._appliedParamHashes = new Map();
     if (this._isRemotePoliciesSupported()) {
       RemotePoliciesProvider.dropInstance();
     }

--- a/toolkit/components/enterprisepolicies/EnterprisePoliciesParent.sys.mjs
+++ b/toolkit/components/enterprisepolicies/EnterprisePoliciesParent.sys.mjs
@@ -429,6 +429,18 @@ EnterprisePoliciesManager.prototype = {
     )) {
       const paramsHash = hashValue(policyParams);
 
+      if (this._isStartupPolicy(policyName)) {
+        // This policy cannot be updated as it needs to be applied during a startup.
+        lazy.log.warn(
+          `Policy ${policyName} requires a restart; the change will not be applied before the next restart.`
+        );
+        paramsHashes.set(policyName, paramsHash);
+        if (policyName in previousPolicies) {
+          parsedPolicies[policyName] = previousPolicies[policyName];
+        }
+        continue;
+      }
+
       if (
         this._lastParamsHashes.get(policyName) === paramsHash &&
         policyName in previousPolicies
@@ -487,6 +499,18 @@ EnterprisePoliciesManager.prototype = {
     for (const [policyName, policyParams] of Object.entries(previousPolicies)) {
       if (this._parsedPolicies[policyName] !== undefined) {
         // Policy remains active.
+        continue;
+      }
+
+      if (this._isStartupPolicy(policyName)) {
+        // A startup policy cannot be removed live any more than it can be
+        // applied live. Keep it applied until the next restart, which will
+        // re-read the policy set without it.
+        lazy.log.warn(
+          `Policy ${policyName} requires a restart; its removal will not take effect before the next restart.`
+        );
+        this._parsedPolicies[policyName] = policyParams;
+        this._lastParamsHashes.set(policyName, hashValue(policyParams));
         continue;
       }
 
@@ -573,6 +597,24 @@ EnterprisePoliciesManager.prototype = {
     }
 
     return { isValid, parsedParams };
+  },
+
+  /**
+   * Whether a policy can only take effect after a browser restart, as
+   * declared by "x-restart-required" in policies-schema.json. Such policies
+   * are applied at startup only: they are neither updated nor removed live.
+   *
+   * @param {string} policyName policy name
+   * @returns {boolean} whether policy requires a restart to be applied
+   */
+  _isStartupPolicy(policyName) {
+    const { schema } = ChromeUtils.importESModule(
+      // eslint-disable-next-line mozilla/no-browser-refs-in-toolkit
+      "resource:///modules/policies/schema.sys.mjs"
+    );
+    const requiresRestart =
+      schema.properties[policyName]?.["x-restart-required"];
+    return requiresRestart ?? true;
   },
 
   /**

--- a/toolkit/components/enterprisepolicies/EnterprisePoliciesParent.sys.mjs
+++ b/toolkit/components/enterprisepolicies/EnterprisePoliciesParent.sys.mjs
@@ -73,6 +73,13 @@ ChromeUtils.defineLazyGetter(lazy, "log", () => {
   });
 });
 
+ChromeUtils.defineLazyGetter(lazy, "schemaModule", () =>
+  ChromeUtils.importESModule(
+    // eslint-disable-next-line mozilla/no-browser-refs-in-toolkit
+    "resource:///modules/policies/schema.sys.mjs"
+  )
+);
+
 // Testing escapes in this file must key on Cu.isInAutomation.
 
 // On Nightly in automation, ignore real system/user policies so a developer's
@@ -603,11 +610,7 @@ EnterprisePoliciesManager.prototype = {
    * @returns {{ isValid: boolean, parsedParams: object|null}}
    */
   _validateAndParsePolicyParams(policyName, policyParams) {
-    const { schema } = ChromeUtils.importESModule(
-      // eslint-disable-next-line mozilla/no-browser-refs-in-toolkit
-      "resource:///modules/policies/schema.sys.mjs"
-    );
-    const policySchema = schema.properties[policyName];
+    const policySchema = lazy.schemaModule.schema.properties[policyName];
 
     if (!policySchema) {
       lazy.log.error(`Unknown policy: ${policyName}`);
@@ -656,12 +659,8 @@ EnterprisePoliciesManager.prototype = {
    * @returns {boolean} whether policy requires a restart to be applied
    */
   _isStartupPolicy(policyName) {
-    const { schema } = ChromeUtils.importESModule(
-      // eslint-disable-next-line mozilla/no-browser-refs-in-toolkit
-      "resource:///modules/policies/schema.sys.mjs"
-    );
     const requiresRestart =
-      schema.properties[policyName]?.["x-restart-required"];
+      lazy.schemaModule.schema.properties[policyName]["x-restart-required"];
     return requiresRestart ?? true;
   },
 

--- a/toolkit/components/enterprisepolicies/tests/browser/live/browser.toml
+++ b/toolkit/components/enterprisepolicies/tests/browser/live/browser.toml
@@ -32,3 +32,5 @@ run-if = [
 ["browser_live_policy_Sync.js"]
 
 ["browser_live_policy_WebsiteFilter.js"]
+
+["browser_live_startup_policies.js"]

--- a/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_and_local_policies_merging.js
+++ b/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_and_local_policies_merging.js
@@ -81,9 +81,7 @@ add_task(async function test_remote_policy_overrides_local_policy() {
     },
   };
 
-  const updateApplied = EnterprisePolicyTesting.awaitNextPolicyUpdate();
-  EnterprisePolicyTesting.stubRemotePolicies(remotePolicies);
-  await updateApplied;
+  await waitForLivePolicyUpdate(remotePolicies.policies);
 
   Assert.deepEqual(
     Services.policies.getActivePolicies(),
@@ -97,9 +95,7 @@ add_task(async function test_remote_policy_overrides_local_policy() {
   );
 
   // Remove remote policies, re-apply local policy
-  const removalApplied = EnterprisePolicyTesting.awaitNextPolicyUpdate();
-  EnterprisePolicyTesting.stubRemotePolicies({ policies: {} });
-  await removalApplied;
+  await waitForLivePolicyUpdate({});
 
   Assert.deepEqual(
     Services.policies.getActivePolicies(),

--- a/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_and_local_policies_merging.js
+++ b/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_and_local_policies_merging.js
@@ -7,10 +7,12 @@ const customSchema = {
   properties: {
     simple_policy0: {
       type: "string",
+      "x-restart-required": false,
     },
 
     simple_policy1: {
       type: "string",
+      "x-restart-required": false,
     },
   },
 };

--- a/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_content_analysis_activation.js
+++ b/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_content_analysis_activation.js
@@ -30,12 +30,6 @@ const ca = Cc["@mozilla.org/contentanalysis;1"].getService(
   Ci.nsIContentAnalysis
 );
 
-async function applyLivePolicies(policies) {
-  const updateApplied = EnterprisePolicyTesting.awaitNextPolicyUpdate();
-  EnterprisePolicyTesting.stubRemotePolicies({ policies });
-  await updateApplied;
-}
-
 async function startFrom(policies) {
   await EnterprisePolicyTesting.setupEngineWithRemotePolicies({ policies });
   const updateApplied = EnterprisePolicyTesting.awaitNextPolicyUpdate();
@@ -63,7 +57,7 @@ add_task(async function test_indicator_appears_in_existing_windows() {
     "no indicator in the second window while inactive"
   );
 
-  await applyLivePolicies({
+  await waitForLivePolicyUpdate({
     DataLossPrevention: { FallbackResult: "block", Rules: [PASTE_RULE] },
   });
 
@@ -78,7 +72,7 @@ add_task(async function test_indicator_appears_in_existing_windows() {
   );
 
   // Deactivation must clear it again in every window.
-  await applyLivePolicies({});
+  await waitForLivePolicyUpdate({});
 
   Assert.ok(!ca.isActive, "Content Analysis inactive again");
   Assert.ok(
@@ -107,7 +101,7 @@ add_task(async function test_indicator_shown_in_a_window_opened_while_active() {
   );
 
   await BrowserTestUtils.closeWindow(newWindow);
-  await applyLivePolicies({});
+  await waitForLivePolicyUpdate({});
 });
 
 // MightBeActive is the content-process gate for CA-aware clipboard reads. It
@@ -130,7 +124,7 @@ add_task(async function test_might_be_active_live_in_content_process() {
         "mightBeActive is false in the content process while inactive"
       );
 
-      await applyLivePolicies({
+      await waitForLivePolicyUpdate({
         DataLossPrevention: { FallbackResult: "block", Rules: [PASTE_RULE] },
       });
 
@@ -148,7 +142,7 @@ add_task(async function test_might_be_active_live_in_content_process() {
         "mightBeActive turned true in the already-running content process"
       );
 
-      await applyLivePolicies({});
+      await waitForLivePolicyUpdate({});
 
       Assert.ok(
         !(await SpecialPowers.spawn(browser, [], () => {

--- a/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_content_analysis_dlp.js
+++ b/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_content_analysis_dlp.js
@@ -71,15 +71,6 @@ function assertInterceptionPoints(expectedOn, message) {
   }
 }
 
-// Serve a new remote policy set and wait for the update to be applied. This is
-// the live path: the poller notices the changed set, the engine diffs it, and
-// EnterprisePolicies:PolicyUpdatesApplied lands after the prefs have settled.
-async function applyLivePolicies(policies) {
-  const updateApplied = EnterprisePolicyTesting.awaitNextPolicyUpdate();
-  EnterprisePolicyTesting.stubRemotePolicies({ policies });
-  await updateApplied;
-}
-
 // Establish a starting policy set, then drive one no-op update through so the
 // C++ backend is in sync with the prefs before the transition under test. An
 // engine restart re-runs the JS handlers but does not fire
@@ -102,7 +93,7 @@ add_task(async function test_live_activation_selects_builtin_backend() {
   );
   Assert.ok(!ca.isActive, "Content Analysis inactive with no policy");
 
-  await applyLivePolicies({
+  await waitForLivePolicyUpdate({
     DataLossPrevention: { FallbackResult: "block", Rules: [PASTE_RULE] },
   });
 
@@ -138,7 +129,7 @@ add_task(async function test_live_rules_edit_does_not_rebuild_backend() {
 
   // Same provider, different rules: the backend reads dlp_rules and the
   // interception-point prefs live, so this must not rebuild it.
-  await applyLivePolicies({
+  await waitForLivePolicyUpdate({
     DataLossPrevention: {
       FallbackResult: "warn",
       Rules: [PASTE_RULE, UPLOAD_RULE],
@@ -182,7 +173,7 @@ add_task(async function test_live_adding_external_suppresses_builtin() {
   Assert.equal(backendKind(), "wasm-module", "starting on the WASM backend");
   const generationBefore = backendGeneration();
 
-  await applyLivePolicies({
+  await waitForLivePolicyUpdate({
     ContentAnalysis: { Enabled: true },
     DataLossPrevention: { FallbackResult: "block", Rules: [PASTE_RULE] },
   });
@@ -225,7 +216,7 @@ add_task(async function test_live_removing_external_reactivates_builtin() {
   );
   const generationBefore = backendGeneration();
 
-  await applyLivePolicies({
+  await waitForLivePolicyUpdate({
     DataLossPrevention: { FallbackResult: "block", Rules: [UPLOAD_RULE] },
   });
 
@@ -271,7 +262,7 @@ add_task(async function test_live_external_enabled_flip_swaps_backend() {
   );
   let generation = backendGeneration();
 
-  await applyLivePolicies({
+  await waitForLivePolicyUpdate({
     ContentAnalysis: { Enabled: true },
     DataLossPrevention: { FallbackResult: "block", Rules: [PASTE_RULE] },
   });
@@ -284,7 +275,7 @@ add_task(async function test_live_external_enabled_flip_swaps_backend() {
   Assert.greater(backendGeneration(), generation, "enabling rebuilt");
   generation = backendGeneration();
 
-  await applyLivePolicies({
+  await waitForLivePolicyUpdate({
     ContentAnalysis: { Enabled: false },
     DataLossPrevention: { FallbackResult: "block", Rules: [PASTE_RULE] },
   });
@@ -317,7 +308,7 @@ add_task(async function test_live_external_connection_change_rebuilds() {
   );
   let generation = backendGeneration();
 
-  await applyLivePolicies({
+  await waitForLivePolicyUpdate({
     ContentAnalysis: { Enabled: true, PipePathName: "live_dlp_pipe_b" },
   });
 
@@ -339,7 +330,7 @@ add_task(async function test_live_external_connection_change_rebuilds() {
   generation = backendGeneration();
 
   // An update that touches nothing the connection depends on must not churn it.
-  await applyLivePolicies({
+  await waitForLivePolicyUpdate({
     ContentAnalysis: {
       Enabled: true,
       PipePathName: "live_dlp_pipe_b",
@@ -387,7 +378,7 @@ add_task(async function test_builtin_does_not_inherit_external_url_filters() {
     "the external agent's allow list is in effect to begin with"
   );
 
-  await applyLivePolicies({
+  await waitForLivePolicyUpdate({
     DataLossPrevention: { FallbackResult: "block", Rules: [PASTE_RULE] },
   });
 
@@ -414,7 +405,7 @@ add_task(async function test_live_deactivation_tears_down_backend() {
   Assert.equal(backendKind(), "wasm-module", "starting on the WASM backend");
   Assert.ok(ca.isActive, "Content Analysis active before deactivation");
 
-  await applyLivePolicies({});
+  await waitForLivePolicyUpdate({});
 
   Assert.ok(!ca.isActive, "Content Analysis inactive after removing DLP");
   Assert.equal(

--- a/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_disable_local_policies.js
+++ b/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_disable_local_policies.js
@@ -7,14 +7,17 @@ const customSchema = {
   properties: {
     DisableLocalPolicies: {
       type: "boolean",
+      "x-restart-required": false,
     },
 
     simple_policy0: {
       type: "string",
+      "x-restart-required": false,
     },
 
     simple_policy1: {
       type: "string",
+      "x-restart-required": false,
     },
   },
 };

--- a/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_policies_basic_tests.js
+++ b/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_policies_basic_tests.js
@@ -63,18 +63,22 @@ add_task(async function test_simple_remote_policies() {
       properties: {
         simple_policy0: {
           type: "boolean",
+          "x-restart-required": false,
         },
 
         simple_policy1: {
           type: "boolean",
+          "x-restart-required": false,
         },
 
         simple_policy2: {
           type: "boolean",
+          "x-restart-required": false,
         },
 
         simple_policy3: {
           type: "boolean",
+          "x-restart-required": false,
         },
       },
     }

--- a/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_policies_diffing.js
+++ b/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_policies_diffing.js
@@ -7,6 +7,7 @@ const customSchema = {
   properties: {
     TestPolicy: {
       type: "string",
+      "x-restart-required": false,
     },
   },
 };

--- a/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_policy_Cookies.js
+++ b/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_policy_Cookies.js
@@ -43,12 +43,6 @@ function checkBehaviorPref(prefName, expectedValue, expectedLocked) {
   );
 }
 
-async function updatePolicies(policies) {
-  const updateApplied = EnterprisePolicyTesting.awaitNextPolicyUpdate();
-  EnterprisePolicyTesting.stubRemotePolicies(policies);
-  await updateApplied;
-}
-
 // Applying a Cookies policy, updating it live and removing it live should be
 // reflected in the cookieBehavior prefs' values and lock status
 add_task(async function test_cookie_behavior_apply_update_remove() {
@@ -77,12 +71,10 @@ add_task(async function test_cookie_behavior_apply_update_remove() {
   );
 
   info("Updating Cookies policy to unlocked accept behavior.");
-  await updatePolicies({
-    policies: {
-      Cookies: {
-        Behavior: "accept",
-        BehaviorPrivateBrowsing: "accept",
-      },
+  await waitForLivePolicyUpdate({
+    Cookies: {
+      Behavior: "accept",
+      BehaviorPrivateBrowsing: "accept",
     },
   });
 
@@ -94,7 +86,7 @@ add_task(async function test_cookie_behavior_apply_update_remove() {
   );
 
   info("Removing the Cookies policy.");
-  await updatePolicies({ policies: {} });
+  await waitForLivePolicyUpdate({});
 
   checkBehaviorPref(BEHAVIOR_PREF, initialBehavior, false);
   checkBehaviorPref(BEHAVIOR_PB_PREF, initialBehaviorPB, false);
@@ -142,7 +134,7 @@ add_task(async function test_cookie_permissions_removed_on_remove() {
   );
 
   info("Removing the Cookies policy.");
-  await updatePolicies({ policies: {} });
+  await waitForLivePolicyUpdate({});
 
   Assert.equal(
     getCurrentCookiePermission(allowOrigin),
@@ -196,11 +188,9 @@ add_task(async function test_cookie_permissions_reconciled_on_update() {
   );
 
   info("Updating Cookies policy config to allow only the first origin.");
-  await updatePolicies({
-    policies: {
-      Cookies: {
-        Allow: [keptOrigin],
-      },
+  await waitForLivePolicyUpdate({
+    Cookies: {
+      Allow: [keptOrigin],
     },
   });
 
@@ -249,7 +239,7 @@ add_task(
     );
 
     info("Removing the Cookies policy.");
-    await updatePolicies({ policies: {} });
+    await waitForLivePolicyUpdate({});
 
     Assert.equal(
       getPersistDataPermission(allowOrigin),

--- a/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_policy_ExtensionSettings.js
+++ b/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_policy_ExtensionSettings.js
@@ -21,12 +21,6 @@ const HARNESS_EXEMPTIONS = {
   "mochikit@mozilla.org": { installation_mode: "allowed" },
 };
 
-async function updatePolicies(policies) {
-  const updateApplied = EnterprisePolicyTesting.awaitNextPolicyUpdate();
-  EnterprisePolicyTesting.stubRemotePolicies(policies);
-  await updateApplied;
-}
-
 function isRestricted(host) {
   return WebExtensionPolicy.isRestrictedURI(
     Services.io.newURI(`https://${host}/`)
@@ -82,11 +76,9 @@ add_task(async function test_restricted_domains_apply_update_remove() {
   );
 
   info("Updating restricted_domains to a different domain.");
-  await updatePolicies({
-    policies: {
-      ExtensionSettings: {
-        "*": { restricted_domains: ["two.example.com"] },
-      },
+  await waitForLivePolicyUpdate({
+    ExtensionSettings: {
+      "*": { restricted_domains: ["two.example.com"] },
     },
   });
 
@@ -97,7 +89,7 @@ add_task(async function test_restricted_domains_apply_update_remove() {
   );
 
   info("Removing the ExtensionSettings policy.");
-  await updatePolicies({ policies: {} });
+  await waitForLivePolicyUpdate({});
 
   Assert.ok(
     !isRestricted("one.example.com") && !isRestricted("two.example.com"),
@@ -154,7 +146,7 @@ add_task(async function test_block_all_prefs_and_feature_reverted() {
   );
 
   info("Removing the ExtensionSettings policy.");
-  await updatePolicies({ policies: {} });
+  await waitForLivePolicyUpdate({});
 
   Assert.ok(
     !Services.prefs.prefIsLocked(SHOW_PANE_PREF),
@@ -208,11 +200,9 @@ add_task(async function test_install_sources_reset() {
   );
 
   info("Updating the policy to drop install_sources.");
-  await updatePolicies({
-    policies: {
-      ExtensionSettings: {
-        "*": { installation_mode: "allowed" },
-      },
+  await waitForLivePolicyUpdate({
+    ExtensionSettings: {
+      "*": { installation_mode: "allowed" },
     },
   });
 
@@ -222,7 +212,7 @@ add_task(async function test_install_sources_reset() {
   );
 
   info("Removing the ExtensionSettings policy.");
-  await updatePolicies({ policies: {} });
+  await waitForLivePolicyUpdate({});
 
   Assert.ok(
     Services.policies.allowedInstallSource(allowed) &&
@@ -256,13 +246,11 @@ add_task(async function test_runtime_blocked_hosts_blocks_access() {
   Assert.ok(canAccess(hostA), "extension can access host A before the policy");
 
   info("Block host A.");
-  await updatePolicies({
-    policies: {
-      ExtensionSettings: {
-        [id]: {
-          installation_mode: "allowed",
-          runtime_blocked_hosts: ["*://*.a.example.com"],
-        },
+  await waitForLivePolicyUpdate({
+    ExtensionSettings: {
+      [id]: {
+        installation_mode: "allowed",
+        runtime_blocked_hosts: ["*://*.a.example.com"],
       },
     },
   });
@@ -273,13 +261,11 @@ add_task(async function test_runtime_blocked_hosts_blocks_access() {
   Assert.ok(canAccess(hostB), "extension can still access host B");
 
   info("Update to block host B instead of A.");
-  await updatePolicies({
-    policies: {
-      ExtensionSettings: {
-        [id]: {
-          installation_mode: "allowed",
-          runtime_blocked_hosts: ["*://*.b.example.com"],
-        },
+  await waitForLivePolicyUpdate({
+    ExtensionSettings: {
+      [id]: {
+        installation_mode: "allowed",
+        runtime_blocked_hosts: ["*://*.b.example.com"],
       },
     },
   });
@@ -293,7 +279,7 @@ add_task(async function test_runtime_blocked_hosts_blocks_access() {
   );
 
   info("Removing the policy clears the guards.");
-  await updatePolicies({ policies: {} });
+  await waitForLivePolicyUpdate({});
   await TestUtils.waitForCondition(
     () => canAccess(hostB),
     "extension can access all hosts again after removal"
@@ -325,10 +311,8 @@ add_task(async function test_installation_mode_lifecycle() {
   );
 
   info("force_installed: the user can no longer remove or disable it.");
-  await updatePolicies({
-    policies: {
-      ExtensionSettings: { [id]: { installation_mode: "force_installed" } },
-    },
+  await waitForLivePolicyUpdate({
+    ExtensionSettings: { [id]: { installation_mode: "force_installed" } },
   });
   await TestUtils.waitForCondition(
     () => !(addon.permissions & AddonManager.PERM_CAN_UNINSTALL),
@@ -340,10 +324,8 @@ add_task(async function test_installation_mode_lifecycle() {
   );
 
   info("normal_installed: disabling is allowed again, removal still locked.");
-  await updatePolicies({
-    policies: {
-      ExtensionSettings: { [id]: { installation_mode: "normal_installed" } },
-    },
+  await waitForLivePolicyUpdate({
+    ExtensionSettings: { [id]: { installation_mode: "normal_installed" } },
   });
   await TestUtils.waitForCondition(
     () => addon.permissions & AddonManager.PERM_CAN_DISABLE,
@@ -355,10 +337,8 @@ add_task(async function test_installation_mode_lifecycle() {
   );
 
   info("blocked: the add-on is uninstalled live.");
-  await updatePolicies({
-    policies: {
-      ExtensionSettings: { [id]: { installation_mode: "blocked" } },
-    },
+  await waitForLivePolicyUpdate({
+    ExtensionSettings: { [id]: { installation_mode: "blocked" } },
   });
   await TestUtils.waitForCondition(
     () => !WebExtensionPolicy.getByID(id),
@@ -373,7 +353,7 @@ add_task(async function test_installation_mode_lifecycle() {
   info(
     "Removing the ExtensionSettings policy (teardown; result not asserted)."
   );
-  await updatePolicies({ policies: {} });
+  await waitForLivePolicyUpdate({});
 });
 
 // Functional: an installed extension whose permission is added to
@@ -396,11 +376,9 @@ add_task(async function test_blocked_permission_disables_and_reenables() {
   );
 
   info("Blocking the history permission via a live update.");
-  await updatePolicies({
-    policies: {
-      ExtensionSettings: {
-        "*": { blocked_permissions: ["history"] },
-      },
+  await waitForLivePolicyUpdate({
+    ExtensionSettings: {
+      "*": { blocked_permissions: ["history"] },
     },
   });
 
@@ -411,7 +389,7 @@ add_task(async function test_blocked_permission_disables_and_reenables() {
   Assert.ok(addon.appDisabled, "the add-on is disabled by blocked_permissions");
 
   info("Removing the ExtensionSettings policy.");
-  await updatePolicies({ policies: {} });
+  await waitForLivePolicyUpdate({});
 
   await TestUtils.waitForCondition(
     () => !addon.appDisabled,
@@ -454,10 +432,8 @@ add_task(async function test_shared_feature_kept_while_sibling_holds_it() {
   info(
     "Removing only ExtensionSettings; InstallAddonsPermission stays active."
   );
-  await updatePolicies({
-    policies: {
-      InstallAddonsPermission: { Default: false },
-    },
+  await waitForLivePolicyUpdate({
+    InstallAddonsPermission: { Default: false },
   });
 
   Assert.ok(
@@ -466,5 +442,5 @@ add_task(async function test_shared_feature_kept_while_sibling_holds_it() {
   );
 
   // Remove all policies to leave a clean state.
-  await updatePolicies({ policies: {} });
+  await waitForLivePolicyUpdate({});
 });

--- a/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_policy_HttpsOnlyMode.js
+++ b/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_policy_HttpsOnlyMode.js
@@ -53,13 +53,6 @@ function checkPref(locked, value) {
   );
 }
 
-// Pushing a new remote policy set and wait for the poller to apply it live
-async function updatePoliciesLive(policies) {
-  const updateApplied = EnterprisePolicyTesting.awaitNextPolicyUpdate();
-  EnterprisePolicyTesting.stubRemotePolicies({ policies });
-  await updateApplied;
-}
-
 // Changing the HttpsOnlyMode value through a live policy update must take
 // effect on the next navigation without a restart.
 add_task(async function test_https_only_mode_live_update() {
@@ -81,14 +74,14 @@ add_task(async function test_https_only_mode_live_update() {
       await navigateAndCheckErrorPage(browser, true);
 
       info("Live-updating HttpsOnlyMode to disallowed");
-      await updatePoliciesLive({ HttpsOnlyMode: "disallowed" });
+      await waitForLivePolicyUpdate({ HttpsOnlyMode: "disallowed" });
 
       // "disallowed" sets and locks the pref to false.
       checkPref(true, false);
       await navigateAndCheckErrorPage(browser, false);
 
       info("Live-updating HttpsOnlyMode to force_enabled");
-      await updatePoliciesLive({ HttpsOnlyMode: "force_enabled" });
+      await waitForLivePolicyUpdate({ HttpsOnlyMode: "force_enabled" });
 
       // "force_enabled" sets and locks the pref to true.
       checkPref(true, true);
@@ -114,14 +107,14 @@ add_task(async function test_https_only_mode_live_removal() {
       await navigateAndCheckErrorPage(browser, false);
 
       info("Applying HttpsOnlyMode: force_enabled");
-      await updatePoliciesLive({ HttpsOnlyMode: "force_enabled" });
+      await waitForLivePolicyUpdate({ HttpsOnlyMode: "force_enabled" });
 
       // "force_enabled" sets and locks the pref to true.
       checkPref(true, true);
       await navigateAndCheckErrorPage(browser, true);
 
       info("Removing HttpsOnlyMode");
-      await updatePoliciesLive({});
+      await waitForLivePolicyUpdate({});
 
       // The pref is unlocked again and its initial value restored.
       checkPref(false, false);
@@ -145,13 +138,13 @@ add_task(
     checkPref(true, false);
 
     info("Applying HttpsOnlyMode: allowed");
-    await updatePoliciesLive({ HttpsOnlyMode: "allowed" });
+    await waitForLivePolicyUpdate({ HttpsOnlyMode: "allowed" });
 
     // "allowed" is a no-op on the pref.
     checkPref(true, false);
 
     info("Removing HttpsOnlyMode");
-    await updatePoliciesLive({});
+    await waitForLivePolicyUpdate({});
 
     // The externally-set lock is preserved since "allowed" never changed it.
     checkPref(true, false);

--- a/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_policy_SitePolicies.js
+++ b/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_policy_SitePolicies.js
@@ -98,9 +98,7 @@ add_task(async function test_apply_then_remove_sitepolicies() {
   );
 
   info("Removing SitePolicies.");
-  let updateApplied = EnterprisePolicyTesting.awaitNextPolicyUpdate();
-  EnterprisePolicyTesting.stubRemotePolicies({ policies: {} });
-  await updateApplied;
+  await waitForLivePolicyUpdate({});
 
   // onRemove must reset both the parent's internal state and
   // the shared data snapshot read by content processes.
@@ -133,18 +131,14 @@ add_task(async function test_apply_then_update_sitepolicies() {
   );
 
   info("Updating SitePolicies to match example.org instead.");
-  let updateApplied = EnterprisePolicyTesting.awaitNextPolicyUpdate();
-  EnterprisePolicyTesting.stubRemotePolicies({
-    policies: {
-      SitePolicies: [
-        {
-          Match: ["*.example.org"],
-          Policies: { DisableJit: true },
-        },
-      ],
-    },
+  await waitForLivePolicyUpdate({
+    SitePolicies: [
+      {
+        Match: ["*.example.org"],
+        Policies: { DisableJit: true },
+      },
+    ],
   });
-  await updateApplied;
 
   assertHasSitePolicy("https://example.com/", false);
   assertHasSitePolicy("https://example.org/", true);
@@ -156,9 +150,7 @@ add_task(async function test_apply_then_update_sitepolicies() {
   );
 
   info("Removing SitePolicies.");
-  updateApplied = EnterprisePolicyTesting.awaitNextPolicyUpdate();
-  EnterprisePolicyTesting.stubRemotePolicies({ policies: {} });
-  await updateApplied;
+  await waitForLivePolicyUpdate({});
 
   await assertNoSitePolicies();
 });
@@ -188,18 +180,14 @@ add_task(async function test_live_update_exceptions() {
   assertJitAllowed("https://example.com/", true);
 
   info("Updating the exception to example.org so the diff re-applies it.");
-  let updateApplied = EnterprisePolicyTesting.awaitNextPolicyUpdate();
-  EnterprisePolicyTesting.stubRemotePolicies({
-    policies: {
-      SitePolicies: [
-        {
-          Exceptions: ["*.example.org"],
-          Policies: { DisableJit: true },
-        },
-      ],
-    },
+  await waitForLivePolicyUpdate({
+    SitePolicies: [
+      {
+        Exceptions: ["*.example.org"],
+        Policies: { DisableJit: true },
+      },
+    ],
   });
-  await updateApplied;
 
   await assertSitePolicyCount(
     ["https://example.com/", "https://example.org/"],
@@ -209,9 +197,7 @@ add_task(async function test_live_update_exceptions() {
   assertJitAllowed("https://example.org/", true);
 
   info("Removing SitePolicies.");
-  updateApplied = EnterprisePolicyTesting.awaitNextPolicyUpdate();
-  EnterprisePolicyTesting.stubRemotePolicies({ policies: {} });
-  await updateApplied;
+  await waitForLivePolicyUpdate({});
 
   await assertNoSitePolicies();
 });

--- a/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_policy_WebsiteFilter.js
+++ b/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_policy_WebsiteFilter.js
@@ -32,9 +32,7 @@ async function isBlockedSite(url, isExpectedBlocked) {
 }
 
 async function removePolicies() {
-  const updateApplied = EnterprisePolicyTesting.awaitNextPolicyUpdate();
-  EnterprisePolicyTesting.stubRemotePolicies({ policies: {} });
-  await updateApplied;
+  await waitForLivePolicyUpdate({});
   Assert.deepEqual(
     Services.policies.getActivePolicies(),
     {},
@@ -88,16 +86,12 @@ add_task(async function test_update_keeps_blocking_redirects() {
 
   // Change the parameters (add an unrelated exception) to trigger a
   // teardown-then-reapply update.
-  const updateApplied = EnterprisePolicyTesting.awaitNextPolicyUpdate();
-  EnterprisePolicyTesting.stubRemotePolicies({
-    policies: {
-      WebsiteFilter: {
-        Block: [BLOCK_PATTERN],
-        Exceptions: ["*://example.com/*"],
-      },
+  await waitForLivePolicyUpdate({
+    WebsiteFilter: {
+      Block: [BLOCK_PATTERN],
+      Exceptions: ["*://example.com/*"],
     },
   });
-  await updateApplied;
 
   await isBlockedSite(BLOCKED_PAGE, true);
   await isBlockedSite(REDIRECT_301, true);
@@ -122,15 +116,11 @@ add_task(async function test_update_changes_block_list() {
   await isBlockedSite(BLOCKED_PAGE, true);
   await isBlockedSite(EXCEPTION_PAGE, false);
 
-  const updateApplied = EnterprisePolicyTesting.awaitNextPolicyUpdate();
-  EnterprisePolicyTesting.stubRemotePolicies({
-    policies: {
-      WebsiteFilter: {
-        Block: ["*://mochi.test/*_exception*"],
-      },
+  await waitForLivePolicyUpdate({
+    WebsiteFilter: {
+      Block: ["*://mochi.test/*_exception*"],
     },
   });
-  await updateApplied;
 
   // The old Block pattern no longer matches, the new one does.
   await isBlockedSite(BLOCKED_PAGE, false);
@@ -157,15 +147,11 @@ add_task(async function test_update_drops_exceptions() {
   await isBlockedSite(EXCEPTION_PAGE, false);
 
   // Drop the exceptions via a live update.
-  const updateApplied = EnterprisePolicyTesting.awaitNextPolicyUpdate();
-  EnterprisePolicyTesting.stubRemotePolicies({
-    policies: {
-      WebsiteFilter: {
-        Block: [BLOCK_PATTERN],
-      },
+  await waitForLivePolicyUpdate({
+    WebsiteFilter: {
+      Block: [BLOCK_PATTERN],
     },
   });
-  await updateApplied;
 
   await isBlockedSite(BLOCKED_PAGE, true);
   await isBlockedSite(EXCEPTION_PAGE, true);

--- a/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_startup_policies.js
+++ b/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_startup_policies.js
@@ -11,36 +11,23 @@
 
 const customSchema = {
   properties: {
-    StartupTestPolicy: { type: "string", "x-restart-required": true },
-    LiveTestPolicy: { type: "string", "x-restart-required": false },
+    TestPolicy: { type: "string", "x-restart-required": true },
   },
 };
 
 let startupValue;
-let liveValue;
 
-const StartupTestPolicy = {
+const TestPolicy = {
   onBeforeUIStartup(manager, param) {
     startupValue = param;
   },
 };
 
-const LiveTestPolicy = {
-  onBeforeUIStartup(manager, param) {
-    liveValue = param;
-  },
-  onRemove() {
-    liveValue = POLICY_PARAM_STATE.REMOVED;
-  },
-};
-
 add_setup(async () => {
-  Policies.StartupTestPolicy = StartupTestPolicy;
-  Policies.LiveTestPolicy = LiveTestPolicy;
+  Policies.TestPolicy = TestPolicy;
 
   registerCleanupFunction(() => {
-    delete Policies.StartupTestPolicy;
-    delete Policies.LiveTestPolicy;
+    delete Policies.TestPolicy;
   });
 });
 
@@ -49,12 +36,12 @@ add_task(async function test_startup_policy_update_ignored_live() {
   startupValue = POLICY_PARAM_STATE.DEFAULT;
 
   await EnterprisePolicyTesting.setupEngineWithRemotePolicies(
-    { policies: { StartupTestPolicy: POLICY_PARAM_STATE.APPLIED } },
+    { policies: { TestPolicy: POLICY_PARAM_STATE.APPLIED } },
     customSchema
   );
   Assert.deepEqual(
     Services.policies.getActivePolicies(),
-    { StartupTestPolicy: POLICY_PARAM_STATE.APPLIED },
+    { TestPolicy: POLICY_PARAM_STATE.APPLIED },
     "Startup policy is applied at startup."
   );
   Assert.equal(startupValue, POLICY_PARAM_STATE.APPLIED);
@@ -64,12 +51,12 @@ add_task(async function test_startup_policy_update_ignored_live() {
 
   info("Live-updating the startup policy's parameters");
   await waitForLivePolicyUpdate({
-    StartupTestPolicy: POLICY_PARAM_STATE.UPDATED_BY_REMOTE_POLICY,
+    TestPolicy: POLICY_PARAM_STATE.UPDATED_BY_REMOTE_POLICY,
   });
 
   Assert.deepEqual(
     Services.policies.getActivePolicies(),
-    { StartupTestPolicy: POLICY_PARAM_STATE.APPLIED },
+    { TestPolicy: POLICY_PARAM_STATE.APPLIED },
     "Startup policy keeps its startup value; the live update is not applied."
   );
   Assert.equal(
@@ -84,7 +71,7 @@ add_task(async function test_startup_policy_removal_ignored_live() {
   startupValue = POLICY_PARAM_STATE.DEFAULT;
 
   await EnterprisePolicyTesting.setupEngineWithRemotePolicies(
-    { policies: { StartupTestPolicy: POLICY_PARAM_STATE.APPLIED } },
+    { policies: { TestPolicy: POLICY_PARAM_STATE.APPLIED } },
     customSchema
   );
   Assert.equal(startupValue, POLICY_PARAM_STATE.APPLIED);
@@ -97,7 +84,7 @@ add_task(async function test_startup_policy_removal_ignored_live() {
 
   Assert.deepEqual(
     Services.policies.getActivePolicies(),
-    { StartupTestPolicy: POLICY_PARAM_STATE.APPLIED },
+    { TestPolicy: POLICY_PARAM_STATE.APPLIED },
     "Startup policy stays applied."
   );
 });

--- a/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_startup_policies.js
+++ b/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_startup_policies.js
@@ -1,0 +1,103 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+// Enterprise policies come in two kinds, flagged per policy by
+// x-restart-required in policies-schema.json. A startup policy
+// (x-restart-required: true) only takes effect when Firefox starts and any
+// attempted update at runtime is ignored; a live policy (x-restart-required: false)
+// can also be applied at runtime.
+
+const customSchema = {
+  properties: {
+    StartupTestPolicy: { type: "string", "x-restart-required": true },
+    LiveTestPolicy: { type: "string", "x-restart-required": false },
+  },
+};
+
+let startupValue;
+let liveValue;
+
+const StartupTestPolicy = {
+  onBeforeUIStartup(manager, param) {
+    startupValue = param;
+  },
+};
+
+const LiveTestPolicy = {
+  onBeforeUIStartup(manager, param) {
+    liveValue = param;
+  },
+  onRemove() {
+    liveValue = POLICY_PARAM_STATE.REMOVED;
+  },
+};
+
+add_setup(async () => {
+  Policies.StartupTestPolicy = StartupTestPolicy;
+  Policies.LiveTestPolicy = LiveTestPolicy;
+
+  registerCleanupFunction(() => {
+    delete Policies.StartupTestPolicy;
+    delete Policies.LiveTestPolicy;
+  });
+});
+
+// A startup policy applied at startup must not be changed by a live update.
+add_task(async function test_startup_policy_update_ignored_live() {
+  startupValue = POLICY_PARAM_STATE.DEFAULT;
+
+  await EnterprisePolicyTesting.setupEngineWithRemotePolicies(
+    { policies: { StartupTestPolicy: POLICY_PARAM_STATE.APPLIED } },
+    customSchema
+  );
+  Assert.deepEqual(
+    Services.policies.getActivePolicies(),
+    { StartupTestPolicy: POLICY_PARAM_STATE.APPLIED },
+    "Startup policy is applied at startup."
+  );
+  Assert.equal(startupValue, POLICY_PARAM_STATE.APPLIED);
+
+  // Reset so any (unexpected) re-application is detectable.
+  startupValue = POLICY_PARAM_STATE.DEFAULT;
+
+  info("Live-updating the startup policy's parameters");
+  await waitForLivePolicyUpdate({
+    StartupTestPolicy: POLICY_PARAM_STATE.UPDATED_BY_REMOTE_POLICY,
+  });
+
+  Assert.deepEqual(
+    Services.policies.getActivePolicies(),
+    { StartupTestPolicy: POLICY_PARAM_STATE.APPLIED },
+    "Startup policy keeps its startup value; the live update is not applied."
+  );
+  Assert.equal(
+    startupValue,
+    POLICY_PARAM_STATE.DEFAULT,
+    "Startup policy callback did not re-run on the live update."
+  );
+});
+
+// A startup policy applied at startup must not be removed by a live update
+add_task(async function test_startup_policy_removal_ignored_live() {
+  startupValue = POLICY_PARAM_STATE.DEFAULT;
+
+  await EnterprisePolicyTesting.setupEngineWithRemotePolicies(
+    { policies: { StartupTestPolicy: POLICY_PARAM_STATE.APPLIED } },
+    customSchema
+  );
+  Assert.equal(startupValue, POLICY_PARAM_STATE.APPLIED);
+
+  // Reset so a stray onRemove is detectable.
+  startupValue = POLICY_PARAM_STATE.DEFAULT;
+
+  info("Removing the startup policy live");
+  await waitForLivePolicyUpdate({});
+
+  Assert.deepEqual(
+    Services.policies.getActivePolicies(),
+    { StartupTestPolicy: POLICY_PARAM_STATE.APPLIED },
+    "Startup policy stays applied."
+  );
+});

--- a/toolkit/components/enterprisepolicies/tests/browser/live/head.js
+++ b/toolkit/components/enterprisepolicies/tests/browser/live/head.js
@@ -24,6 +24,20 @@ const POLICY_PARAM_STATE = {
   REMOVED: "removed",
 };
 
+/**
+ * Serve a new remote policy set and wait until the live poller has fetched and
+ * applied it, so callers can assert on the post-update state without a restart.
+ *
+ * @param {object} policies policy set served as the new remote policies
+ *                          and applied on the next poll
+ * @returns {Promise<void>} resolves once the update has been applied
+ */
+async function waitForLivePolicyUpdate(policies) {
+  const updateApplied = EnterprisePolicyTesting.awaitNextPolicyUpdate();
+  EnterprisePolicyTesting.stubRemotePolicies({ policies });
+  await updateApplied;
+}
+
 add_setup(async () => {
   PoliciesPrefTracker.start();
 


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2046462

- Adds `x-restart-required` flag for enterprise-only policies in `policies-schema.json`
- Makes the policy engine ignore any updates to policies that require a restart (they get applied on the next restart)
- Adds helper method `waitForLivePolicyUpdate` in `toolkit/components/enterprisepolicies/tests/browser/live/head.js` to reduplicate test code
- Adds required `x-restart-required` key to test policies

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Testing <!-- OPTIONAL -->

* [X] Added tests
* [X] Manual testing performed

<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
