### PR TITLE
bug 2044493 - fetch DLP module from console instead of from an extension

### DIFF
--- a/browser/components/enterprisepolicies/helpers/ContentAnalysisPolicies.sys.mjs
+++ b/browser/components/enterprisepolicies/helpers/ContentAnalysisPolicies.sys.mjs
@@ -58,7 +58,6 @@ const CA_PLAIN_TEXT_POINTS = [
 const CA_SHARED_PREFS = [
   "enabled",
   "use_wasm_backend",
-  "wasm_module_extension_require_signature",
   "default_result",
   "timeout_result",
   "dlp_rules",
@@ -151,10 +150,6 @@ export const ContentAnalysisPolicies = {
 function applyExternalContentAnalysis(caParam) {
   lazy.PoliciesUtils.setAndLockPref(caPrefName("enabled"), true);
   lazy.PoliciesUtils.setAndLockPref(caPrefName("use_wasm_backend"), false);
-  lazy.PoliciesUtils.setAndLockPref(
-    caPrefName("wasm_module_extension_require_signature"),
-    true
-  );
 
   applyContentAnalysisConfig(caParam);
 }
@@ -163,10 +158,6 @@ function applyExternalContentAnalysis(caParam) {
 function applyBuiltinDlp(dlpParam) {
   lazy.PoliciesUtils.setAndLockPref(caPrefName("enabled"), true);
   lazy.PoliciesUtils.setAndLockPref(caPrefName("use_wasm_backend"), true);
-  lazy.PoliciesUtils.setAndLockPref(
-    caPrefName("wasm_module_extension_require_signature"),
-    true
-  );
 
   // Built-in DLP policy does not have an explicit deny list, but encodes
   // domain deny behavior in the DLP rules for processing by the engine.
@@ -251,10 +242,6 @@ function applyBuiltinDlp(dlpParam) {
 function activelyDisableContentAnalysis(caParam) {
   lazy.PoliciesUtils.setAndLockPref(caPrefName("enabled"), false);
   lazy.PoliciesUtils.setAndLockPref(caPrefName("use_wasm_backend"), false);
-  lazy.PoliciesUtils.setAndLockPref(
-    caPrefName("wasm_module_extension_require_signature"),
-    true
-  );
   applyContentAnalysisConfig(caParam);
 }
 

--- a/browser/components/enterprisepolicies/tests/browser/browser_policy_data_loss_prevention.js
+++ b/browser/components/enterprisepolicies/tests/browser/browser_policy_data_loss_prevention.js
@@ -311,7 +311,6 @@ add_task(async function test_builtin_fixed_prefs_are_set_and_locked() {
 
   checkLockedPref(CA_PREFIX + "enabled", true);
   checkLockedPref(CA_PREFIX + "use_wasm_backend", true);
-  checkLockedPref(CA_PREFIX + "wasm_module_extension_require_signature", true);
   checkLockedPref(CA_PREFIX + "deny_url_regex_list", "");
   checkLockedPref(CA_PREFIX + "agent_timeout", 300);
   checkLockedPref(CA_PREFIX + "show_blocked_result", true);

--- a/modules/libpref/init/StaticPrefList.yaml
+++ b/modules/libpref/init/StaticPrefList.yaml
@@ -1321,13 +1321,6 @@
   value: false
   mirror: always
 
-# If true, the content analysis extension must be signed before Firefox will
-# read and run its DLP module. Should only be set to false for testing.
-- name: browser.contentanalysis.wasm_module_extension_require_signature
-  type: bool
-  value: true
-  mirror: never
-
 # The rule set (the DLPRules JSON) consulted by the built-in DLP backend.
 # Set by the DataLossPrevention enterprise policy.
 # Empty means no rules.

--- a/toolkit/components/contentanalysis/ContentAnalysisWasmRunner.sys.mjs
+++ b/toolkit/components/contentanalysis/ContentAnalysisWasmRunner.sys.mjs
@@ -79,8 +79,9 @@ export class ContentAnalysisWasmRunner {
     // Note that `getDlpWasmModule()` will return 204 No Content
     // if the version of the DLP module is >= the version we have already.
     // This will mean `buffer` will be empty.
-    // Right now we don't do any caching so we always pass a 0.0.0 version
+    // Right now we always pass 0.0.0 as the current version
     // to the console, so `buffer` should always be the latest version.
+    // When we start sending a real cached version, this should be revisited.
     this.#cachedModuleBytes = new Uint8Array(buffer);
     return {
       moduleBytes: this.#cachedModuleBytes,

--- a/toolkit/components/contentanalysis/ContentAnalysisWasmRunner.sys.mjs
+++ b/toolkit/components/contentanalysis/ContentAnalysisWasmRunner.sys.mjs
@@ -39,7 +39,9 @@ export class ContentAnalysisWasmRunner {
   // In the future we should get this from the WASM bytes somehow, perhaps
   // by calling ca_abi_version()?
   get cachedModuleVersion() {
-    return "1.0";
+    return this.#cachedModuleBytes && this.#cachedModuleBytes.length
+      ? "1.0"
+      : "(unknown)";
   }
 
   async analyze(aRequestBytes, aContentBytes, aRules) {

--- a/toolkit/components/contentanalysis/ContentAnalysisWasmRunner.sys.mjs
+++ b/toolkit/components/contentanalysis/ContentAnalysisWasmRunner.sys.mjs
@@ -41,7 +41,7 @@ export class ContentAnalysisWasmRunner {
   get cachedModuleVersion() {
     return this.#cachedModuleBytes && this.#cachedModuleBytes.length
       ? "1.0"
-      : "(unknown)";
+      : "";
   }
 
   async analyze(aRequestBytes, aContentBytes, aRules) {

--- a/toolkit/components/contentanalysis/ContentAnalysisWasmRunner.sys.mjs
+++ b/toolkit/components/contentanalysis/ContentAnalysisWasmRunner.sys.mjs
@@ -9,73 +9,19 @@
  *
  * This runs in the parent process so it cannot compile or run the module -
  * that work is done by the ContentAnalysisWasm actor.
+ *
+ * The module is fetched from the console once, on the first call to
+ * ensureModuleReady() (from WasmModuleBackend::EnsureReady() at startup, or
+ * from analyze() if that races it), and reused for the runner's lifetime.
  */
 
 const lazy = {};
 ChromeUtils.defineESModuleGetters(lazy, {
-  AddonManager: "resource://gre/modules/AddonManager.sys.mjs",
+  ConsoleClient: "resource://gre/modules/enterprise/ConsoleClient.sys.mjs",
   E10SUtils: "resource://gre/modules/E10SUtils.sys.mjs",
-  ExtensionParent: "resource://gre/modules/ExtensionParent.sys.mjs",
-  NetUtil: "resource://gre/modules/NetUtil.sys.mjs",
 });
 
-// keep in sync with mozilla::contentanalysis::kWasmModuleExtensionId
-const EXTENSION_ID = "dlp-wasm-provider@mozilla.org";
-const REQUIRE_SIGNATURE_PREF =
-  "browser.contentanalysis.wasm_module_extension_require_signature";
-
-// Name the module is expected to have inside an extension's package.
-const EXTENSION_MODULE_FILENAME = "content_analysis_wasm.wasm";
-
 const ACTOR_NAME = "ContentAnalysisWasm";
-
-/**
- * Read a file packaged inside an installed extension (identified by ID) as raw
- * bytes. Also checks the signature if the pref is set.
- *
- * @param {string} extensionId The extension ID to load
- * @param {string} path The path of the file to load from the extension
- * @returns {{moduleBytes: Uint8Array, extensionVersion: string}}
- */
-function readExtensionBytes(extensionId, path) {
-  const extension =
-    lazy.ExtensionParent.GlobalManager.getExtension(extensionId);
-  if (!extension) {
-    return null;
-  }
-
-  const requireSignature = Services.prefs.getBoolPref(
-    REQUIRE_SIGNATURE_PREF,
-    true
-  );
-  if (requireSignature) {
-    const signedState = extension.addonData?.signedState;
-    if (!(signedState >= lazy.AddonManager.SIGNEDSTATE_SYSTEM)) {
-      throw Components.Exception(
-        `DLP wasm extension '${extensionId}' is not acceptably signed ` +
-          `(signedState=${signedState}); refusing to load its module`,
-        Cr.NS_ERROR_INVALID_SIGNATURE
-      );
-    }
-  }
-
-  const channel = lazy.NetUtil.newChannel({
-    uri: extension.getURL(path),
-    loadUsingSystemPrincipal: true,
-  });
-  const stream = channel.open();
-  const bstream = Cc["@mozilla.org/binaryinputstream;1"].createInstance(
-    Ci.nsIBinaryInputStream
-  );
-  bstream.setInputStream(stream);
-  const bytes = bstream.readByteArray(stream.available());
-  bstream.close();
-  stream.close();
-  return {
-    moduleBytes: Uint8Array.from(bytes),
-    extensionVersion: extension.version,
-  };
-}
 
 /**
  * nsIContentAnalysisWasmRunner implementation. See the module comment above.
@@ -83,30 +29,61 @@ function readExtensionBytes(extensionId, path) {
 export class ContentAnalysisWasmRunner {
   QueryInterface = ChromeUtils.generateQI(["nsIContentAnalysisWasmRunner"]);
 
+  // In-memory cache of the module fetched from the console.
+  #cachedModuleBytes = null;
+
+  // The in-flight (or settled) fetch of the module. Cleared on failure so
+  // a later call will retry.
+  #modulePromise = null;
+
+  // In the future we should get this from the WASM bytes somehow, perhaps
+  // by calling ca_abi_version()?
+  get cachedModuleVersion() {
+    return "1.0";
+  }
+
   async analyze(aRequestBytes, aContentBytes, aRules) {
-    // Reading + signature verification stay in the parent (the trust decision):
-    // WebExtensionPolicy/AddonManager are parent-process only.
-    const extensionInfo = readExtensionBytes(
-      EXTENSION_ID,
-      EXTENSION_MODULE_FILENAME
-    );
-    if (!extensionInfo) {
-      throw Components.Exception(
-        `DLP WASM extension '${EXTENSION_ID}' is not installed or not enabled`,
-        Cr.NS_ERROR_NOT_AVAILABLE
-      );
-    }
-    const { moduleBytes, extensionVersion } = extensionInfo;
+    const { moduleBytes, version } = await this.ensureModuleReady();
 
     const actor = await this.#getActor();
     // Resolves with a Uint8Array, which the C++ caller reads in bulk.
     return actor.sendQuery("Analyze", {
-      version: extensionVersion,
+      version,
       moduleBytes,
       requestBytes: Uint8Array.from(aRequestBytes),
       contentBytes: Uint8Array.from(aContentBytes || []),
       rules: toPlainRules(aRules),
     });
+  }
+
+  /**
+   * Ensures the module has been fetched from the console. Safe to call
+   * redundantly.
+   *
+   * @returns {Promise<{moduleBytes: Uint8Array, version: string}>}
+   */
+  ensureModuleReady() {
+    if (!this.#modulePromise) {
+      this.#modulePromise = this.#fetchModule().catch(e => {
+        this.#modulePromise = null;
+        throw e;
+      });
+    }
+    return this.#modulePromise;
+  }
+
+  async #fetchModule() {
+    const buffer = await lazy.ConsoleClient.getDlpWasmModule();
+    // Note that `getDlpWasmModule()` will return 204 No Content
+    // if the version of the DLP module is >= the version we have already.
+    // This will mean `buffer` will be empty.
+    // Right now we don't do any caching so we always pass a 0.0.0 version
+    // to the console, so `buffer` should always be the latest version.
+    this.#cachedModuleBytes = new Uint8Array(buffer);
+    return {
+      moduleBytes: this.#cachedModuleBytes,
+      version: this.cachedModuleVersion,
+    };
   }
 
   async #getActor() {

--- a/toolkit/components/contentanalysis/WasmModuleBackend.cpp
+++ b/toolkit/components/contentanalysis/WasmModuleBackend.cpp
@@ -102,12 +102,28 @@ static nsresult ReadFileContents(const nsString& aFilePath,
 
 nsresult WasmModuleBackend::EnsureReady() {
   AssertIsOnMainThread();
-  // The runner loads the wasm module lazily on first analyze; getting the
-  // service here surfaces gross misconfiguration (e.g. missing component) early
-  // without paying for module compilation until a request actually arrives.
   nsCOMPtr<nsIContentAnalysisWasmRunner> runner =
       do_GetService(WASM_RUNNER_CONTRACTID);
-  return runner ? NS_OK : NS_ERROR_NOT_AVAILABLE;
+  if (!runner) {
+    return NS_ERROR_NOT_AVAILABLE;
+  }
+
+  // Kick off fetching the module now instead of waiting for the first
+  // Analyze(), so the console round trip isn't on the critical path of the
+  // first real request.
+  // If this doesn't succeed, the EnsureModuleReady() call will try again
+  // the next time it's called.
+  RefPtr<dom::Promise> promise;
+  if (NS_SUCCEEDED(runner->EnsureModuleReady(getter_AddRefs(promise))) &&
+      promise) {
+    promise->AddCallbacksWithCycleCollectedArgs(
+        [](JSContext*, JS::Handle<JS::Value>, ErrorResult&) {},
+        [](JSContext*, JS::Handle<JS::Value>, ErrorResult&) {
+          MOZ_LOG(gContentAnalysisLog, LogLevel::Warning,
+                  ("Failed to prefetch the DLP wasm module at startup"));
+        });
+  }
+  return NS_OK;
 }
 
 nsresult WasmModuleBackend::LoadDlpRules(
@@ -283,10 +299,8 @@ void WasmModuleBackend::HandleWasmResponse(JSContext* aCx,
     return;
   }
 
-  // The module produced a real verdict, so it's genuinely connected and (if
-  // it had previously failed signature verification) that's no longer true.
+  // The module produced a real verdict, so it's genuinely connected.
   mConnectedToAgent = true;
-  mFailedSignatureVerification = false;
   owner->HandleResponseFromAgent(response, aAutoAcknowledge);
 }
 
@@ -341,7 +355,6 @@ nsresult WasmModuleBackend::InvokeRunner(
         }
         nsresult rv = ExtractExceptionResult(aCx, aValue);
         self->mConnectedToAgent = false;
-        self->mFailedSignatureVerification = rv == NS_ERROR_INVALID_SIGNATURE;
         owner->CancelWithError(nsCString(userActionId), rv);
       });
   return NS_OK;
@@ -350,10 +363,17 @@ nsresult WasmModuleBackend::InvokeRunner(
 RefPtr<ContentAnalysisBackend::DiagnosticInfoPromise>
 WasmModuleBackend::GetDiagnosticInfo() {
   AssertIsOnMainThread();
-  nsString moduleExtensionId = kWasmModuleExtensionId;
+  // No agent path or signature verification applies to this backend, so just
+  // report the module's version in the agent path field instead.
+  nsAutoString version;
+  nsCOMPtr<nsIContentAnalysisWasmRunner> runner =
+      do_GetService(WASM_RUNNER_CONTRACTID);
+  if (runner) {
+    MOZ_ALWAYS_SUCCEEDS(runner->GetCachedModuleVersion(version));
+    version.Insert(u"version ", 0);
+  }
   auto info = MakeRefPtr<ContentAnalysisDiagnosticInfo>(
-      mConnectedToAgent, std::move(moduleExtensionId),
-      mFailedSignatureVerification, mRequestCount);
+      mConnectedToAgent, std::move(version), false, mRequestCount);
   return DiagnosticInfoPromise::CreateAndResolve(info, __func__);
 }
 

--- a/toolkit/components/contentanalysis/WasmModuleBackend.cpp
+++ b/toolkit/components/contentanalysis/WasmModuleBackend.cpp
@@ -370,7 +370,11 @@ WasmModuleBackend::GetDiagnosticInfo() {
       do_GetService(WASM_RUNNER_CONTRACTID);
   if (runner) {
     MOZ_ALWAYS_SUCCEEDS(runner->GetCachedModuleVersion(version));
-    version.Insert(u"version ", 0);
+    if (version.Length() > 0) {
+      version.Insert(u"version ", 0);
+    } else {
+      version = u"(none)";
+    }
   }
   auto info = MakeRefPtr<ContentAnalysisDiagnosticInfo>(
       mConnectedToAgent, std::move(version), false, mRequestCount);

--- a/toolkit/components/contentanalysis/WasmModuleBackend.h
+++ b/toolkit/components/contentanalysis/WasmModuleBackend.h
@@ -17,16 +17,13 @@ class ContentAnalysisRequest;
 
 namespace mozilla::contentanalysis {
 
-// keep in sync with EXTENSION_ID in ContentAnalysisWasmRunner.sys.mjs
-const auto kWasmModuleExtensionId = u"dlp-wasm-provider@mozilla.org"_ns;
-
 // Backend that produces verdicts from an in-process WebAssembly DLP module.
 //
 // The module is loaded and executed by SpiderMonkey's wasm engine through a JS
 // runner (nsIContentAnalysisWasmRunner).  This backend serializes the request
 // to the canonical content_analysis SDK protobuf, hands the bytes to the
-// runner, and converts the response back.  The module is read from the
-// extension named by kWasmModuleExtensionId.
+// runner, and converts the response back.  The module is fetched by the
+// runner from the enterprise console.
 class WasmModuleBackend final : public ContentAnalysisBackend {
  public:
   WasmModuleBackend() = default;
@@ -71,11 +68,6 @@ class WasmModuleBackend final : public ContentAnalysisBackend {
   // Whether the module most recently ran successfully. Updated whenever an
   // analyze() call to the runner settles.
   bool mConnectedToAgent MOZ_GUARDED_BY(sMainThreadCapability) = false;
-
-  // Whether the most recent analyze() failure was because the module's
-  // extension is not signed.
-  bool mFailedSignatureVerification MOZ_GUARDED_BY(sMainThreadCapability) =
-      false;
 
   // Set once Shutdown() runs (e.g. when the service swaps this backend out on a
   // live policy change). A runner promise that resolves afterward is dropped so

--- a/toolkit/components/contentanalysis/nsIContentAnalysis.idl
+++ b/toolkit/components/contentanalysis/nsIContentAnalysis.idl
@@ -579,10 +579,10 @@ interface nsIContentAnalysisRule : nsISupports {
 
 /**
  * Runs an in-process WebAssembly DLP module. Implemented in JS
- * (ContentAnalysisWasmRunner.sys.mjs). The parent-process service reads and
- * signature-checks the module out of the configured extension, then compiles and
- * runs it in a content process (via the ContentAnalysisWasm actor) because the
- * parent process forbids wasm compilation. The C++ WasmModuleBackend calls this.
+ * (ContentAnalysisWasmRunner.sys.mjs). The parent-process service fetches the
+ * module from the enterprise console, then compiles and runs it in a content
+ * process (via the ContentAnalysisWasm actor) because the parent process
+ * forbids wasm compilation. The C++ WasmModuleBackend calls this.
  */
 [scriptable, uuid(909ea37a-71a0-4454-82ec-98a64087fe22)]
 interface nsIContentAnalysisWasmRunner : nsISupports {
@@ -596,10 +596,26 @@ interface nsIContentAnalysisWasmRunner : nsISupports {
    *                       module's FfiRule ABI.
    * @return A Promise that resolves with the serialized
    *         content_analysis.sdk.ContentAnalysisResponse (as an Array<octet>), or
-   *         rejects if the module is unavailable or the extension is not acceptably
-   *         signed.
+   *         rejects if the module is unavailable.
    */
   Promise analyze(in Array<octet> aRequestBytes,
                   in Array<octet> aContentBytes,
                   in Array<nsIContentAnalysisRule> aRules);
+
+  /**
+   * Ensures the module has been fetched from the console, fetching it only
+   * once for the runner's lifetime, so it's safe to call redundantly. Called eagerly
+   * by WasmModuleBackend::EnsureReady() so the fetch isn't on the critical
+   * path of the first real request.
+   *
+   * @return A Promise that resolves once the module is cached, or rejects if
+   *         the fetch failed (a later call will retry).
+   */
+  Promise ensureModuleReady();
+
+  /**
+   * The version of the module currently cached in memory, as published by the
+   * console's wasm-version endpoint. Empty if no module has been fetched yet.
+   */
+  readonly attribute AString cachedModuleVersion;
 };

--- a/toolkit/components/contentanalysis/tests/xpcshell/head.js
+++ b/toolkit/components/contentanalysis/tests/xpcshell/head.js
@@ -3,19 +3,11 @@
 
 "use strict";
 
-const { ExtensionTestUtils } = ChromeUtils.importESModule(
-  "resource://testing-common/ExtensionXPCShellUtils.sys.mjs"
+const { ConsoleClient } = ChromeUtils.importESModule(
+  "resource://gre/modules/enterprise/ConsoleClient.sys.mjs"
 );
 
-ExtensionTestUtils.init(this);
-
-// ID of the WebExtension that bundles the DLP wasm module, shared by the tests
-// that install it. keep in sync with EXTENSION_ID in
-// ContentAnalysisWasmRunner.sys.mjs
-const EXTENSION_ID = "dlp-wasm-provider@mozilla.org";
-
-// Name the wasm module has both as a test support-file and inside the extension
-// package.
+// Name the wasm module has as a test support-file.
 const WASM_PATH = "content_analysis_wasm.wasm";
 
 // The ContentAnalysisWasm process actor is normally registered at browser
@@ -37,20 +29,9 @@ try {
   }
 }
 
-// Install a WebExtension bundling the wasm module under WASM_PATH
-async function installModuleExtension() {
-  const extension = ExtensionTestUtils.loadExtension({
-    manifest: {
-      browser_specific_settings: { gecko: { id: EXTENSION_ID } },
-      web_accessible_resources: [WASM_PATH],
-    },
-    files: {
-      // The XPI writer requires an ArrayBuffer for binary entries. do_get_file
-      // resolves WASM_PATH against the test's directory (the wasm is a
-      // support-file copied there) and IOUtils.read needs an absolute path.
-      [WASM_PATH]: (await IOUtils.read(do_get_file(WASM_PATH).path)).buffer,
-    },
-  });
-  await extension.startup();
-  return extension;
+// Stub ConsoleClient's DLP wasm endpoints to serve the module bundled under
+// WASM_PATH as the given version, standing in for the real console.
+async function stubDlpWasmModule() {
+  const moduleBytes = await IOUtils.read(do_get_file(WASM_PATH).path);
+  ConsoleClient.getDlpWasmModule = async () => moduleBytes.buffer;
 }

--- a/toolkit/components/contentanalysis/tests/xpcshell/head.js
+++ b/toolkit/components/contentanalysis/tests/xpcshell/head.js
@@ -30,10 +30,10 @@ try {
 }
 
 // Stub ConsoleClient's DLP wasm endpoints to serve the module bundled under
-// WASM_PATH as the given version, standing in for the real console.
+// WASM_PATH, standing in for the real console.
 async function stubDlpWasmModule() {
   const moduleBytes = await IOUtils.read(do_get_file(WASM_PATH).path);
-  	
+
   const originalGetDlpWasmModule = ConsoleClient.getDlpWasmModule;
   const restore = () => {
     ConsoleClient.getDlpWasmModule = originalGetDlpWasmModule;

--- a/toolkit/components/contentanalysis/tests/xpcshell/head.js
+++ b/toolkit/components/contentanalysis/tests/xpcshell/head.js
@@ -33,5 +33,11 @@ try {
 // WASM_PATH as the given version, standing in for the real console.
 async function stubDlpWasmModule() {
   const moduleBytes = await IOUtils.read(do_get_file(WASM_PATH).path);
+  	
+  const originalGetDlpWasmModule = ConsoleClient.getDlpWasmModule;
+  const restore = () => {
+    ConsoleClient.getDlpWasmModule = originalGetDlpWasmModule;
+  };
+  registerCleanupFunction(restore);
   ConsoleClient.getDlpWasmModule = async () => moduleBytes.buffer;
 }

--- a/toolkit/components/contentanalysis/tests/xpcshell/test_wasm_backend.js
+++ b/toolkit/components/contentanalysis/tests/xpcshell/test_wasm_backend.js
@@ -8,19 +8,14 @@
 // to the content_analysis SDK protobuf, resolves the request's content,
 // and hands both to the in-process wasm DLP module via nsIContentAnalysisWasmRunner.
 //
-// The wasm module is bundled in a WebExtension and read through the real
-// production path, exactly as test_wasm_runner.js does. The rules below are
-// delivered the way the DataLossPrevention policy delivers them in production,
-// through the browser.contentanalysis.dlp_rules pref that WasmModuleBackend
-// reads (block uploads to cloud-storage domains, warn on AI domains, block
-// content marked CONFIDENTIAL).
-
-const { AddonManager } = ChromeUtils.importESModule(
-  "resource://gre/modules/AddonManager.sys.mjs"
-);
-
-const REQUIRE_SIGNATURE_PREF =
-  "browser.contentanalysis.wasm_module_extension_require_signature";
+// The wasm module is fetched from the enterprise console (ConsoleClient) and
+// read through the real production path, with ConsoleClient's fetch methods
+// stubbed to serve the module bundled as a test support-file (see
+// stubDlpWasmModule in head.js). The rules below are delivered the way
+// the DataLossPrevention policy delivers them in production, through the
+// browser.contentanalysis.dlp_rules pref that WasmModuleBackend reads (block
+// uploads to cloud-storage domains, warn on AI domains, block content marked
+// CONFIDENTIAL).
 
 const DLP_RULES = {
   DLPRules: {
@@ -56,7 +51,6 @@ const DLP_RULES = {
 // since the backend is chosen once in its constructor.
 Services.prefs.setBoolPref("browser.contentanalysis.use_wasm_backend", true);
 Services.prefs.setBoolPref("browser.contentanalysis.enabled", true);
-Services.prefs.setBoolPref(REQUIRE_SIGNATURE_PREF, false);
 Services.prefs.setBoolPref(
   "browser.contentanalysis.interception_point.file_upload.enabled",
   true
@@ -162,7 +156,7 @@ add_setup(async function () {
 // reading the file's contents off the main thread before handing them to the
 // module.
 add_task(async function test_file_upload_to_blocked_domain_is_blocked() {
-  const extension = await installModuleExtension();
+  await stubDlpWasmModule();
   const filePath = await makeTempFile(
     "dlp_blocked_upload.txt",
     "contents of a file being uploaded to cloud storage"
@@ -186,14 +180,12 @@ add_task(async function test_file_upload_to_blocked_domain_is_blocked() {
     !result.shouldAllowContent,
     "file upload to drive.google.com is blocked"
   );
-
-  await extension.unload();
 });
 
 // The same file uploaded to an unlisted domain is allowed. This still reads the
 // file off the main thread and round-trips it through the module.
 add_task(async function test_file_upload_to_unlisted_domain_is_allowed() {
-  const extension = await installModuleExtension();
+  await stubDlpWasmModule();
   const filePath = await makeTempFile(
     "dlp_allowed_upload.txt",
     "contents of a file being uploaded to an ordinary site"
@@ -214,15 +206,13 @@ add_task(async function test_file_upload_to_unlisted_domain_is_allowed() {
   );
 
   Assert.ok(result.shouldAllowContent, "file upload to example.com is allowed");
-
-  await extension.unload();
 });
 
 // An empty file must still round-trip cleanly (the off-main-thread read handles
 // a zero-length file by passing empty content) and be allowed on an unlisted
 // domain.
 add_task(async function test_empty_file_upload_is_allowed() {
-  const extension = await installModuleExtension();
+  await stubDlpWasmModule();
   const filePath = await makeTempFile("dlp_empty_upload.txt", "");
 
   const result = await contentAnalysis.analyzeContentRequests(
@@ -240,14 +230,12 @@ add_task(async function test_empty_file_upload_is_allowed() {
   );
 
   Assert.ok(result.shouldAllowContent, "empty file upload is allowed");
-
-  await extension.unload();
 });
 
 // Text (bulk data entry) requests take the synchronous, no-file path in the
 // backend; verify it still works alongside the file path.
 add_task(async function test_text_paste_to_unlisted_domain_is_allowed() {
-  const extension = await installModuleExtension();
+  await stubDlpWasmModule();
 
   const result = await contentAnalysis.analyzeContentRequests(
     [
@@ -263,8 +251,6 @@ add_task(async function test_text_paste_to_unlisted_domain_is_allowed() {
   );
 
   Assert.ok(result.shouldAllowContent, "text paste to example.com is allowed");
-
-  await extension.unload();
 });
 
 // Pasted text is handed to the module as content bytes, separately from the
@@ -274,7 +260,7 @@ add_task(async function test_text_paste_to_unlisted_domain_is_allowed() {
 // destination domain here isn't covered by any domain-based rule, isolating
 // the content path from the domain path.
 add_task(async function test_text_paste_with_confidential_marker_is_blocked() {
-  const extension = await installModuleExtension();
+  await stubDlpWasmModule();
 
   const result = await contentAnalysis.analyzeContentRequests(
     [
@@ -293,15 +279,13 @@ add_task(async function test_text_paste_with_confidential_marker_is_blocked() {
     !result.shouldAllowContent,
     "text paste containing a CONFIDENTIAL marker is blocked"
   );
-
-  await extension.unload();
 });
 
 // Same content-pattern rule, but content resolved from a file instead of
 // inline text_content, to confirm the file-content path also reaches the
 // module's pattern matching.
 add_task(async function test_file_with_confidential_marker_is_blocked() {
-  const extension = await installModuleExtension();
+  await stubDlpWasmModule();
   const filePath = await makeTempFile(
     "dlp_confidential.txt",
     "top secret plan: CONFIDENTIAL launch details"
@@ -325,8 +309,6 @@ add_task(async function test_file_with_confidential_marker_is_blocked() {
     !result.shouldAllowContent,
     "file upload containing a CONFIDENTIAL marker is blocked"
   );
-
-  await extension.unload();
 });
 
 // Print requests fetch their content via the cross-platform GetPrintData,
@@ -335,7 +317,7 @@ add_task(async function test_file_with_confidential_marker_is_blocked() {
 // shared-memory handle. Verify the WASM backend correctly hands print data to
 // the module on every platform.
 add_task(async function test_print_to_unlisted_domain_is_allowed() {
-  const extension = await installModuleExtension();
+  await stubDlpWasmModule();
 
   const before = await contentAnalysis.getDiagnosticInfo();
 
@@ -369,14 +351,12 @@ add_task(async function test_print_to_unlisted_domain_is_allowed() {
     after.connectedToAgent,
     "connected after analyzing a print request"
   );
-
-  await extension.unload();
 });
 
 // GetDiagnosticInfo should track the number of analyze() calls and report
 // that the module is connected after it runs successfully.
 add_task(async function test_diagnostic_info_tracks_successful_analysis() {
-  const extension = await installModuleExtension();
+  await stubDlpWasmModule();
 
   const before = await contentAnalysis.getDiagnosticInfo();
 
@@ -404,73 +384,6 @@ add_task(async function test_diagnostic_info_tracks_successful_analysis() {
     !after.failedSignatureVerification,
     "no signature failure after a successful analysis"
   );
-
-  await extension.unload();
-});
-
-// A module extension that fails signature verification should be reflected in
-// GetDiagnosticInfo, mirroring how ExternalAgentBackend reports a mismatched
-// agent signature.
-add_task(async function test_diagnostic_info_on_signature_failure() {
-  Services.prefs.setBoolPref(REQUIRE_SIGNATURE_PREF, true);
-  const extension = await installModuleExtension();
-  extension.extension.addonData.signedState = AddonManager.SIGNEDSTATE_MISSING;
-
-  await contentAnalysis.analyzeContentRequests(
-    [
-      makeRequest({
-        analysisType: Ci.nsIContentAnalysisRequest.eBulkDataEntry,
-        reason: Ci.nsIContentAnalysisRequest.eClipboardPaste,
-        operationTypeForDisplay: Ci.nsIContentAnalysisRequest.eClipboard,
-        urlSpec: "https://example.com/",
-        textContent: "text that can't be analyzed",
-      }),
-    ],
-    true
-  );
-
-  const info = await contentAnalysis.getDiagnosticInfo();
-  Assert.ok(
-    !info.connectedToAgent,
-    "not connected after a signature verification failure"
-  );
-  Assert.ok(
-    info.failedSignatureVerification,
-    "failedSignatureVerification is set after a signature verification " +
-      "failure"
-  );
-
-  Services.prefs.setBoolPref(REQUIRE_SIGNATURE_PREF, false);
-  await extension.unload();
-});
-
-add_task(async function test_succeeds_with_signature_check_if_signed() {
-  Services.prefs.setBoolPref(REQUIRE_SIGNATURE_PREF, true);
-  const extension = await installModuleExtension();
-  extension.extension.addonData.signedState = AddonManager.SIGNEDSTATE_SYSTEM;
-
-  await contentAnalysis.analyzeContentRequests(
-    [
-      makeRequest({
-        analysisType: Ci.nsIContentAnalysisRequest.eBulkDataEntry,
-        reason: Ci.nsIContentAnalysisRequest.eClipboardPaste,
-        operationTypeForDisplay: Ci.nsIContentAnalysisRequest.eClipboard,
-        urlSpec: "https://example.com/",
-        textContent: "text that can't be analyzed",
-      }),
-    ],
-    true
-  );
-
-  const info = await contentAnalysis.getDiagnosticInfo();
-  Assert.ok(info.connectedToAgent, "connected after using a signed extension");
-  Assert.ok(
-    !info.failedSignatureVerification,
-    "failedSignatureVerification is not set after using a signed extension"
-  );
-
-  Services.prefs.setBoolPref(REQUIRE_SIGNATURE_PREF, false);
-  await extension.unload();
 });
 
 // Upload the same file to the same domain repeatedly; only the rule set varies.
@@ -509,7 +422,7 @@ async function uploadWasAllowed() {
 // comparison is the only thing keeping the rules current after a live policy
 // update -- if it regressed, the first rule set would be enforced forever.
 add_task(async function test_changed_rules_take_effect_without_invalidation() {
-  const extension = await installModuleExtension();
+  await stubDlpWasmModule();
 
   setDlpRules([
     {
@@ -547,14 +460,13 @@ add_task(async function test_changed_rules_take_effect_without_invalidation() {
   );
 
   restoreDefaultDlpRules();
-  await extension.unload();
 });
 
 // A rule set that fails to parse must not be cached as "no rules", which would
 // turn a single bad policy into a silent allow-everything from the second
 // request onward. Both requests below must fail closed.
 add_task(async function test_unparsable_rules_are_not_cached_as_no_rules() {
-  const extension = await installModuleExtension();
+  await stubDlpWasmModule();
 
   Services.prefs.setStringPref(DLP_RULES_PREF, "{ this is not valid JSON");
 
@@ -580,5 +492,4 @@ add_task(async function test_unparsable_rules_are_not_cached_as_no_rules() {
   );
 
   restoreDefaultDlpRules();
-  await extension.unload();
 });

--- a/toolkit/components/enterprise/modules/ConsoleClient.sys.mjs
+++ b/toolkit/components/enterprise/modules/ConsoleClient.sys.mjs
@@ -142,6 +142,11 @@ export const ConsoleClient = {
    * Paths to API endpoints of the remote enterprise console
    */
   get _paths() {
+    // Strip off any trailing "a1", etc.
+    let majorMinorPatchVersion = Services.appinfo.appBuildID.replace(
+      /[a-zA-Z].*$/,
+      ""
+    );
     return {
       SSO: "/sso/login",
       SIGNOUT: "/sso/logout",
@@ -153,6 +158,7 @@ export const ConsoleClient = {
       DEVICE_POSTURE: "/sso/device_posture",
       WHOAMI: "/api/browser/whoami",
       FXACCOUNT: "/api/browser/account",
+      DLP_WASM: `/api/browser/content-analysis-wasm/update/156.0/${majorMinorPatchVersion}/0.0.0`,
     };
   },
 
@@ -267,23 +273,32 @@ export const ConsoleClient = {
    * which native fetch() does not expose.
    *
    * Limitations compared to native fetch():
-   * - Response object only has: ok, status, json(), text()
-   * - Missing: statusText, headers, url, redirected, clone(),
-   *   arrayBuffer(), blob(), formData()
+   * - Response object only has: ok, status, json(), text(), arrayBuffer()
+   * - Missing: statusText, headers, url, redirected, clone(), blob(),
+   *   formData()
    * - json()/text() can be called multiple times (no body consumption)
+   *
+   * If the passed in responseType is "arraybuffer", then calling json() or text()
+   * will throw an exception.
    *
    * @param {string} url - The URL to fetch
    * @param {object} options - Fetch-like options
    * @param {string} [options.method="GET"] - HTTP method
    * @param {object} [options.headers={}] - Request headers
    * @param {string|null} [options.body=null] - Request body
-   * @returns {Promise<{ok: boolean, status: number, json: Function, text: Function}>}
+   * @param {""|"arraybuffer"} [options.responseType=""] - XHR response type -
+   *   use "arraybuffer" for binary responses and "" for text responses.
+   * @returns {Promise<{ok: boolean, status: number, json: Function, text: Function, arrayBuffer: Function}>}
    */
-  _xhrFetch(url, { method = "GET", headers = {}, body = null } = {}) {
+  _xhrFetch(
+    url,
+    { method = "GET", headers = {}, body = null, responseType = "" } = {}
+  ) {
     return new Promise((resolve, reject) => {
       const xhr = new XMLHttpRequest();
       xhr.open(method, url, true);
       xhr.timeout = XHR_TIMEOUT_MS;
+      xhr.responseType = responseType;
 
       // Handle both plain objects and Headers instances
       const headerEntries = Headers.isInstance(headers)
@@ -305,6 +320,7 @@ export const ConsoleClient = {
             }
           },
           text: () => Promise.resolve(xhr.responseText),
+          arrayBuffer: () => Promise.resolve(xhr.response),
         };
         resolve(response);
       };
@@ -377,6 +393,15 @@ export const ConsoleClient = {
   },
 
   /**
+   * Fetches the bytes of the DLP wasm module.
+   *
+   * @returns {Promise<ArrayBuffer>}
+   */
+  async getDlpWasmModule() {
+    return this._fetchBinary(this._paths.DLP_WASM);
+  },
+
+  /**
    * Ensures that we have a valid session and performs an authenticated fetch against
    * a registered console endpoint. If we get a 401 or 403 refresh and retry once.
    *
@@ -419,6 +444,40 @@ export const ConsoleClient = {
 
     const text = await res.text().catch(() => "");
     throw new Error(`Fetch ${method} ${path} failed (${res.status}): ${text}`);
+  },
+
+  /**
+   * Ensures that we have a valid session and performs an authenticated GET
+   * against a registered console endpoint, returning the raw binary body.
+   * If we get a 401 or 403 refresh and retry once.
+   *
+   * @param {string} path - Console API to request
+   * @param {{ _didRefresh?: boolean }} [options]
+   * @throws {Error}
+   * @returns {Promise<ArrayBuffer>}
+   */
+  async _fetchBinary(path, { _didRefresh = false } = {}) {
+    const headers = new Headers({});
+    const accessToken = await this.getAccessToken();
+    headers.set("Authorization", `Bearer ${accessToken}`);
+
+    const url = await this.constructURI(path);
+    const res = await this._xhrFetch(url, {
+      method: "GET",
+      headers,
+      responseType: "arraybuffer",
+    });
+
+    if (res.ok) {
+      return res.arrayBuffer();
+    }
+
+    if ((res.status === 403 || res.status === 401) && !_didRefresh) {
+      await this._refreshSession();
+      return this._fetchBinary(path, { _didRefresh: true });
+    }
+
+    throw new Error(`Fetch GET ${path} failed (${res.status})`);
   },
 
   /**

--- a/toolkit/components/enterprise/modules/ConsoleClient.sys.mjs
+++ b/toolkit/components/enterprise/modules/ConsoleClient.sys.mjs
@@ -158,6 +158,8 @@ export const ConsoleClient = {
       DEVICE_POSTURE: "/sso/device_posture",
       WHOAMI: "/api/browser/whoami",
       FXACCOUNT: "/api/browser/account",
+      // Right now we always pass 0.0.0 as the current version
+      // to the console because we don't cache it on disk.
       DLP_WASM: `/api/browser/content-analysis-wasm/update/${majorMinorPatchVersion}/${Services.appinfo.appBuildID}/0.0.0`,
     };
   },

--- a/toolkit/components/enterprise/modules/ConsoleClient.sys.mjs
+++ b/toolkit/components/enterprise/modules/ConsoleClient.sys.mjs
@@ -143,7 +143,7 @@ export const ConsoleClient = {
    */
   get _paths() {
     // Strip off any trailing "a1", etc.
-    let majorMinorPatchVersion = Services.appinfo.appBuildID.replace(
+    let majorMinorPatchVersion = Services.appinfo.version.replace(
       /[a-zA-Z].*$/,
       ""
     );
@@ -158,7 +158,7 @@ export const ConsoleClient = {
       DEVICE_POSTURE: "/sso/device_posture",
       WHOAMI: "/api/browser/whoami",
       FXACCOUNT: "/api/browser/account",
-      DLP_WASM: `/api/browser/content-analysis-wasm/update/156.0/${majorMinorPatchVersion}/0.0.0`,
+      DLP_WASM: `/api/browser/content-analysis-wasm/update/${majorMinorPatchVersion}/${Services.appinfo.appBuildID}/0.0.0`,
     };
   },
 


### PR DESCRIPTION
### Description

Bugzilla: Bug-2044493

Fetch DLP WASM module from the console instead of from an installed extension.


### Testing <!-- OPTIONAL -->

* [ ] Added tests <- I did not add any tests but tweaked the existing ones and verified that they still pass
* [x] Manual testing performed