### PR TITLE
Bug 2066424 - Remove the Firefox VPN section from about:preferences on Enterprise builds

### DIFF
--- a/browser/components/preferences/config/privacy.mjs
+++ b/browser/components/preferences/config/privacy.mjs
@@ -1505,6 +1505,9 @@ SettingGroupManager.registerGroups({
     l10nId: "ip-protection-description-1",
     headingLevel: 2,
     supportPage: "built-in-vpn",
+    get hidden() {
+      return lazy.AppConstants.MOZ_ENTERPRISE;
+    },
     items: [
       {
         id: "ipProtectionNotOptedInSection",

--- a/browser/components/preferences/privacy.inc.xhtml
+++ b/browser/components/preferences/privacy.inc.xhtml
@@ -398,7 +398,9 @@
 <html:setting-group groupid="nonTechnicalPrivacy2" data-category="panePrivacy" hidden="true" data-srd-migrated=""/>
 
 <!-- Firefox VPN - IP Protection -->
+#ifndef MOZ_ENTERPRISE
 <html:setting-group groupid="ipprotection" data-category="panePrivacy" data-subcategory="vpn" hidden="true" data-srd-migrated=""></html:setting-group>
+#endif
 
 <html:setting-group groupid="cookiesAndSiteData" data-category="panePrivacy" hidden="true" data-srd-groupid="cookiesAndSiteData2"/>
 <html:setting-group groupid="cookiesAndSiteData2" data-category="panePrivacy" hidden="true" data-srd-migrated="" />

--- a/browser/components/preferences/tests/privacy/browser-srd.toml
+++ b/browser/components/preferences/tests/privacy/browser-srd.toml
@@ -30,6 +30,7 @@ tags = "os_integration"
 ["browser_privacy_history_search_l10n_ids.js"]
 
 ["browser_privacy_ipprotection.js"]
+skip-if = ["enterprise"] # Enterprise builds repurpose the VPN as the Access Connector and hide the VPN section in the privacy preferences.
 
 ["browser_privacy_passwordGenerationAndAutofill_srd.js"]
 

--- a/browser/components/preferences/tests/privacy/browser.toml
+++ b/browser/components/preferences/tests/privacy/browser.toml
@@ -46,6 +46,7 @@ skip-if = [
 ["browser_privacy_gpc.js"]
 
 ["browser_privacy_ipprotection.js"]
+skip-if = ["enterprise"] # Enterprise builds repurpose the VPN as the Access Connector and hide the VPN section in the privacy preferences.
 
 ["browser_privacy_passwordGenerationAndAutofill.js"]
 


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2066424

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

The FxVPN/IPP code is repurposed as the AccessConnector, which is configurable by policy only. The VPN section in `about:preferences` is irrelevant to Enterprise regardless of preference or policy configuration and should be removed. 

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

<img width="1007" height="688" alt="about-preferences-with-vpn" src="https://github.com/user-attachments/assets/d557fc79-ae46-417f-bc94-19d6d4838705" />

_Before_

<img width="1007" height="688" alt="about-preferences-without-vpn" src="https://github.com/user-attachments/assets/86a4a66a-b983-4f10-9b6c-4f7de9c94ac5" />

_After_

---

### Testing <!-- OPTIONAL -->

* [ ] Added tests
* [x] Manual testing performed


**Steps to verify changes:**
1. Open browser
2. Navigate to `about:preferences#privacy` or search for "vpn"

**Expected result:**

"Built-in VPN" section is not present in `about:preferences`.

Try run: https://treeherder.mozilla.org/jobs?repo=enterprise-firefox-try&revision=4c4b217454ecdf203ef7498b856324edc821a94d