### PR TITLE
Bug 2068283 - Generic console support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1423,6 +1423,7 @@ dependencies = [
  "cocoabind",
  "crashping",
  "embed-manifest",
+ "enterprise-console",
  "env_logger",
  "flate2",
  "fluent",
@@ -2117,6 +2118,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "enterprise-console"
+version = "0.1.0"
+dependencies = [
+ "serde_json",
+]
+
+[[package]]
 name = "enum-map"
 version = "2.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2313,6 +2321,7 @@ name = "felt"
 version = "0.1.0"
 dependencies = [
  "cstr",
+ "enterprise-console",
  "env_logger",
  "ipc-channel",
  "libc",

--- a/browser/branding/enterprise/byteshift.py
+++ b/browser/branding/enterprise/byteshift.py
@@ -6,7 +6,10 @@ import buildconfig
 
 # Byte shift value applied to AutoConfig files. Must match the default of the
 # general.config.obscure_value preference, which the browser subtracts when
-# reading the file.
+# reading the file, and DEFAULT_OBSCURE_VALUE in the enterprise-console crate
+# (toolkit/components/enterprise/rust), which decodes the file for the early
+# startup and crash reporter consumers. The generic console address
+# placeholder below is CONSOLE_ADDRESS_PLACEHOLDER in that crate.
 OBSCURE_VALUE = 13
 
 
@@ -20,8 +23,8 @@ def generate(output, input_path):
     the URL changes. `output` is a binary file object provided by the build
     system.
     """
-    console_url = buildconfig.substs["MOZ_ENTERPRISE_CONSOLE_URL"]
     with open(input_path, "rb") as fh:
         data = fh.read()
+    console_url = buildconfig.substs["MOZ_ENTERPRISE_CONSOLE_URL"]
     data = data.replace(b"@MOZ_ENTERPRISE_CONSOLE_URL@", console_url.encode("utf-8"))
     output.write(bytes((byte + OBSCURE_VALUE) & 0xFF for byte in data))

--- a/browser/components/tests/marionette/test_no_errors_clean_profile.py
+++ b/browser/components/tests/marionette/test_no_errors_clean_profile.py
@@ -83,6 +83,15 @@ known_errors = [
     {"message": "_refreshSession()"},
     {"message": "Unable to update user icon in badge without user information"},
     {"message": "enterprise.logo_url pref is not set, skipping logo update"},
+    {
+        "message": "Failed to resolve the console address, Error: Console address is the generic placeholder and no stored address exists"
+    },
+    {
+        "message": "Error in processing browser-before-ui-startup for EnterpriseEndpoints.init"
+    },
+    {
+        "message": "Error: Console address is the generic placeholder and no stored address exists"
+    },
 ]
 
 # Same rules apply here - please don't add anything! - but headless runs

--- a/browser/moz.configure
+++ b/browser/moz.configure
@@ -76,7 +76,7 @@ set_define("MOZ_ENTERPRISE", enable_enterprise)
 imply_option("--with-crashreporter-url", "", when="--enable-enterprise")
 
 default_enterprise_console = dependable(
-    "https://stage.fx-enterprise.nonprod.webservices.mozgcp.net"
+    "FIREFOX_ENTERPRISE_GENERIC"
 )
 
 option(
@@ -94,9 +94,15 @@ option(
 def enterprise_console_url(value, default_url):
     # --disable-enterprise-console or an empty value falls back to the default.
     url = value[0] if value and value[0] else default_url
-    if not url.startswith("https://"):
+    if not any(
+        [
+            url.startswith("https://"),
+            url.startswith("http://"),
+            url == "FIREFOX_ENTERPRISE_GENERIC",
+        ]
+    ):
         die(
-            "--with-enterprise-console-url must be a https:// URL, got %s",
+            "--with-enterprise-console-url must be a http(s):// URL, got %s",
             url,
         )
     # The value is interpolated into a JS string literal in firefox.cfg.

--- a/testing/enterprise/base_test.py
+++ b/testing/enterprise/base_test.py
@@ -61,6 +61,7 @@ class Environment(Enum):
 class EnterpriseTestsBase(MarionetteTestCase):
     def setUp(self):
         os.environ.update({"MOZ_DISABLE_NONLOCAL_CONNECTIONS": "0"})
+        os.environ.update({"MOZ_ENTERPRISE_CONSOLE_URL": "http://127.0.0.1:1"})
 
         if getattr(self, "EXTRA_ENV", None):
             self._saved_env = deepcopy(os.environ)
@@ -128,6 +129,7 @@ class EnterpriseTestsBase(MarionetteTestCase):
             self.marionette.instance.prefs = None
 
         del os.environ["MOZ_DISABLE_NONLOCAL_CONNECTIONS"]
+        del os.environ["MOZ_ENTERPRISE_CONSOLE_URL"]
 
         self.marionette.quit(in_app=False, clean=True)
 

--- a/testing/enterprise/test_felt_updates_autoconfig.py
+++ b/testing/enterprise/test_felt_updates_autoconfig.py
@@ -12,9 +12,19 @@ sys.path.append(os.path.dirname(__file__))
 from base_test import Environment, decode_autoconfig
 from felt_tests import FeltTests
 
+# Placeholder marking a generic (non-repacked) build; keep in sync with
+# ENTERPRISE_CONSOLE_PLACEHOLDER in nsXULAppAPI.h.
+CONSOLE_ADDRESS_PLACEHOLDER = "FIREFOX_ENTERPRISE_GENERIC"
+
+# Console address FELT resolves when the shipped AutoConfig file holds the
+# placeholder; local builds are generic so this keeps the console setup dialog
+# from blocking startup.
+ENV_CONSOLE_ADDRESS = "https://console.autoconfig.example.com"
+
 
 class FeltUpdatesAutoConfig(FeltTests):
     KEEP_AUTOCONFIG = True
+    EXTRA_ENV = {"MOZ_ENTERPRISE_CONSOLE_URL": ENV_CONSOLE_ADDRESS}
 
     def test_felt_updates_autoconfig(self):
         self.run_verify_felt_app_update_url()
@@ -52,6 +62,10 @@ class FeltUpdatesAutoConfig(FeltTests):
         )
 
         autoconfig_console_addr = self.get_autoconfig_console_address()
+        if autoconfig_console_addr == CONSOLE_ADDRESS_PLACEHOLDER:
+            # Generic build: the address comes from the environment override
+            # (or the console setup dialog, out of scope here), not the cfg.
+            autoconfig_console_addr = ENV_CONSOLE_ADDRESS
         autoconfig_console_update_url = f"{autoconfig_console_addr}/{update_url_end}"
         assert update_url == autoconfig_console_update_url, (
             f"FELT has Console-based update URL read from AutoConfig: {update_url} == {autoconfig_console_update_url}"

--- a/testing/mozharness/configs/marionette/enterprise_config.py
+++ b/testing/mozharness/configs/marionette/enterprise_config.py
@@ -17,6 +17,9 @@ config = {
             ],
             "run_filename": "",
             "testsdir": "marionette",
+            "env": {
+                "MOZ_ENTERPRISE_CONSOLE_URL": "http://127.0.0.1:1",
+            },
         },
     },
 }

--- a/toolkit/components/enterprise/modules/ConsoleClient.sys.mjs
+++ b/toolkit/components/enterprise/modules/ConsoleClient.sys.mjs
@@ -35,6 +35,36 @@ ChromeUtils.defineLazyGetter(lazy, "log", () => {
 export const CONSOLE_ADDRESS_PREF = "enterprise.console.address";
 
 /**
+ * Placeholder value the pref holds on generic (non-repacked) builds, where
+ * the AutoConfig file does not bake in a real console address. The actual
+ * address then comes from the MOZ_ENTERPRISE_CONSOLE_URL environment
+ * variable or from felt.json, filled in by the pre-profile console setup
+ * dialog. Keep in sync with CONSOLE_ADDRESS_PLACEHOLDER in the
+ * enterprise-console crate (toolkit/components/enterprise/rust), which holds
+ * this resolution logic for the native consumers; resolveConsoleAddress below
+ * mirrors it in JS.
+ */
+export const CONSOLE_ADDRESS_PLACEHOLDER = "FIREFOX_ENTERPRISE_GENERIC";
+
+async function resolveConsoleAddress(prefValue) {
+  if (prefValue !== CONSOLE_ADDRESS_PLACEHOLDER) {
+    return prefValue;
+  }
+  const envUrl = Services.env.get("MOZ_ENTERPRISE_CONSOLE_URL");
+  if (envUrl) {
+    return envUrl;
+  }
+  await lazy.FeltStorage.init();
+  const storedUrl = lazy.FeltStorage.getConsoleAddress();
+  if (!storedUrl) {
+    throw new Error(
+      "Console address is the generic placeholder and no stored address exists"
+    );
+  }
+  return storedUrl;
+}
+
+/**
  * Error logged when user needs to reauthenticate to obtain new token data
  */
 class ReauthRequiredError extends Error {
@@ -100,7 +130,7 @@ export const ConsoleClient = {
       this._consoleUriReadyPromise = new Promise((resolve, reject) => {
         try {
           const consoleURI = Services.prefs.getStringPref(CONSOLE_ADDRESS_PREF);
-          resolve(consoleURI);
+          resolve(resolveConsoleAddress(consoleURI));
         } catch (e) {
           lazy.log.warn(`Missing console URI. Waiting on pref change.`);
           const consolePrefObserver = {
@@ -115,7 +145,7 @@ export const ConsoleClient = {
                   try {
                     const consoleURI =
                       Services.prefs.getStringPref(CONSOLE_ADDRESS_PREF);
-                    resolve(consoleURI);
+                    resolve(resolveConsoleAddress(consoleURI));
                   } catch (ex) {
                     lazy.log.error(
                       `Critical misconfiguration: Missing console URI`
@@ -128,6 +158,13 @@ export const ConsoleClient = {
           };
           Services.prefs.addObserver(CONSOLE_ADDRESS_PREF, consolePrefObserver);
         }
+      });
+      // A failure (e.g. felt.json unreadable at that instant) must not be
+      // cached for the rest of the session: clear the slot so the next
+      // access retries the resolution. Callers still see the rejection.
+      this._consoleUriReadyPromise.catch(e => {
+        lazy.log.error("Failed to resolve the console address", e);
+        this._consoleUriReadyPromise = null;
       });
     }
     return this._consoleUriReadyPromise.then(url => new URL(url));

--- a/toolkit/components/enterprise/rust/enterprise-console/Cargo.toml
+++ b/toolkit/components/enterprise/rust/enterprise-console/Cargo.toml
@@ -1,0 +1,12 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+[package]
+name = "enterprise-console"
+version = "0.1.0"
+edition = "2021"
+license = "MPL-2.0"
+
+[dependencies]
+serde_json = "1"

--- a/toolkit/components/enterprise/rust/enterprise-console/src/lib.rs
+++ b/toolkit/components/enterprise/rust/enterprise-console/src/lib.rs
@@ -1,0 +1,348 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+//! Shared logic for obtaining the enterprise console address.
+//!
+//! A repack bakes the console address into the AutoConfig file
+//! (`firefox.cfg`); on generic builds the file holds
+//! [`CONSOLE_ADDRESS_PLACEHOLDER`] instead, and the address is resolved from
+//! the [`CONSOLE_ADDRESS_ENV`] environment variable or from the value the
+//! console setup dialog persisted in `felt.json`. This crate keeps that
+//! resolution identical for every native consumer: the browser (through the
+//! felt crate's FFI, used by CreateAppData.cpp) and the standalone crash
+//! reporter client. `resolveConsoleAddress` in ConsoleClient.sys.mjs mirrors
+//! it in JS.
+//!
+//! The crate is IO-free: callers hand in file contents and the environment
+//! value, so each consumer keeps its own file and environment access (the
+//! crash reporter mocks both in its tests).
+
+/// The pref holding the enterprise console address, set by the AutoConfig
+/// file.
+pub const CONSOLE_ADDRESS_PREF: &str = "enterprise.console.address";
+
+/// Placeholder address in the AutoConfig file of generic (non-repacked)
+/// builds. Keep in sync with CONSOLE_ADDRESS_PLACEHOLDER in
+/// ConsoleClient.sys.mjs and the placeholder in
+/// browser/branding/enterprise/byteshift.py.
+pub const CONSOLE_ADDRESS_PLACEHOLDER: &str = "FIREFOX_ENTERPRISE_GENERIC";
+
+/// Environment variable providing the console address on generic builds
+/// (used by test harnesses).
+pub const CONSOLE_ADDRESS_ENV: &str = "MOZ_ENTERPRISE_CONSOLE_URL";
+
+/// Storage file in the user application data directory where the console
+/// setup dialog persists the address on generic builds.
+pub const FELT_STORAGE_FILENAME: &str = "felt.json";
+
+/// Key holding the console address in the felt storage file. Keep in sync
+/// with FeltStorage.sys.mjs.
+pub const FELT_CONSOLE_ADDRESS_KEY: &str = "consoleAddress";
+
+/// Default byte shift applied to AutoConfig files
+/// (`general.config.obscure_value`). Keep in sync with OBSCURE_VALUE in
+/// browser/branding/enterprise/byteshift.py.
+pub const DEFAULT_OBSCURE_VALUE: u8 = 13;
+
+/// Pref-setting functions an AutoConfig file may use to set a string pref.
+const PREF_FUNCTIONS: &[&str] = &["lockPref", "defaultPref", "pref"];
+
+/// Extract the console address from the raw contents of an AutoConfig file
+/// without evaluating it.
+///
+/// AutoConfig files are byte shifted by `general.config.obscure_value` and
+/// have an intentionally unparseable first line; the shift is undone (trying
+/// the default value, then plaintext) and the file scanned for the pref call.
+/// On generic builds this yields [`CONSOLE_ADDRESS_PLACEHOLDER`]; pass the
+/// result through [`resolve_console_address`].
+pub fn console_address_from_autoconfig(contents: &[u8]) -> Option<String> {
+    for shift in [DEFAULT_OBSCURE_VALUE, 0] {
+        let decoded: Vec<u8> = contents.iter().map(|b| b.wrapping_sub(shift)).collect();
+        let Ok(text) = String::from_utf8(decoded) else {
+            continue;
+        };
+        for func in PREF_FUNCTIONS {
+            if let Some(value) = find_string_pref_call(&text, func, CONSOLE_ADDRESS_PREF) {
+                return Some(value.to_owned());
+            }
+        }
+    }
+    None
+}
+
+/// Why [`resolve_console_address`] or [`stored_console_address`] could not
+/// produce an address. Callers treat every variant as "console setup needed";
+/// the variant names the cause for logging.
+#[derive(Debug)]
+pub enum ResolveError {
+    /// felt.json could not be read. `std::io::ErrorKind::NotFound` is the
+    /// expected first-run state; other kinds are real problems.
+    FeltStorageRead(std::io::Error),
+    /// felt.json exists but is not parseable JSON.
+    FeltStorageCorrupt,
+    /// felt.json holds no (non-empty) console address.
+    NoStoredAddress,
+}
+
+impl std::fmt::Display for ResolveError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ResolveError::FeltStorageRead(e) => {
+                write!(f, "could not read the felt storage file: {e}")
+            }
+            ResolveError::FeltStorageCorrupt => {
+                write!(f, "the felt storage file is not parseable JSON")
+            }
+            ResolveError::NoStoredAddress => {
+                write!(f, "the felt storage file holds no console address")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ResolveError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            ResolveError::FeltStorageRead(e) => Some(e),
+            _ => None,
+        }
+    }
+}
+
+impl ResolveError {
+    /// The expected setup-needed state: no felt.json yet, or one without an
+    /// address. Everything else points at a real problem worth surfacing.
+    pub fn is_expected_first_run(&self) -> bool {
+        match self {
+            ResolveError::FeltStorageRead(e) => e.kind() == std::io::ErrorKind::NotFound,
+            ResolveError::FeltStorageCorrupt => false,
+            ResolveError::NoStoredAddress => true,
+        }
+    }
+}
+
+/// Resolve a console address that may be [`CONSOLE_ADDRESS_PLACEHOLDER`].
+///
+/// A real address is returned unchanged. The placeholder resolves to
+/// `env_value` (the value of [`CONSOLE_ADDRESS_ENV`]) when non-empty, then to
+/// the address stored in felt.json, whose contents `read_felt_json` supplies
+/// (called only when needed). The error says why the placeholder could not be
+/// resolved; the browser then shows the console setup dialog.
+pub fn resolve_console_address(
+    address: &str,
+    env_value: Option<&str>,
+    read_felt_json: impl FnOnce() -> Result<Vec<u8>, std::io::Error>,
+) -> Result<String, ResolveError> {
+    if address != CONSOLE_ADDRESS_PLACEHOLDER {
+        return Ok(address.to_owned());
+    }
+    if let Some(url) = env_value {
+        if !url.is_empty() {
+            return Ok(url.to_owned());
+        }
+    }
+    stored_console_address(&read_felt_json().map_err(ResolveError::FeltStorageRead)?)
+}
+
+/// Read the console address out of felt.json contents.
+pub fn stored_console_address(felt_json: &[u8]) -> Result<String, ResolveError> {
+    let json: serde_json::Value =
+        serde_json::from_slice(felt_json).map_err(|_| ResolveError::FeltStorageCorrupt)?;
+    match json.get(FELT_CONSOLE_ADDRESS_KEY).and_then(|v| v.as_str()) {
+        Some(url) if !url.is_empty() => Ok(url.to_owned()),
+        _ => Err(ResolveError::NoStoredAddress),
+    }
+}
+
+/// Outcome of [`remove_stored_console_address`].
+pub enum RemoveStoredAddress {
+    /// No address was stored (including unparseable contents); nothing to
+    /// write back.
+    AlreadyAbsent,
+    /// The address was removed; the new felt.json contents to write back.
+    Removed(String),
+    /// The contents are not a JSON object; nothing can be removed.
+    Invalid,
+}
+
+/// Remove the console address from felt.json contents, keeping other keys.
+pub fn remove_stored_console_address(felt_json: &[u8]) -> RemoveStoredAddress {
+    let Ok(mut json) = serde_json::from_slice::<serde_json::Value>(felt_json) else {
+        return RemoveStoredAddress::AlreadyAbsent;
+    };
+    let Some(obj) = json.as_object_mut() else {
+        return RemoveStoredAddress::Invalid;
+    };
+    if obj.remove(FELT_CONSOLE_ADDRESS_KEY).is_none() {
+        return RemoveStoredAddress::AlreadyAbsent;
+    }
+    RemoveStoredAddress::Removed(json.to_string())
+}
+
+/// Find the string value of a `func("pref", "value");` call, ignoring calls
+/// setting other prefs and occurrences of the pref name in other positions.
+fn find_string_pref_call<'a>(contents: &'a str, func: &str, pref: &str) -> Option<&'a str> {
+    let opener = format!("{func}(");
+    let mut search_content = contents;
+    loop {
+        let (before, s) = search_content.split_once(&format!("\"{pref}\""))?;
+        if !before.trim().ends_with(&opener) {
+            search_content = s;
+            continue;
+        }
+        let s = s.trim_start_matches(|c: char| c.is_whitespace() || c == ',');
+        let (content, _) = s.split_once(");")?;
+        return content.trim().strip_prefix('"')?.strip_suffix('"');
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn encode(plaintext: &str) -> Vec<u8> {
+        plaintext
+            .bytes()
+            .map(|b| b.wrapping_add(DEFAULT_OBSCURE_VALUE))
+            .collect()
+    }
+
+    const CFG: &str = "// first line is ignored\n\
+         lockPref(\"enterprise.console.address\", \"https://console.example.com/foo/\");";
+
+    #[test]
+    fn autoconfig_encoded() {
+        assert_eq!(
+            console_address_from_autoconfig(&encode(CFG)).as_deref(),
+            Some("https://console.example.com/foo/")
+        );
+    }
+
+    #[test]
+    fn autoconfig_plaintext() {
+        assert_eq!(
+            console_address_from_autoconfig(CFG.as_bytes()).as_deref(),
+            Some("https://console.example.com/foo/")
+        );
+    }
+
+    #[test]
+    fn autoconfig_default_pref_function() {
+        let cfg = r#"defaultPref("enterprise.console.address", "https://d.example.com/");"#;
+        assert_eq!(
+            console_address_from_autoconfig(cfg.as_bytes()).as_deref(),
+            Some("https://d.example.com/")
+        );
+    }
+
+    #[test]
+    fn autoconfig_ignores_other_prefs_and_positions() {
+        let cfg = "lockPref(\"other.pref\", \"enterprise.console.address\");\n\
+             lockPref(\"enterprise.console.address\", \"https://real.example.com/\");";
+        assert_eq!(
+            console_address_from_autoconfig(cfg.as_bytes()).as_deref(),
+            Some("https://real.example.com/")
+        );
+    }
+
+    #[test]
+    fn autoconfig_missing_pref() {
+        assert_eq!(console_address_from_autoconfig(b"// nothing here"), None);
+    }
+
+    #[test]
+    fn resolve_real_address_passes_through() {
+        assert_eq!(
+            resolve_console_address("https://console.example.com/", None, || panic!(
+                "must not read felt.json"
+            ))
+            .unwrap(),
+            "https://console.example.com/"
+        );
+    }
+
+    #[test]
+    fn resolve_placeholder_from_environment() {
+        assert_eq!(
+            resolve_console_address(
+                CONSOLE_ADDRESS_PLACEHOLDER,
+                Some("https://env.example.com/"),
+                || panic!("must not read felt.json")
+            )
+            .unwrap(),
+            "https://env.example.com/"
+        );
+    }
+
+    #[test]
+    fn resolve_placeholder_from_felt_storage() {
+        assert_eq!(
+            resolve_console_address(CONSOLE_ADDRESS_PLACEHOLDER, Some(""), || Ok(
+                br#"{"consoleAddress": "https://stored.example.com/"}"#.to_vec()
+            ))
+            .unwrap(),
+            "https://stored.example.com/"
+        );
+    }
+
+    #[test]
+    fn resolve_placeholder_unresolvable_names_the_cause() {
+        let no_address = resolve_console_address(CONSOLE_ADDRESS_PLACEHOLDER, None, || {
+            Ok(br#"{"deviceId": "abc"}"#.to_vec())
+        });
+        assert!(matches!(&no_address, Err(ResolveError::NoStoredAddress)));
+        assert!(no_address.unwrap_err().is_expected_first_run());
+
+        let missing_file = resolve_console_address(CONSOLE_ADDRESS_PLACEHOLDER, None, || {
+            Err(std::io::Error::from(std::io::ErrorKind::NotFound))
+        });
+        assert!(matches!(
+            &missing_file,
+            Err(ResolveError::FeltStorageRead(_))
+        ));
+        assert!(missing_file.unwrap_err().is_expected_first_run());
+
+        let unreadable_file = resolve_console_address(CONSOLE_ADDRESS_PLACEHOLDER, None, || {
+            Err(std::io::Error::from(std::io::ErrorKind::PermissionDenied))
+        });
+        assert!(!unreadable_file.unwrap_err().is_expected_first_run());
+
+        let corrupt = resolve_console_address(CONSOLE_ADDRESS_PLACEHOLDER, None, || {
+            Ok(b"not json".to_vec())
+        });
+        assert!(matches!(&corrupt, Err(ResolveError::FeltStorageCorrupt)));
+        assert!(!corrupt.unwrap_err().is_expected_first_run());
+    }
+
+    #[test]
+    fn remove_stored_address_keeps_other_keys() {
+        let json = br#"{"consoleAddress": "https://x.example.com/", "deviceId": "abc"}"#;
+        match remove_stored_console_address(json) {
+            RemoveStoredAddress::Removed(new_json) => {
+                assert_eq!(new_json, r#"{"deviceId":"abc"}"#);
+            }
+            _ => panic!("expected Removed"),
+        }
+    }
+
+    #[test]
+    fn remove_stored_address_absent() {
+        assert!(matches!(
+            remove_stored_console_address(br#"{"deviceId": "abc"}"#),
+            RemoveStoredAddress::AlreadyAbsent
+        ));
+        assert!(matches!(
+            remove_stored_console_address(b"not json"),
+            RemoveStoredAddress::AlreadyAbsent
+        ));
+    }
+
+    #[test]
+    fn remove_stored_address_invalid() {
+        assert!(matches!(
+            remove_stored_console_address(b"[1, 2]"),
+            RemoveStoredAddress::Invalid
+        ));
+    }
+}

--- a/toolkit/components/enterprise/tests/browser/browser.toml
+++ b/toolkit/components/enterprise/tests/browser/browser.toml
@@ -5,6 +5,8 @@ prefs = [
   "enterprise.log_level=Debug",
 ]
 
+["browser_console_setup_dialog.js"]
+
 ["browser_enterprise_endpoints.js"]
 
 ["browser_help_menu.js"]

--- a/toolkit/components/enterprise/tests/browser/browser_console_setup_dialog.js
+++ b/toolkit/components/enterprise/tests/browser/browser_console_setup_dialog.js
@@ -1,0 +1,177 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+const { FeltStorage } = ChromeUtils.importESModule(
+  "resource://gre/modules/enterprise/FeltStorage.sys.mjs"
+);
+const { sinon } = ChromeUtils.importESModule(
+  "resource://testing-common/Sinon.sys.mjs"
+);
+
+const DIALOG_URL = "chrome://felt/content/consoleSetup.xhtml";
+
+// Result slot contract with ShowEnterpriseConsoleSetup() in nsAppRunner.cpp.
+const RESULT_INDEX = 0;
+const RESULT_SAVED = 1;
+
+// Opens the console setup dialog the way ShowEnterpriseConsoleSetup() does,
+// minus the modal flag, which would block the test.
+async function openSetupDialog() {
+  const paramBlock = Cc["@mozilla.org/embedcomp/dialogparam;1"].createInstance(
+    Ci.nsIDialogParamBlock
+  );
+  const winPromise = BrowserTestUtils.domWindowOpenedAndLoaded(
+    null,
+    win => win.document.documentURI === DIALOG_URL
+  );
+  Services.ww.openWindow(
+    null,
+    DIALOG_URL,
+    "_blank",
+    "centerscreen,chrome,titlebar,resizable",
+    paramBlock
+  );
+  const win = await winPromise;
+  await SimpleTest.promiseFocus(win);
+
+  const doc = win.document;
+  const input = doc.getElementById("console-setup-address");
+  const saveBtn = doc.getElementById("console-setup-save-btn");
+  const quitBtn = doc.getElementById("console-setup-quit-btn");
+  const errorBar = doc.getElementById("console-setup-error");
+  await Promise.all([input.updateComplete, saveBtn.updateComplete]);
+
+  return { win, paramBlock, input, saveBtn, quitBtn, errorBar };
+}
+
+add_task(async function test_save_disabled_until_input() {
+  const { win, paramBlock, saveBtn, quitBtn } = await openSetupDialog();
+
+  ok(saveBtn.disabled, "Save is disabled while the input is empty");
+
+  EventUtils.synthesizeKey("KEY_Enter", {}, win);
+  ok(!win.closed, "Enter does not submit while Save is disabled");
+
+  EventUtils.sendString("h", win);
+  ok(!saveBtn.disabled, "Save is enabled once the input has text");
+
+  EventUtils.synthesizeKey("KEY_Backspace", {}, win);
+  ok(saveBtn.disabled, "Save is disabled again when the input is emptied");
+
+  const closed = BrowserTestUtils.domWindowClosed(win);
+  quitBtn.click();
+  await closed;
+  Assert.notEqual(
+    paramBlock.GetInt(RESULT_INDEX),
+    RESULT_SAVED,
+    "Quitting does not report a saved address"
+  );
+});
+
+add_task(async function test_rejects_invalid_addresses() {
+  const { win, paramBlock, saveBtn, errorBar } = await openSetupDialog();
+
+  for (const invalid of ["not a url", "ftp://ftp.example.com/"]) {
+    EventUtils.synthesizeKey("a", { accelKey: true }, win);
+    EventUtils.sendString(invalid, win);
+    ok(errorBar.hidden, `No error before trying to save "${invalid}"`);
+
+    saveBtn.click();
+    ok(!errorBar.hidden, `An error is shown for "${invalid}"`);
+    Assert.equal(
+      errorBar.getAttribute("data-l10n-id"),
+      "felt-console-setup-invalid-address",
+      "The error is the invalid address one"
+    );
+    ok(!win.closed, "The dialog stays open on an invalid address");
+  }
+
+  EventUtils.sendString("x", win);
+  ok(errorBar.hidden, "Typing again clears the error");
+
+  const closed = BrowserTestUtils.domWindowClosed(win);
+  EventUtils.synthesizeKey("KEY_Escape", {}, win);
+  await closed;
+  Assert.notEqual(
+    paramBlock.GetInt(RESULT_INDEX),
+    RESULT_SAVED,
+    "Escape does not report a saved address"
+  );
+});
+
+add_task(async function test_valid_address_persists_and_signals_relaunch() {
+  const sandbox = sinon.createSandbox();
+  const init = sandbox.stub(FeltStorage, "init").resolves();
+  const persist = sandbox.stub(FeltStorage, "persistConsoleAddress").resolves();
+
+  try {
+    const { win, paramBlock } = await openSetupDialog();
+
+    EventUtils.sendString("  https://console.example.com  ", win);
+
+    const closed = BrowserTestUtils.domWindowClosed(win);
+    EventUtils.synthesizeKey("KEY_Enter", {}, win);
+    await closed;
+
+    ok(init.calledBefore(persist), "Storage is initialized before persisting");
+    Assert.equal(persist.callCount, 1, "The address is persisted once");
+    Assert.equal(
+      persist.firstCall.args[0],
+      "https://console.example.com/",
+      "The persisted address is trimmed and normalized"
+    );
+    Assert.equal(
+      paramBlock.GetInt(RESULT_INDEX),
+      RESULT_SAVED,
+      "The dialog reports that an address was saved"
+    );
+  } finally {
+    sandbox.restore();
+  }
+});
+
+add_task(async function test_save_failure_shows_error_and_recovers() {
+  const sandbox = sinon.createSandbox();
+  sandbox.stub(FeltStorage, "init").resolves();
+  const persist = sandbox
+    .stub(FeltStorage, "persistConsoleAddress")
+    .rejects(new Error("disk full"));
+
+  try {
+    const { win, paramBlock, saveBtn, errorBar } = await openSetupDialog();
+
+    EventUtils.sendString("https://console.example.com/", win);
+    saveBtn.click();
+
+    await TestUtils.waitForCondition(
+      () => !errorBar.hidden,
+      "Waiting for the error bar after a failed save"
+    );
+    Assert.equal(
+      errorBar.getAttribute("data-l10n-id"),
+      "felt-console-setup-save-failed",
+      "The error is the save failure one"
+    );
+    ok(!saveBtn.disabled, "Save is re-enabled after a failure");
+    ok(!win.closed, "The dialog stays open after a failure");
+    Assert.notEqual(
+      paramBlock.GetInt(RESULT_INDEX),
+      RESULT_SAVED,
+      "A failed save is not reported as saved"
+    );
+
+    persist.resolves();
+    const closed = BrowserTestUtils.domWindowClosed(win);
+    saveBtn.click();
+    await closed;
+    Assert.equal(
+      paramBlock.GetInt(RESULT_INDEX),
+      RESULT_SAVED,
+      "Retrying after a failure saves and closes"
+    );
+  } finally {
+    sandbox.restore();
+  }
+});

--- a/toolkit/components/enterprise/tests/xpcshell/test_console_client_console_address.js
+++ b/toolkit/components/enterprise/tests/xpcshell/test_console_client_console_address.js
@@ -1,0 +1,140 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+// FeltStorage computes FELT_FILE_PATH from UAppData at import time, so the
+// key must point inside the test profile before the module is imported.
+const gDataHome = do_get_profile().clone();
+gDataHome.append("appdata");
+gDataHome.createUnique(Ci.nsIFile.DIRECTORY_TYPE, 0o755);
+Services.dirsvc.set("UAppData", gDataHome);
+
+const { ConsoleClient, CONSOLE_ADDRESS_PREF, CONSOLE_ADDRESS_PLACEHOLDER } =
+  ChromeUtils.importESModule(
+    "resource://gre/modules/enterprise/ConsoleClient.sys.mjs"
+  );
+const { FeltStorage } = ChromeUtils.importESModule(
+  "resource://gre/modules/enterprise/FeltStorage.sys.mjs"
+);
+const { TestUtils } = ChromeUtils.importESModule(
+  "resource://testing-common/TestUtils.sys.mjs"
+);
+
+const ENV_VAR = "MOZ_ENTERPRISE_CONSOLE_URL";
+
+// Test harnesses set MOZ_ENTERPRISE_CONSOLE_URL globally, so every scenario
+// must set it explicitly rather than rely on it being absent.
+const gOriginalEnv = Services.env.get(ENV_VAR);
+
+registerCleanupFunction(async () => {
+  Services.env.set(ENV_VAR, gOriginalEnv);
+  Services.prefs.clearUserPref(CONSOLE_ADDRESS_PREF);
+  await FeltStorage.uninit();
+  await IOUtils.remove(FeltStorage.FELT_FILE_PATH, { ignoreAbsent: true });
+});
+
+// Puts the pref, the environment variable and felt.json in the given state,
+// then returns the resolved console base URI promise.
+async function resolveWith({ pref, env = "", stored = null }) {
+  ConsoleClient._consoleUriReadyPromise = null;
+  Services.env.set(ENV_VAR, env);
+
+  await FeltStorage.uninit();
+  await IOUtils.remove(FeltStorage.FELT_FILE_PATH, { ignoreAbsent: true });
+  if (stored) {
+    await FeltStorage.init();
+    await FeltStorage.persistConsoleAddress(stored);
+    // Leave the storage uninitialized so the resolution reads it back from
+    // disk, like the post-dialog relaunch does.
+    await FeltStorage.uninit();
+  }
+
+  Services.prefs.setStringPref(CONSOLE_ADDRESS_PREF, pref);
+  return ConsoleClient.consoleBaseURI;
+}
+
+add_task(async function test_real_address_passes_through() {
+  const url = await resolveWith({
+    pref: "https://real.example.com/",
+    env: "https://env.example.com/",
+    stored: "https://stored.example.com/",
+  });
+  Assert.equal(
+    url.href,
+    "https://real.example.com/",
+    "A repacked build's baked-in address wins over environment and storage"
+  );
+});
+
+add_task(async function test_placeholder_resolves_from_environment() {
+  const url = await resolveWith({
+    pref: CONSOLE_ADDRESS_PLACEHOLDER,
+    env: "https://env.example.com/",
+    stored: "https://stored.example.com/",
+  });
+  Assert.equal(
+    url.href,
+    "https://env.example.com/",
+    "The placeholder resolves from the environment before storage"
+  );
+});
+
+add_task(async function test_placeholder_resolves_from_storage() {
+  const url = await resolveWith({
+    pref: CONSOLE_ADDRESS_PLACEHOLDER,
+    stored: "https://stored.example.com/",
+  });
+  Assert.equal(
+    url.href,
+    "https://stored.example.com/",
+    "The placeholder resolves from the address the setup dialog persisted"
+  );
+});
+
+add_task(async function test_placeholder_unresolvable_rejects_uncached() {
+  await Assert.rejects(
+    resolveWith({ pref: CONSOLE_ADDRESS_PLACEHOLDER }),
+    /no stored address/,
+    "The placeholder with no environment or stored address rejects"
+  );
+
+  await TestUtils.waitForCondition(
+    () => ConsoleClient._consoleUriReadyPromise === null,
+    "A failed resolution must not stay cached for the session"
+  );
+
+  // Once an address exists (the setup dialog saved one), the next access
+  // succeeds without a restart.
+  await FeltStorage.init();
+  await FeltStorage.persistConsoleAddress("https://recovered.example.com/");
+  const url = await ConsoleClient.consoleBaseURI;
+  Assert.equal(
+    url.href,
+    "https://recovered.example.com/",
+    "Resolution recovers once an address is stored"
+  );
+});
+
+add_task(async function test_waits_for_pref_to_appear() {
+  // AutoConfig sets the pref only once the pref service evaluates the file,
+  // so the client observes the pref when it is not there yet.
+  ConsoleClient._consoleUriReadyPromise = null;
+  Services.env.set(ENV_VAR, "");
+  Services.prefs.clearUserPref(CONSOLE_ADDRESS_PREF);
+
+  const promise = ConsoleClient.consoleBaseURI.then(url =>
+    Assert.equal(
+      url.href,
+      "https://late.example.com/",
+      "The address resolves once the pref appears"
+    )
+  );
+
+  Services.prefs.setStringPref(
+    CONSOLE_ADDRESS_PREF,
+    "https://late.example.com/"
+  );
+
+  await promise;
+});

--- a/toolkit/components/enterprise/tests/xpcshell/test_felt_storage_console_address.js
+++ b/toolkit/components/enterprise/tests/xpcshell/test_felt_storage_console_address.js
@@ -1,0 +1,92 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+// FeltStorage computes FELT_FILE_PATH from UAppData at import time, so the
+// key must point inside the test profile before the module is imported.
+const gDataHome = do_get_profile().clone();
+gDataHome.append("appdata");
+gDataHome.createUnique(Ci.nsIFile.DIRECTORY_TYPE, 0o755);
+Services.dirsvc.set("UAppData", gDataHome);
+
+const { FeltStorage } = ChromeUtils.importESModule(
+  "resource://gre/modules/enterprise/FeltStorage.sys.mjs"
+);
+
+const ADDRESS = "https://console.example.com/";
+
+async function resetStorage() {
+  if (FeltStorage._initialized) {
+    await FeltStorage._feltStorage.finalize();
+  }
+  await FeltStorage.uninit();
+  await IOUtils.remove(FeltStorage.FELT_FILE_PATH, { ignoreAbsent: true });
+}
+
+registerCleanupFunction(resetStorage);
+
+add_task(async function test_no_address_by_default() {
+  await resetStorage();
+  await FeltStorage.init();
+
+  Assert.strictEqual(
+    FeltStorage.getConsoleAddress(),
+    undefined,
+    "No console address is stored initially"
+  );
+});
+
+add_task(async function test_persist_writes_immediately() {
+  await resetStorage();
+  await FeltStorage.init();
+  await FeltStorage.persistConsoleAddress(ADDRESS);
+
+  // The console setup dialog relaunches right after persisting, so the
+  // address must already be on disk, without waiting for a deferred save.
+  const onDisk = await IOUtils.readJSON(FeltStorage.FELT_FILE_PATH);
+  Assert.equal(
+    onDisk.consoleAddress,
+    ADDRESS,
+    "The address is flushed to felt.json as soon as persist resolves"
+  );
+  Assert.equal(
+    FeltStorage.getConsoleAddress(),
+    ADDRESS,
+    "getConsoleAddress returns the persisted address"
+  );
+});
+
+add_task(async function test_persist_keeps_other_keys() {
+  await resetStorage();
+  await FeltStorage.init();
+
+  const deviceId = FeltStorage.getDeviceId();
+  FeltStorage.updateLastSignedInUserEmail("user@example.com");
+  await FeltStorage.persistConsoleAddress(ADDRESS);
+
+  const onDisk = await IOUtils.readJSON(FeltStorage.FELT_FILE_PATH);
+  Assert.equal(onDisk.consoleAddress, ADDRESS, "The address was written");
+  Assert.equal(onDisk.deviceId, deviceId, "The device id is preserved");
+  Assert.equal(
+    onDisk.lastSignedInUserEmail,
+    "user@example.com",
+    "The last signed in email is preserved"
+  );
+});
+
+add_task(async function test_address_survives_reload() {
+  await resetStorage();
+  await FeltStorage.init();
+  await FeltStorage.persistConsoleAddress(ADDRESS);
+
+  // A fresh init after the post-dialog relaunch must read the address back
+  // from disk.
+  await FeltStorage.uninit();
+  await FeltStorage.init();
+  Assert.equal(
+    FeltStorage.getConsoleAddress(),
+    ADDRESS,
+    "The persisted address is read back after a reload"
+  );
+});

--- a/toolkit/components/enterprise/tests/xpcshell/xpcshell.toml
+++ b/toolkit/components/enterprise/tests/xpcshell/xpcshell.toml
@@ -1,7 +1,12 @@
 [DEFAULT]
+environment = ["MOZ_BYPASS_FELT=1"]
 firefox-appdir = "browser"
 skip-if = [
   "os == 'android'",
 ]
+
+["test_console_client_console_address.js"]
+
+["test_felt_storage_console_address.js"]
 
 ["test_relaunch_enforcer.js"]

--- a/toolkit/components/felt/FeltStorage.sys.mjs
+++ b/toolkit/components/felt/FeltStorage.sys.mjs
@@ -12,6 +12,9 @@ ChromeUtils.defineESModuleGetters(lazy, {
  * Storage helper for reading and writing felt-related data to felt.json
  */
 export const FeltStorage = {
+  _initialized: false,
+
+  _feltStorage: null,
   /**
    * Absolute path to the felt.json file in the user's app-data directory (UAppData).
    *
@@ -23,9 +26,12 @@ export const FeltStorage = {
   ),
 
   async init() {
-    this._feltStorage = new lazy.JSONFile({
-      path: this.FELT_FILE_PATH,
-    });
+    if (!this._initialized) {
+      this._feltStorage = new lazy.JSONFile({
+        path: this.FELT_FILE_PATH,
+      });
+      this._initialized = true;
+    }
     await this._feltStorage.load();
   },
 
@@ -68,7 +74,31 @@ export const FeltStorage = {
     this._feltStorage.saveSoon();
   },
 
+  /**
+   * Gets the enterprise console address entered in the console setup dialog
+   * (if available). Only meaningful on generic builds, where the AutoConfig
+   * file does not provide a real address.
+   *
+   * @returns {string | undefined} url
+   */
+  getConsoleAddress() {
+    return this._feltStorage.data?.consoleAddress;
+  },
+
+  /**
+   * Persists the enterprise console address, writing felt.json immediately.
+   * Called from the pre-profile console setup dialog, which relaunches right
+   * after, so the write cannot be deferred to saveSoon().
+   *
+   * @param {string} url
+   */
+  async persistConsoleAddress(url) {
+    this._feltStorage.data.consoleAddress = url;
+    await this._feltStorage._save();
+  },
+
   async uninit() {
     this._feltStorage = {};
+    this._initialized = false;
   },
 };

--- a/toolkit/components/felt/content/consoleSetup.js
+++ b/toolkit/components/felt/content/consoleSetup.js
@@ -1,0 +1,102 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+const { FeltStorage } = ChromeUtils.importESModule(
+  "resource://gre/modules/enterprise/FeltStorage.sys.mjs"
+);
+
+// Result slot read by ShowEnterpriseConsoleSetup() in nsAppRunner.cpp:
+// 1 means an address was persisted and the application should relaunch,
+// anything else aborts startup.
+const RESULT_INDEX = 0;
+const RESULT_SAVED = 1;
+
+function parseConsoleAddress(value) {
+  let url;
+  try {
+    url = new URL(value.trim());
+  } catch (e) {
+    return null;
+  }
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    return null;
+  }
+  return url.href;
+}
+
+let saving = false;
+
+function showError(errorBar, l10nId) {
+  document.l10n.setAttributes(errorBar, l10nId);
+  errorBar.hidden = false;
+}
+
+async function save(paramBlock, addressInput, saveBtn, errorBar) {
+  if (saving) {
+    return;
+  }
+
+  const address = parseConsoleAddress(addressInput.value);
+  if (!address) {
+    showError(errorBar, "felt-console-setup-invalid-address");
+    return;
+  }
+
+  saving = true;
+  saveBtn.disabled = true;
+  errorBar.hidden = true;
+  try {
+    await FeltStorage.init();
+    await FeltStorage.persistConsoleAddress(address);
+  } catch (e) {
+    console.error("Failed to persist the console address", e);
+    showError(errorBar, "felt-console-setup-save-failed");
+    saving = false;
+    saveBtn.disabled = false;
+    return;
+  }
+
+  paramBlock.SetInt(RESULT_INDEX, RESULT_SAVED);
+  window.close();
+}
+
+window.addEventListener("load", () => {
+  const paramBlock = window.arguments[0].QueryInterface(Ci.nsIDialogParamBlock);
+  const addressInput = document.getElementById("console-setup-address");
+  const saveBtn = document.getElementById("console-setup-save-btn");
+  const quitBtn = document.getElementById("console-setup-quit-btn");
+  const errorBar = document.getElementById("console-setup-error");
+
+  addressInput.focus();
+
+  addressInput.addEventListener("input", () => {
+    saveBtn.disabled = saving || addressInput.value.trim() === "";
+    errorBar.hidden = true;
+  });
+
+  // <moz-button> does not trigger the native "submit" event on <form>
+  // so we manually handle submission on button click and when Enter is pressed
+  saveBtn.addEventListener("click", () => {
+    save(paramBlock, addressInput, saveBtn, errorBar);
+  });
+  addressInput.addEventListener("keydown", e => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      if (!saveBtn.disabled) {
+        save(paramBlock, addressInput, saveBtn, errorBar);
+      }
+    }
+  });
+
+  quitBtn.addEventListener("click", () => {
+    window.close();
+  });
+  window.addEventListener("keydown", e => {
+    if (e.key === "Escape") {
+      window.close();
+    }
+  });
+});

--- a/toolkit/components/felt/content/consoleSetup.xhtml
+++ b/toolkit/components/felt/content/consoleSetup.xhtml
@@ -1,0 +1,89 @@
+<?xml version="1.0"?>
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at https://mozilla.org/MPL/2.0/. -->
+
+<html
+  xmlns="http://www.w3.org/1999/xhtml"
+  role="document"
+  class="system-font-size"
+  id="felt-console-setup-window"
+>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="Content-Security-Policy" content="default-src chrome:" />
+    <link
+      rel="stylesheet"
+      href="chrome://felt/content/styles/consoleSetup.css"
+    />
+    <link rel="localization" href="branding/brand.ftl" />
+    <link rel="localization" href="toolkit/enterprise/felt.ftl" />
+    <script
+      type="application/javascript"
+      src="chrome://global/content/customElements.js"
+    ></script>
+    <script
+      type="application/javascript"
+      src="chrome://felt/content/consoleSetup.js"
+    ></script>
+    <title data-l10n-id="felt-console-setup-window-title"></title>
+  </head>
+
+  <body>
+    <div class="felt">
+      <div class="felt-logo">
+        <div class="felt-logo__container"></div>
+      </div>
+      <div class="felt-main">
+        <div class="felt-card">
+          <div class="felt-login">
+            <div class="felt-login__email-pane">
+              <img class="enterprise-wordmark" />
+              <form class="felt-form">
+                <h1
+                  class="felt-form__title"
+                  data-l10n-id="felt-console-setup-title"
+                ></h1>
+                <div class="felt-form__elements">
+                  <p
+                    class="console-setup__description"
+                    data-l10n-id="felt-console-setup-description"
+                  ></p>
+                  <moz-input-text
+                    id="console-setup-address"
+                    data-l10n-id="felt-console-setup-input"
+                    class="fill-width"
+                  ></moz-input-text>
+                  <moz-button
+                    id="console-setup-save-btn"
+                    type="primary"
+                    class="fill-width"
+                    data-l10n-id="felt-console-setup-save-btn"
+                    disabled="true"
+                  ></moz-button>
+                  <moz-button
+                    id="console-setup-quit-btn"
+                    class="fill-width"
+                    data-l10n-id="felt-console-setup-quit-btn"
+                  ></moz-button>
+                  <moz-message-bar
+                    id="console-setup-error"
+                    class="fill-width"
+                    type="error"
+                    data-l10n-id="felt-console-setup-invalid-address"
+                    hidden=""
+                  ></moz-message-bar>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+        <div class="felt-footer">
+          <div id="felt-footer-content">
+            <span class="felt-powered-by" data-l10n-id="felt-powered-by"></span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </body>
+</html>

--- a/toolkit/components/felt/content/styles/consoleSetup.css
+++ b/toolkit/components/felt/content/styles/consoleSetup.css
@@ -1,0 +1,16 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/* The console setup dialog reuses the FELT window's look wholesale: same
+ * layout, branding assets, and colors. */
+@import url("chrome://felt/content/styles/felt.css");
+
+.console-setup__description {
+  margin: 0;
+  color: var(--text-color-deemphasized);
+}
+
+moz-message-bar[hidden] {
+  display: none;
+}

--- a/toolkit/components/felt/rust/Cargo.toml
+++ b/toolkit/components/felt/rust/Cargo.toml
@@ -16,6 +16,7 @@ thin-vec = "0.2.12"
 time = "0.3.36"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+enterprise-console = { path = "../../enterprise/rust/enterprise-console" }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/toolkit/components/felt/rust/felt.h
+++ b/toolkit/components/felt/rust/felt.h
@@ -6,6 +6,7 @@
 #define felt_h
 
 #include "nsISupportsUtils.h"  // for nsresult, etc.
+#include "nsStringFwd.h"
 
 extern "C" {
 
@@ -30,6 +31,15 @@ bool firefox_connect_to_felt(const char* server_name);
 void firefox_felt_connection_start_thread();
 
 bool firefox_felt_is_startup_complete();
+
+bool firefox_felt_clear_stored_console_url(const nsACString* aFeltJsonPath);
+
+bool firefox_felt_console_address_from_autoconfig(const nsACString* aContents,
+                                                  nsACString* aOutAddress);
+
+bool firefox_felt_resolve_console_address(const nsACString* aAddress,
+                                          const nsACString* aFeltJsonPath,
+                                          nsACString* aOutUrl);
 
 nsresult felt_constructor(REFNSIID iid, void** result);
 

--- a/toolkit/components/felt/rust/src/lib.rs
+++ b/toolkit/components/felt/rust/src/lib.rs
@@ -18,7 +18,6 @@ extern crate thin_vec;
 
 mod client;
 mod components;
-mod message;
 mod edr_checker;
 #[cfg(target_os = "linux")]
 mod edr_checker_linux;
@@ -26,6 +25,7 @@ mod edr_checker_linux;
 mod edr_checker_macos;
 #[cfg(target_os = "windows")]
 mod edr_checker_win;
+mod message;
 mod utils;
 
 pub use utils::{CONSOLE_URL, TOKENS};
@@ -149,6 +149,92 @@ pub extern "C" fn firefox_felt_is_startup_complete() -> bool {
         Some(client) => client.is_startup_complete(),
         None => {
             trace!("firefox_felt_is_startup_complete(): missing client, blocking startup");
+            false
+        }
+    }
+}
+
+/// Remove the persisted console URL from felt.json, keeping the other keys.
+/// Returns true when the value is gone (including when it was never there);
+/// false when the file could not be read or updated, so the stale URL may
+/// still be picked up.
+#[no_mangle]
+pub extern "C" fn firefox_felt_clear_stored_console_url(path: &nsstring::nsACString) -> bool {
+    let path = path.to_utf8();
+    let bytes = match std::fs::read(&*path) {
+        Ok(bytes) => bytes,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return true,
+        Err(e) => {
+            log::warn!("could not read {path} to clear the stored console URL: {e}");
+            return false;
+        }
+    };
+    use enterprise_console::RemoveStoredAddress;
+    match enterprise_console::remove_stored_console_address(&bytes) {
+        RemoveStoredAddress::AlreadyAbsent => true,
+        RemoveStoredAddress::Invalid => {
+            log::warn!("cannot clear the stored console URL: {path} is not a JSON object");
+            false
+        }
+        RemoveStoredAddress::Removed(json) => match std::fs::write(&*path, json) {
+            Ok(()) => true,
+            Err(e) => {
+                log::warn!("could not write {path} to clear the stored console URL: {e}");
+                false
+            }
+        },
+    }
+}
+
+/// Extract the console address from raw AutoConfig file contents (byte shift
+/// decoded, not evaluated). Backs XRE_ReadEnterpriseConsoleAddress.
+#[no_mangle]
+pub extern "C" fn firefox_felt_console_address_from_autoconfig(
+    contents: &nsstring::nsACString,
+    out_address: &mut nsstring::nsACString,
+) -> bool {
+    match enterprise_console::console_address_from_autoconfig(contents) {
+        Some(address) => {
+            out_address.assign(&address);
+            true
+        }
+        None => false,
+    }
+}
+
+/// Resolve a console address that may be the generic build placeholder, from
+/// the MOZ_ENTERPRISE_CONSOLE_URL environment variable or the URL
+/// persisted in felt.json at the given path. A real address is returned
+/// unchanged. Returns false when the placeholder cannot be resolved; the
+/// caller then shows the console setup dialog. Backs
+/// XRE_ParseEnterpriseServerURL.
+#[no_mangle]
+pub extern "C" fn firefox_felt_resolve_console_address(
+    address: &nsstring::nsACString,
+    felt_json_path: &nsstring::nsACString,
+    out_url: &mut nsstring::nsACString,
+) -> bool {
+    let path = felt_json_path.to_utf8();
+    match enterprise_console::resolve_console_address(
+        &address.to_utf8(),
+        std::env::var(enterprise_console::CONSOLE_ADDRESS_ENV)
+            .ok()
+            .as_deref(),
+        || std::fs::read(&*path),
+    ) {
+        Ok(url) => {
+            out_url.assign(&url);
+            true
+        }
+        Err(e) => {
+            // A missing felt.json or one without an address is the normal
+            // first-run state leading to the setup dialog; anything else
+            // means a saved address exists but cannot be used.
+            if e.is_expected_first_run() {
+                trace!("console address placeholder not resolvable yet: {e}");
+            } else {
+                log::warn!("could not resolve the console address placeholder: {e}");
+            }
             false
         }
     }

--- a/toolkit/crashreporter/client/app/Cargo.toml
+++ b/toolkit/crashreporter/client/app/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = "1.0"
 buildid_reader = { path = "../../../library/buildid_reader" }
 cfg-if = "1.0"
 crashping = { path = "../../crashping" }
+enterprise-console = { path = "../../../components/enterprise/rust/enterprise-console", optional = true }
 env_logger = { version = "0.10", default-features = false }
 flate2 = "1"
 fluent = "0.17.0"
@@ -63,7 +64,7 @@ features = [
 ]
 
 [features]
-enterprise = []
+enterprise = ["dep:enterprise-console"]
 # Required for tests
 mock = []
 

--- a/toolkit/crashreporter/client/app/src/config.rs
+++ b/toolkit/crashreporter/client/app/src/config.rs
@@ -132,6 +132,9 @@ pub struct Config {
     pub run_memtest: bool,
     /// The data directory.
     pub data_dir: Option<PathBuf>,
+    /// The user application data directory: the top-level Firefox directory
+    /// containing `profiles.ini` and the profiles.
+    pub app_data_dir: Option<PathBuf>,
     /// The events directory.
     pub events_dir: Option<PathBuf>,
     /// The profile directory in use when the crash occurred.
@@ -269,6 +272,25 @@ impl Config {
             }
         }
 
+        // Set the data dir if not already set.
+        // TODO bug 1910736: if we don't need to support VENDOR_KEY and PRODUCT_KEY in the extra
+        // file, it'd simplify the data_dir logic and things like glean initialization (which
+        // relies on the data dir).
+        let vendor = extra[VENDOR_KEY].as_str().unwrap_or(DEFAULT_VENDOR);
+        let product = extra[PRODUCT_KEY].as_str().unwrap_or(DEFAULT_PRODUCT);
+        if self.data_dir.is_none() {
+            self.data_dir = Some(self.get_data_dir(vendor, product)?);
+            self.update_log_file();
+        }
+        // Computed rather than derived from `data_dir`, which may be an
+        // arbitrary directory passed in the environment.
+        if self.app_data_dir.is_none() {
+            match self.get_app_data_dir(vendor, product) {
+                Ok(dir) => self.app_data_dir = Some(dir),
+                Err(e) => log::warn!("could not determine the application data directory: {e:#}"),
+            }
+        }
+
         // Enterprise builds normally get the submission endpoint from the
         // ServerURL annotation. Before the browser derives it from the console
         // address (e.g. a startup crash) it is still the domainless placeholder
@@ -277,23 +299,13 @@ impl Config {
         #[cfg(feature = "enterprise")]
         {
             let current = self.report_url.as_deref().and_then(OsStr::to_str);
-            match crate::enterprise_prefs::console_report_url(current) {
+            match crate::enterprise_prefs::console_report_url(current, self.app_data_dir.as_deref())
+            {
                 Ok(url) => self.report_url = Some(url.into()),
                 Err(e) => {
                     log::warn!("could not resolve enterprise console report URL: {e:#}")
                 }
             }
-        }
-
-        // Set the data dir if not already set.
-        // TODO bug 1910736: if we don't need to support VENDOR_KEY and PRODUCT_KEY in the extra
-        // file, it'd simplify the data_dir logic and things like glean initialization (which
-        // relies on the data dir).
-        if self.data_dir.is_none() {
-            let vendor = extra[VENDOR_KEY].as_str().unwrap_or(DEFAULT_VENDOR);
-            let product = extra[PRODUCT_KEY].as_str().unwrap_or(DEFAULT_PRODUCT);
-            self.data_dir = Some(self.get_data_dir(vendor, product)?);
-            self.update_log_file();
         }
 
         if Self::should_suppress_restart(&extra) {
@@ -504,24 +516,50 @@ impl Config {
         Ok(data_path)
     }
 
+    /// The crash reporter data directory, `Crash Reports` inside the user
+    /// application data directory.
+    fn get_data_dir(&self, vendor: &str, product: &str) -> anyhow::Result<PathBuf> {
+        let app_data_dir = self.get_app_data_dir(vendor, product)?;
+        #[cfg(all(not(mock), target_os = "macos"))]
+        std::fs::create_dir_all(&app_data_dir).with_context(|| {
+            self.build_string("crashreporter-error-creating-dir")
+                .arg("path", app_data_dir.display().to_string())
+                .get()
+        })?;
+        Ok(app_data_dir.join("Crash Reports"))
+    }
+
+    /// The user application data directory (`UAppData`): the top-level Firefox
+    /// directory holding `profiles.ini`, the profiles themselves and the
+    /// profile-independent enterprise storage (`felt.json`).
+    ///
+    /// This must match `nsXREDirProvider::GetUserAppDataDirectory`; the
+    /// per-platform layout below mirrors `AppendProfilePath` there.
+    fn get_app_data_dir(&self, vendor: &str, product: &str) -> anyhow::Result<PathBuf> {
+        // The browser honors this override (`./mach run --appdata`) ahead of
+        // the computed location.
+        if let Some(dir) = std::env::var_os("MOZ_APP_DATA") {
+            return Ok(PathBuf::from(dir));
+        }
+        self.default_app_data_dir(vendor, product)
+    }
+
     cfg_if::cfg_if! {
         if #[cfg(mock)] {
-            fn get_data_dir(&self, vendor: &str, product: &str) -> anyhow::Result<PathBuf> {
+            fn default_app_data_dir(&self, vendor: &str, product: &str) -> anyhow::Result<PathBuf> {
                 let mut path = PathBuf::from("data_dir");
                 path.push(vendor);
                 path.push(product);
-                path.push("Crash Reports");
                 Ok(path)
             }
         } else if #[cfg(target_os = "linux")] {
-            fn get_data_dir(&self, vendor: &str, product: &str) -> anyhow::Result<PathBuf> {
-            let mut data_path = self.get_data_dir_root(vendor)?;
+            fn default_app_data_dir(&self, vendor: &str, product: &str) -> anyhow::Result<PathBuf> {
+                let mut data_path = self.get_data_dir_root(vendor)?;
                 data_path.push(product.to_lowercase());
-                data_path.push("Crash Reports");
                 Ok(data_path)
             }
         } else if #[cfg(target_os = "macos")] {
-            fn get_data_dir(&self, _vendor: &str, product: &str) -> anyhow::Result<PathBuf> {
+            fn default_app_data_dir(&self, _vendor: &str, product: &str) -> anyhow::Result<PathBuf> {
                 use objc::{
                     rc::autoreleasepool,
                     runtime::{Object, BOOL, YES},
@@ -561,16 +599,10 @@ impl Config {
                     Ok(PathBuf::from(s))
                 })?;
                 data_path.push(product);
-                std::fs::create_dir_all(&data_path).with_context(|| {
-                    self.build_string("crashreporter-error-creating-dir")
-                        .arg("path", data_path.display().to_string())
-                        .get()
-                })?;
-                data_path.push("Crash Reports");
                 Ok(data_path)
             }
         } else if #[cfg(target_os = "windows")] {
-            fn get_data_dir(&self, vendor: &str, product: &str) -> anyhow::Result<PathBuf> {
+            fn default_app_data_dir(&self, vendor: &str, product: &str) -> anyhow::Result<PathBuf> {
                 use crate::std::os::windows::ffi::OsStringExt;
                 use windows_sys::{
                     core::PWSTR,
@@ -595,7 +627,6 @@ impl Config {
                 let mut path = PathBuf::from(osstr);
                 path.push(vendor);
                 path.push(product);
-                path.push("Crash Reports");
                 Ok(path)
             }
         }

--- a/toolkit/crashreporter/client/app/src/enterprise_prefs.rs
+++ b/toolkit/crashreporter/client/app/src/enterprise_prefs.rs
@@ -10,10 +10,18 @@
 //! The console address normally comes from the `ServerURL` crash annotation
 //! (recorded by the browser once AutoConfig has run). A crash before then has
 //! no usable annotation, so we recover the address by reading the AutoConfig
-//! (`.cfg`) file ourselves.
+//! (`.cfg`) file ourselves. The extraction and the resolution of the generic
+//! build placeholder (environment variable, then `felt.json`) live in the
+//! shared enterprise-console crate; this module only does the IO through the
+//! mockable `crate::std`.
 
 use crate::config::installation_resource_path;
-use crate::prefs_parser::find_string_pref_call;
+use crate::std::path::Path;
+use anyhow::Context;
+use enterprise_console::{
+    console_address_from_autoconfig, resolve_console_address, CONSOLE_ADDRESS_ENV,
+    CONSOLE_ADDRESS_PREF, FELT_STORAGE_FILENAME,
+};
 use url::Url;
 
 /// The enterprise AutoConfig file name. Enterprise builds point
@@ -21,20 +29,11 @@ use url::Url;
 /// a default value anywhere else.
 const ENTERPRISE_AUTOCONFIG_FILENAME: &str = "firefox.cfg";
 
-/// The pref holding the enterprise console address.
-const CONSOLE_ADDRESS_PREF: &str = "enterprise.console.address";
-
 /// Path appended to the console address to form the crash submission endpoint.
 const CRASH_SUBMIT_PATH: &str = "api/browser/crash-reports/submit";
 
 /// Path appended to the console address to form the Glean telemetry endpoint.
 const GLEAN_SUBMIT_PATH: &str = "api/browser/telemetry";
-
-/// Default byte shift applied to AutoConfig files (`general.config.obscure_value`).
-const DEFAULT_OBSCURE_VALUE: u8 = 13;
-
-/// Pref-setting functions an AutoConfig file may use to set a string pref.
-const PREF_FUNCTIONS: &[&str] = &["lockPref", "defaultPref", "pref"];
 
 /// Resolve the crash report submission URL.
 ///
@@ -42,20 +41,36 @@ const PREF_FUNCTIONS: &[&str] = &["lockPref", "defaultPref", "pref"];
 /// an absolute URL, since that is the submission endpoint itself. Otherwise
 /// (missing, or a domainless placeholder such as `/submit?...`) constructs the
 /// endpoint from the enterprise console address.
-pub fn console_report_url(server_url: Option<&str>) -> anyhow::Result<String> {
+///
+/// `app_data_dir` is the user application data directory (the top-level
+/// Firefox directory holding `profiles.ini` and the profiles), where
+/// `felt.json` is stored on generic builds.
+pub fn console_report_url(
+    server_url: Option<&str>,
+    app_data_dir: Option<&Path>,
+) -> anyhow::Result<String> {
     if let Some(server_url) = server_url {
         if Url::parse(server_url).is_ok() {
             return Ok(server_url.to_owned());
         }
     }
-    Ok(format!("{}/{}", console_base(None)?, CRASH_SUBMIT_PATH))
+    Ok(format!(
+        "{}/{}",
+        console_base(None, app_data_dir)?,
+        CRASH_SUBMIT_PATH
+    ))
 }
 
 /// Construct the Glean telemetry endpoint from the enterprise console address.
 ///
 /// `server_url` is the `ServerURL` crash annotation, when available.
-pub fn console_glean_url(server_url: Option<&str>) -> anyhow::Result<String> {
-    let base = console_base(server_url)?;
+/// `app_data_dir` is the user application data directory, see
+/// [`console_report_url`].
+pub fn console_glean_url(
+    server_url: Option<&str>,
+    app_data_dir: Option<&Path>,
+) -> anyhow::Result<String> {
+    let base = console_base(server_url, app_data_dir)?;
     let mut url = Url::parse(&base)?;
     url.set_path(&format!(
         "{}/{}",
@@ -81,7 +96,7 @@ pub fn is_console_url(url: &str) -> bool {
 
 fn same_origin_as_console(url: &str) -> anyhow::Result<bool> {
     let url = Url::parse(url)?;
-    let console = Url::parse(&read_autoconfig_string_pref(CONSOLE_ADDRESS_PREF)?)?;
+    let console = Url::parse(&autoconfig_console_address()?)?;
     let origin = url.origin();
     // Opaque origins (such as that of a `data:` URL) must never match, not even
     // each other.
@@ -93,39 +108,42 @@ fn same_origin_as_console(url: &str) -> anyhow::Result<bool> {
 /// Resolution order:
 /// 1. `server_url` (the `ServerURL` crash annotation, i.e. the submission
 ///    endpoint) by stripping the submission path back to the base;
-/// 2. the AutoConfig file.
-fn console_base(server_url: Option<&str>) -> anyhow::Result<String> {
+/// 2. the AutoConfig file; when it holds the generic build placeholder, the
+///    environment variable and then the felt storage file in `app_data_dir`
+///    (see the enterprise-console crate).
+fn console_base(server_url: Option<&str>, app_data_dir: Option<&Path>) -> anyhow::Result<String> {
     if let Some(server_url) = server_url {
         let trimmed = server_url.trim_end_matches('/');
         if let Some(base) = trimmed.strip_suffix(CRASH_SUBMIT_PATH) {
             return Ok(base.trim_end_matches('/').to_owned());
         }
     }
-    let base = read_autoconfig_string_pref(CONSOLE_ADDRESS_PREF)?;
+    let address = autoconfig_console_address()?;
+    let env_value = crate::std::env::var(CONSOLE_ADDRESS_ENV).ok();
+    let base = resolve_console_address(&address, env_value.as_deref(), || {
+        let dir = app_data_dir.ok_or_else(|| {
+            crate::std::io::Error::new(
+                crate::std::io::ErrorKind::NotFound,
+                "no application data directory to locate the felt storage file",
+            )
+        })?;
+        crate::std::fs::read(&dir.join(FELT_STORAGE_FILENAME))
+    })
+    .context("could not resolve the generic build console address placeholder")?;
     Ok(base.trim_end_matches('/').to_owned())
 }
 
-/// Read a string preference from the installation's AutoConfig file.
-///
-/// AutoConfig files are byte-shifted by `general.config.obscure_value` (13 by
-/// default) and have an intentionally unparseable first line. We undo the
-/// shift (trying the default value, then plaintext) and scan for the pref.
-fn read_autoconfig_string_pref(pref: &str) -> anyhow::Result<String> {
+/// Read the console address (or the generic build placeholder) out of the
+/// installation's AutoConfig file.
+fn autoconfig_console_address() -> anyhow::Result<String> {
     let path = installation_resource_path().join(ENTERPRISE_AUTOCONFIG_FILENAME);
-    let bytes = crate::std::fs::read(&path)?;
-
-    for shift in [DEFAULT_OBSCURE_VALUE, 0] {
-        let decoded: Vec<u8> = bytes.iter().map(|b| b.wrapping_sub(shift)).collect();
-        let Ok(text) = String::from_utf8(decoded) else {
-            continue;
-        };
-        for func in PREF_FUNCTIONS {
-            if let Some(value) = find_string_pref_call(&text, func, pref) {
-                return Ok(value.to_owned());
-            }
-        }
-    }
-    anyhow::bail!("could not find pref {pref:?} in {}", path.display())
+    let contents = crate::std::fs::read(&path)?;
+    console_address_from_autoconfig(&contents).with_context(|| {
+        format!(
+            "could not find pref {CONSOLE_ADDRESS_PREF:?} in {}",
+            path.display()
+        )
+    })
 }
 
 #[cfg(test)]
@@ -140,7 +158,7 @@ mod test {
     fn encode(plaintext: &str) -> Vec<u8> {
         plaintext
             .bytes()
-            .map(|b| b.wrapping_add(DEFAULT_OBSCURE_VALUE))
+            .map(|b| b.wrapping_add(enterprise_console::DEFAULT_OBSCURE_VALUE))
             .collect()
     }
 
@@ -157,13 +175,38 @@ mod test {
             .run(body)
     }
 
+    const GENERIC_CFG: &str = "// first line is ignored\n\
+         lockPref(\"enterprise.console.address\", \"FIREFOX_ENTERPRISE_GENERIC\");";
+
+    fn with_generic_autoconfig<R>(
+        felt_json: Option<&str>,
+        configure: impl FnOnce(&mut mock::Builder),
+        body: impl FnOnce() -> R,
+    ) -> R {
+        let mock_files = MockFiles::new();
+        mock_files.add_dir("work_dir");
+        mock_files.add_file("work_dir/firefox.cfg", encode(GENERIC_CFG));
+        mock_files.add_dir("app_data");
+        if let Some(felt_json) = felt_json {
+            mock_files.add_file("app_data/felt.json", felt_json);
+        }
+        let mut builder = mock::builder();
+        builder.set(MockFS, mock_files.clone()).set(
+            crate::std::env::MockCurrentExe,
+            "work_dir/crashreporter".into(),
+        );
+        configure(&mut builder);
+        builder.run(body)
+    }
+
     #[test]
     fn console_base_prefers_annotation() {
         // No file access needed: the submission path is stripped to the base.
         assert_eq!(
-            console_base(Some(
-                "https://console.example.com/foo/api/browser/crash-reports/submit"
-            ))
+            console_base(
+                Some("https://console.example.com/foo/api/browser/crash-reports/submit"),
+                None
+            )
             .unwrap(),
             "https://console.example.com/foo"
         );
@@ -173,7 +216,7 @@ mod test {
     fn console_base_reads_encoded_autoconfig() {
         with_autoconfig(|| {
             assert_eq!(
-                console_base(None).unwrap(),
+                console_base(None, None).unwrap(),
                 "https://console.example.com/foo"
             );
         });
@@ -189,17 +232,73 @@ mod test {
                 "work_dir/crashreporter".into(),
             )
             .run(|| {
-                assert!(console_base(None).is_err());
+                assert!(console_base(None, None).is_err());
             });
+    }
+
+    #[test]
+    fn console_base_generic_uses_environment() {
+        with_generic_autoconfig(
+            None,
+            |builder| {
+                builder.set(
+                    crate::std::env::MockEnv(CONSOLE_ADDRESS_ENV.into()),
+                    "https://env.example.com/".into(),
+                );
+            },
+            || {
+                assert_eq!(
+                    console_base(None, Some((&"app_data").as_ref())).unwrap(),
+                    "https://env.example.com"
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn console_base_generic_reads_felt_storage() {
+        with_generic_autoconfig(
+            Some(r#"{"consoleAddress": "https://stored.example.com/"}"#),
+            |_| {},
+            || {
+                assert_eq!(
+                    console_base(None, Some((&"app_data").as_ref())).unwrap(),
+                    "https://stored.example.com"
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn console_base_generic_errors_without_stored_address() {
+        with_generic_autoconfig(
+            Some(r#"{"deviceId": "abc"}"#),
+            |_| {},
+            || {
+                assert!(console_base(None, Some((&"app_data").as_ref())).is_err());
+            },
+        );
+    }
+
+    #[test]
+    fn console_base_generic_errors_without_app_data_dir() {
+        with_generic_autoconfig(
+            Some(r#"{"consoleAddress": "https://stored.example.com/"}"#),
+            |_| {},
+            || {
+                assert!(console_base(None, None).is_err());
+            },
+        );
     }
 
     #[test]
     fn report_url_uses_valid_annotation() -> anyhow::Result<()> {
         // An absolute annotation is the submission endpoint; return it as-is.
         assert_eq!(
-            console_report_url(Some(
-                "https://console.example.com/foo/api/browser/crash-reports/submit"
-            ))?,
+            console_report_url(
+                Some("https://console.example.com/foo/api/browser/crash-reports/submit"),
+                None
+            )?,
             "https://console.example.com/foo/api/browser/crash-reports/submit"
         );
         anyhow::Ok(())
@@ -210,7 +309,7 @@ mod test {
         // A domainless placeholder is ignored; the URL is built from AutoConfig.
         with_autoconfig(|| {
             assert_eq!(
-                console_report_url(Some("/submit?id=x"))?,
+                console_report_url(Some("/submit?id=x"), None)?,
                 "https://console.example.com/foo/api/browser/crash-reports/submit"
             );
             anyhow::Ok(())
@@ -259,9 +358,10 @@ mod test {
     fn glean_url_appends_telemetry_path_from_annotation() -> anyhow::Result<()> {
         // Derived from the ServerURL annotation without touching the filesystem.
         assert_eq!(
-            console_glean_url(Some(
-                "https://console.example.com/foo/api/browser/crash-reports/submit"
-            ))?,
+            console_glean_url(
+                Some("https://console.example.com/foo/api/browser/crash-reports/submit"),
+                None
+            )?,
             "https://console.example.com/foo/api/browser/telemetry"
         );
         anyhow::Ok(())

--- a/toolkit/crashreporter/client/app/src/glean.rs
+++ b/toolkit/crashreporter/client/app/src/glean.rs
@@ -16,9 +16,11 @@ pub struct InitOptions {
     pub data_dir: ::std::path::PathBuf,
     pub locale: Option<String>,
     pub upload_enabled: bool,
-    /// The crash submission endpoint (`ServerURL` annotation), used to recover
-    /// the enterprise console base without reading AutoConfig when available.
-    #[cfg(all(not(mock), feature = "enterprise"))]
+    /// The server to send telemetry to, overriding the default endpoint.
+    /// Set to the console telemetry endpoint (see
+    /// `enterprise_prefs::console_glean_url`); mock builds always use a fixed
+    /// example endpoint.
+    #[cfg(feature = "enterprise")]
     pub server_url: Option<String>,
 }
 
@@ -80,20 +82,21 @@ impl InitOptions {
 
         let upload_enabled = determine_telemetry_enabled(cfg.profile_dir.as_deref());
 
-        #[cfg(all(not(mock), feature = "enterprise"))]
-        let server_url = cfg
-            .report_url
-            .as_ref()
-            .and_then(|s| s.to_str())
-            .map(str::to_owned);
-
         InitOptions {
             data_dir,
             locale,
             upload_enabled,
-            #[cfg(all(not(mock), feature = "enterprise"))]
-            server_url,
+            #[cfg(feature = "enterprise")]
+            server_url: None,
         }
+    }
+
+    /// Set the server to which telemetry is sent, overriding the default
+    /// endpoint.
+    #[cfg(feature = "enterprise")]
+    #[cfg_attr(mock, allow(dead_code))]
+    pub fn set_server_url(&mut self, url: String) {
+        self.server_url = Some(url);
     }
 
     /// Initialize glean.
@@ -113,8 +116,6 @@ impl InitOptions {
     }
 
     fn init_glean(self) -> anyhow::Result<crashping::InitGlean> {
-        #[cfg(all(not(mock), feature = "enterprise"))]
-        let server_url = self.server_url;
         let mut data_dir = if cfg!(mock) {
             // Use a (non-mocked) temp directory since glean won't access our mocked API.
             ::std::env::temp_dir().join("crashreporter-mock")
@@ -143,16 +144,14 @@ impl InitOptions {
         init_glean.configuration.uploader = Some(Box::new(uploader::Uploader::new()));
         init_glean.configuration.upload_enabled = self.upload_enabled;
 
+        #[cfg(feature = "enterprise")]
+        if let Some(url) = self.server_url {
+            init_glean.configuration.server_endpoint = Some(url);
+        }
         #[cfg(mock)]
         {
             init_glean.configuration.server_endpoint =
                 Some("https://incoming.glean.example.com".to_owned());
-        }
-        #[cfg(all(not(mock), feature = "enterprise"))]
-        {
-            init_glean.configuration.server_endpoint = Some(
-                crate::enterprise_prefs::console_glean_url(server_url.as_deref())?,
-            );
         }
 
         Ok(init_glean)

--- a/toolkit/crashreporter/client/app/src/main.rs
+++ b/toolkit/crashreporter/client/app/src/main.rs
@@ -267,9 +267,22 @@ fn try_run(config: &mut Arc<Config>) -> anyhow::Result<bool> {
         //
         // When we are testing, glean will already be initialized (if needed).
         #[cfg(not(test))]
-        let _glean_handle = glean::InitOptions::from_config(&config)
-            .init()
-            .context("failed to acquire Glean store")?;
+        let _glean_handle = {
+            #[cfg_attr(any(mock, not(feature = "enterprise")), allow(unused_mut))]
+            let mut options = glean::InitOptions::from_config(&config);
+            // Send telemetry to the enterprise console, deriving the endpoint
+            // from the crash submission URL (the `ServerURL` annotation)
+            // resolved by `load_extra_file` above.
+            #[cfg(all(not(mock), feature = "enterprise"))]
+            options.set_server_url(
+                enterprise_prefs::console_glean_url(
+                    config.report_url.as_ref().and_then(|s| s.to_str()),
+                    config.app_data_dir.as_deref(),
+                )
+                .context("failed to resolve the enterprise telemetry endpoint")?,
+            );
+            options.init().context("failed to acquire Glean store")?
+        };
 
         logic::ReportCrash::new(config.clone(), extra)?.run()
     }

--- a/toolkit/crashreporter/client/app/src/prefs_parser.rs
+++ b/toolkit/crashreporter/client/app/src/prefs_parser.rs
@@ -43,18 +43,6 @@ pub fn find_string_pref<'a>(prefs_content: &'a str, pref: &str) -> Option<&'a st
     find_pref(prefs_content, pref).and_then(|s| s.strip_prefix('"')?.strip_suffix('"'))
 }
 
-/// Like [`find_string_pref`], but for an arbitrary pref-setting function.
-///
-/// Only used by `enterprise_prefs`, which is compiled under the same feature.
-#[cfg(feature = "enterprise")]
-pub fn find_string_pref_call<'a>(
-    prefs_content: &'a str,
-    func: &str,
-    pref: &str,
-) -> Option<&'a str> {
-    find_pref_call(prefs_content, func, pref).and_then(|s| s.strip_prefix('"')?.strip_suffix('"'))
-}
-
 /// Find a single bool pref (if any) from the prefs file contents.
 pub fn find_bool_pref(prefs_content: &str, pref: &str) -> Option<bool> {
     find_pref(prefs_content, pref).and_then(|s| s.parse().ok())
@@ -105,17 +93,8 @@ mod test {
 
     #[cfg(feature = "enterprise")]
     #[test]
-    fn test_find_string_pref_call_lock_pref() {
-        let input = r#"lockPref("enterprise.console.address", "https://example.com/");"#;
-        assert_eq!(
-            find_string_pref_call(input, "lockPref", "enterprise.console.address"),
-            Some("https://example.com/")
-        );
-    }
-
-    #[test]
-    fn test_find_string_pref_ignores_lock_pref() {
-        // The standard user_pref finder must not match a lockPref call.
+    fn find_pref_ignores_other_functions() {
+        // The user_pref finder must not match a lockPref call.
         let input = r#"lockPref("enterprise.console.address", "https://example.com/");"#;
         assert_eq!(find_string_pref(input, "enterprise.console.address"), None);
     }

--- a/toolkit/crashreporter/client/app/src/send_ping.rs
+++ b/toolkit/crashreporter/client/app/src/send_ping.rs
@@ -7,6 +7,17 @@
 use crate::std::{env, io::stdin};
 use crate::{glean, logging, net::ping};
 
+/// The user application data directory, derived from the crash data path.
+///
+/// `CrashManager` always passes `UAppData/Crash Reports`, so the parent of the
+/// given path is the directory holding `felt.json`.
+#[cfg(all(not(mock), feature = "enterprise"))]
+fn app_data_dir(data_path: &::std::ffi::OsStr) -> Option<::std::path::PathBuf> {
+    ::std::path::Path::new(data_path)
+        .parent()
+        .map(::std::path::Path::to_path_buf)
+}
+
 pub fn main() {
     logging::init();
 
@@ -17,18 +28,27 @@ pub fn main() {
     let extra: serde_json::Value =
         serde_json::from_reader(stdin()).expect("failed to read extra data from stdin");
 
-    let _glean_handle = glean::InitOptions {
+    #[cfg(all(not(mock), feature = "enterprise"))]
+    let app_data_dir = app_data_dir(&data_path);
+
+    #[cfg_attr(any(mock, not(feature = "enterprise")), allow(unused_mut))]
+    let mut options = glean::InitOptions {
         data_dir: data_path.into(),
         locale: None,
         // Assume that this is only invoked to send a ping when upload is enabled.
         upload_enabled: true,
-        // No annotation available here; the console address is read from
-        // AutoConfig during init.
-        #[cfg(all(not(mock), feature = "enterprise"))]
+        #[cfg(feature = "enterprise")]
         server_url: None,
-    }
-    .init()
-    .expect("failed to acquire Glean store");
+    };
+    // No `ServerURL` annotation is available here, so the endpoint is derived
+    // from the console address in AutoConfig (or, on generic builds, the
+    // environment variable or felt.json).
+    #[cfg(all(not(mock), feature = "enterprise"))]
+    options.set_server_url(
+        crate::enterprise_prefs::console_glean_url(None, app_data_dir.as_deref())
+            .expect("failed to resolve the enterprise telemetry endpoint"),
+    );
+    let _glean_handle = options.init().expect("failed to acquire Glean store");
 
     ping::CrashPing {
         extra: &extra,
@@ -54,15 +74,23 @@ pub fn cleanup_main() {
         .parse()
         .expect("invalid upload enabled value");
 
-    let _glean_handle = glean::InitOptions {
+    #[cfg(all(not(mock), feature = "enterprise"))]
+    let app_data_dir = app_data_dir(&data_path);
+
+    #[cfg_attr(any(mock, not(feature = "enterprise")), allow(unused_mut))]
+    let mut options = glean::InitOptions {
         data_dir: data_path.into(),
         locale: None,
         upload_enabled,
-        #[cfg(all(not(mock), feature = "enterprise"))]
+        #[cfg(feature = "enterprise")]
         server_url: None,
-    }
-    .init()
-    .expect("failed to acquire Glean store");
+    };
+    #[cfg(all(not(mock), feature = "enterprise"))]
+    options.set_server_url(
+        crate::enterprise_prefs::console_glean_url(None, app_data_dir.as_deref())
+            .expect("failed to resolve the enterprise telemetry endpoint"),
+    );
+    let _glean_handle = options.init().expect("failed to acquire Glean store");
 
     // Sleep for a short period for Glean to do its thing in the background (and so that
     // `glean::shutdown()` won't log a warning about waiting for init to complete).

--- a/toolkit/locales/en-US/toolkit/enterprise/felt.ftl
+++ b/toolkit/locales/en-US/toolkit/enterprise/felt.ftl
@@ -106,3 +106,21 @@ felt-warning-title-download-attempt-failed =
 felt-error-warning-download-attempt-failed-contact-admin = The latest update couldn’t be downloaded. If this problem persists, contact your administrator for help.
 
 felt-back-button = Back to login
+
+## Console setup dialog, shown before anything else on generic builds where no
+## enterprise console address has been configured yet.
+
+felt-console-setup-window-title = { -brand-short-name } — Setup
+felt-console-setup-title = Get started
+felt-console-setup-description = Enter the address of your organization’s management console. Your administrator can provide it.
+felt-console-setup-input =
+    .label = Console address
+    .placeholder = https://console.example.com
+felt-console-setup-invalid-address =
+    .message = Enter a valid address, such as https://console.example.com
+felt-console-setup-save-failed =
+    .message = The address couldn’t be saved. Please try again, or contact your administrator if the problem persists.
+felt-console-setup-save-btn =
+    .label = Save and restart
+felt-console-setup-quit-btn =
+    .label = Quit

--- a/toolkit/xre/CreateAppData.cpp
+++ b/toolkit/xre/CreateAppData.cpp
@@ -17,6 +17,10 @@
 
 #if defined(MOZ_ENTERPRISE)
 #  include "mozilla/toolkit/components/felt/felt.h"
+#  include "mozilla/Try.h"
+#  include "mozilla/URLPreloader.h"
+#  include "nsXREDirProvider.h"
+#  include "nsString.h"
 #endif
 
 using namespace mozilla;
@@ -81,12 +85,82 @@ nsresult XRE_ParseAppData(nsIFile* aINIFile, XREAppData& aAppData) {
 }
 
 #if defined(MOZ_ENTERPRISE)
+// Path to felt.json, the profile-independent enterprise storage file kept in
+// UAppData. It must be computable before the directory service and XPCOM are
+// up, which is why nsXREDirProvider's static helper is used.
+static nsresult GetFeltStorageFilePath(nsCString& aOutPath) {
+  nsCOMPtr<nsIFile> dir;
+  nsresult rv = nsXREDirProvider::GetUserAppDataDirectory(getter_AddRefs(dir));
+  NS_ENSURE_SUCCESS(rv, rv);
+  // The first GetUserAppDataDirectory call hands out the instance that
+  // nsXREDirProvider caches and serves as UAppData for the rest of startup,
+  // so it must not be mutated: appending without cloning would turn UAppData
+  // into .../felt.json for every later consumer.
+  nsCOMPtr<nsIFile> file;
+  rv = dir->Clone(getter_AddRefs(file));
+  NS_ENSURE_SUCCESS(rv, rv);
+  rv = file->AppendNative("felt.json"_ns);
+  NS_ENSURE_SUCCESS(rv, rv);
+  nsAutoString path;
+  rv = file->GetPath(path);
+  NS_ENSURE_SUCCESS(rv, rv);
+  CopyUTF16toUTF8(path, aOutPath);
+  return NS_OK;
+}
+
+nsresult XRE_ClearStoredEnterpriseConsoleUrl() {
+  nsCString path;
+  nsresult rv = GetFeltStorageFilePath(path);
+  NS_ENSURE_SUCCESS(rv, rv);
+  return firefox_felt_clear_stored_console_url(&path) ? NS_OK
+                                                      : NS_ERROR_FAILURE;
+}
+
+nsresult XRE_ReadEnterpriseConsoleAddress(const XREAppData& aAppData,
+                                          nsACString& aConsoleAddress) {
+  nsCOMPtr<nsIFile> cfgFile;
+  nsresult rv = aAppData.xreDirectory->Clone(getter_AddRefs(cfgFile));
+  NS_ENSURE_SUCCESS(rv, rv);
+  rv = cfgFile->Append(u"firefox.cfg"_ns);
+  NS_ENSURE_SUCCESS(rv, rv);
+
+  nsCString obscured = MOZ_TRY(URLPreloader::ReadFile(cfgFile));
+
+  // Byte shift decoding and light-weight extraction of the pref value happen
+  // in the shared enterprise-console crate; full AutoConfig evaluation only
+  // happens in XRE_mainRun.
+  if (!firefox_felt_console_address_from_autoconfig(&obscured,
+                                                    &aConsoleAddress)) {
+    return NS_ERROR_NOT_AVAILABLE;
+  }
+  return NS_OK;
+}
+
 nsresult XRE_ParseEnterpriseServerURL(XREAppData& aAppData,
                                       const char* aServerUrl) {
   nsCString serverUrl(aServerUrl);
   if (serverUrl.IsEmpty()) {
     return NS_ERROR_NOT_AVAILABLE;
   }
+
+  // On a generic (non-repacked) build the address is the placeholder baked in
+  // by the branding; the shared enterprise-console crate resolves it from the
+  // test override environment variable or the URL persisted by the console
+  // setup dialog. If neither exists the caller shows that dialog. A real
+  // address passes through unchanged. The path computation is best effort:
+  // it is only read when the placeholder has to be resolved from felt.json.
+  nsCString feltJsonPath;
+  if (NS_FAILED(GetFeltStorageFilePath(feltJsonPath))) {
+    NS_WARNING(
+        "Could not compute the felt.json path; a stored console address "
+        "cannot be found");
+  }
+  nsCString resolvedUrl;
+  if (!firefox_felt_resolve_console_address(&serverUrl, &feltJsonPath,
+                                            &resolvedUrl)) {
+    return NS_ERROR_NOT_AVAILABLE;
+  }
+  serverUrl = resolvedUrl;
 
   if (serverUrl.Last() != '/') {
     serverUrl.Append('/');

--- a/toolkit/xre/nsAppRunner.cpp
+++ b/toolkit/xre/nsAppRunner.cpp
@@ -3459,6 +3459,69 @@ static ReturnAbortOnError ShowProfileSelector(
                            kTelemetryEnv);
 }
 
+#if defined(MOZ_ENTERPRISE)
+// Modal pre-profile dialog asking for the enterprise console address on
+// generic builds (the AutoConfig file holds the generic console placeholder
+// and nothing is persisted yet). The dialog stores the address in felt.json,
+// then this relaunches so the very early startup consumers (crash reporter URL,
+// update URL, FELT connection) see the configured value from the start.
+// Modeled on ShowProfileDialog.
+static ReturnAbortOnError ShowEnterpriseConsoleSetup(
+    nsINativeAppSupport* aNative) {
+  nsresult rv;
+  int32_t dialogReturn = 0;
+
+  // We aren't going to start this instance so we can unblock other instances
+  // from starting up.
+#  if defined(MOZ_HAS_REMOTE)
+  gStartupLock = nullptr;
+#  endif
+
+  {
+    ScopedXPCOMStartup xpcom;
+    rv = xpcom.Initialize();
+    NS_ENSURE_SUCCESS(rv, rv);
+
+    rv = xpcom.SetWindowCreator(aNative);
+    NS_ENSURE_SUCCESS(rv, NS_ERROR_FAILURE);
+
+#  ifdef XP_MACOSX
+    InitializeMacApp();
+    CommandLineServiceMac::SetupMacCommandLine(gRestartArgc, gRestartArgv,
+                                               true);
+#  endif
+
+    {  // extra scoping is needed so we release these components before xpcom
+       // shutdown
+      nsCOMPtr<nsIWindowWatcher> windowWatcher(
+          do_GetService(NS_WINDOWWATCHER_CONTRACTID));
+      nsCOMPtr<nsIDialogParamBlock> ioParamBlock(
+          do_CreateInstance(NS_DIALOGPARAMBLOCK_CONTRACTID));
+      NS_ENSURE_TRUE(windowWatcher && ioParamBlock, NS_ERROR_FAILURE);
+
+      nsCOMPtr<nsIAppStartup> appStartup(components::AppStartup::Service());
+      NS_ENSURE_TRUE(appStartup, NS_ERROR_FAILURE);
+
+      nsCOMPtr<mozIDOMWindowProxy> newWindow;
+      // Same size as the FELT window (Felt.sys.mjs showWindow), which this
+      // dialog visually mirrors.
+      rv = windowWatcher->OpenWindow(
+          nullptr, "chrome://felt/content/consoleSetup.xhtml"_ns, u"_blank"_ns,
+          "centerscreen,chrome,modal,titlebar,resizable,width=727,height=744"_ns,
+          ioParamBlock, getter_AddRefs(newWindow));
+      NS_ENSURE_SUCCESS_LOG(rv, rv);
+
+      rv = ioParamBlock->GetInt(0, &dialogReturn);
+      if (NS_FAILED(rv) || dialogReturn != 1) {
+        return NS_ERROR_ABORT;
+      }
+    }
+  }
+
+  return LaunchChild(false, true);
+}
+#endif
+
 static bool gDoMigration = false;
 static bool gDoProfileReset = false;
 constinit static nsCOMPtr<nsIToolkitProfile> gResetOldProfile;
@@ -4345,6 +4408,13 @@ static void MakeOrSetMinidumpPath(nsIFile* profD) {
 
 const XREAppData* gAppData = nullptr;
 
+#if defined(MOZ_ENTERPRISE)
+// Set when the AutoConfig file holds the generic console placeholder and no
+// console address has been persisted yet; XRE_mainStartup then runs the
+// console setup dialog (FELT UI only).
+static bool gEnterpriseConsoleSetupNeeded = false;
+#endif
+
 /**
  * NSPR will search for the "nspr_use_zone_allocator" symbol throughout
  * the process and use it to determine whether the application defines its own
@@ -4872,6 +4942,46 @@ int XREMain::XRE_mainInit(bool* aExitFlag) {
       return 1;
     }
   }
+
+#if defined(MOZ_ENTERPRISE)
+  // The flag allows to trigger again the dialog, if autoconfig file contains
+  // the placeholder value. It should be safe enough on shippable builds where
+  // the autoconfig file is part of the distribution and thus should be immune
+  // to any change.
+  if (CheckArg("reset-console-url") == ARG_FOUND) {
+    // Forget the address entered in the console setup dialog. On generic
+    // builds the dialog then runs again below. CheckArg removes the flag from
+    // gArgv before gRestartArgv is derived from it, so the post-dialog
+    // relaunch does not clear the freshly saved address again.
+    if (NS_FAILED(XRE_ClearStoredEnterpriseConsoleUrl())) {
+      // The user asked for the reset explicitly, so failing to perform it
+      // must be visible: the stored address stays in effect and the setup
+      // dialog will not run again.
+      Output(true,
+             "Could not reset the console address; the stored address remains "
+             "in effect.\n");
+    }
+  }
+  {
+    // AutoConfig only evaluates firefox.cfg once the pref service is up in
+    // XRE_mainRun, where the server URLs are derived from the
+    // enterprise.console.address pref. Read the file directly here to learn
+    // before profile selection whether it holds the generic console
+    // placeholder with no resolvable address, in which case XRE_mainStartup
+    // shows the console setup dialog. A read failure only warns: XRE_mainRun
+    // derives the URLs from the evaluated pref either way.
+    nsAutoCString consoleAddress;
+    rv = XRE_ReadEnterpriseConsoleAddress(*mAppData, consoleAddress);
+    if (NS_FAILED(rv)) {
+      NS_WARNING(
+          "Could not read the enterprise console address from the AutoConfig "
+          "file; enterprise server URLs may stay unset");
+    } else if (XRE_ParseEnterpriseServerURL(*mAppData, consoleAddress.get()) ==
+               NS_ERROR_NOT_AVAILABLE) {
+      gEnterpriseConsoleSetupNeeded = true;
+    }
+  }
+#endif
 
   // Check sanity and correctness of app data.
 
@@ -5960,6 +6070,30 @@ int XREMain::XRE_mainStartup(bool* aExitFlag) {
 
   // We now know there is no existing instance using the selected profile.
 
+#if defined(MOZ_ENTERPRISE)
+  // Test harnesses provide a console address via
+  // MOZ_ENTERPRISE_CONSOLE_URL (mozrunner test_environment and
+  // Marionette's GeckoInstance), so setup should never be needed under
+  // automation. Keep a backstop for harnesses that miss it: the modal
+  // pre-profile dialog would otherwise hang the task until timeout.
+  const bool enterpriseConsoleSetupAllowed = !EnvHasValue("MOZ_AUTOMATION");
+  if (gEnterpriseConsoleSetupNeeded && enterpriseConsoleSetupAllowed &&
+      is_felt_ui()
+#  ifdef MOZ_BACKGROUNDTASKS
+      && !BackgroundTasks::IsBackgroundTaskMode()
+#  endif
+  ) {
+    rv = ShowEnterpriseConsoleSetup(mNativeApp);
+    if (rv == NS_ERROR_LAUNCHED_CHILD_PROCESS || rv == NS_ERROR_ABORT) {
+      *aExitFlag = true;
+      return 0;
+    }
+    if (NS_FAILED(rv)) {
+      return 1;
+    }
+  }
+#endif
+
   // We only ever show the profile selector if a specific profile wasn't chosen
   // via command line arguments or environment variables.
   if (wasDefaultSelection) {
@@ -6603,12 +6737,22 @@ nsresult XREMain::XRE_mainRun() {
       nsAutoCString consoleAddress;
       rv =
           Preferences::GetCString("enterprise.console.address", consoleAddress);
-      if (NS_SUCCEEDED(rv)) {
-        XRE_ParseEnterpriseServerURL(*mAppData, consoleAddress.get());
-        if (mAppData->crashReporterURL) {
-          CrashReporter::SetServerURL(
-              nsDependentCString(mAppData->crashReporterURL));
-        }
+      if (NS_FAILED(rv)) {
+        NS_WARNING(
+            "enterprise.console.address is not set; enterprise server URLs "
+            "stay unset");
+      } else if (NS_FAILED(XRE_ParseEnterpriseServerURL(
+                     *mAppData, consoleAddress.get()))) {
+        // Reachable when the pref holds the generic build placeholder and
+        // the setup dialog was skipped (e.g. under MOZ_AUTOMATION without
+        // MOZ_ENTERPRISE_CONSOLE_URL): crash reports and updates have no
+        // endpoint to go to.
+        NS_WARNING(
+            "Could not derive the enterprise server URLs from the console "
+            "address");
+      } else if (mAppData->crashReporterURL) {
+        CrashReporter::SetServerURL(
+            nsDependentCString(mAppData->crashReporterURL));
       }
     }
 #endif

--- a/xpcom/build/nsXULAppAPI.h
+++ b/xpcom/build/nsXULAppAPI.h
@@ -9,6 +9,7 @@
 #include "mozilla/ProcessType.h"
 #include "mozilla/TimeStamp.h"
 #include "nscore.h"
+#include "nsStringFwd.h"
 
 #if defined(MOZ_WIDGET_ANDROID)
 #  include <jni.h>
@@ -256,10 +257,36 @@ nsresult XRE_ParseAppData(nsIFile* aINIFile, mozilla::XREAppData& aAppData);
  * @param aAppData The nsXREAppData structure on which to set the
  * crashReporterURL.
  *
- * @param aServerUrl Enterprise console address. Fails if empty.
+ * @param aServerUrl Enterprise console address. Fails if empty. On generic
+ * (non-repacked) builds this is the placeholder from the AutoConfig file,
+ * resolved by the enterprise-console crate
+ * (toolkit/components/enterprise/rust) from the
+ * MOZ_ENTERPRISE_CONSOLE_URL environment variable or from the value
+ * persisted in felt.json by the console setup dialog.
+ *
+ * @return NS_ERROR_NOT_AVAILABLE when aServerUrl is the generic build
+ * placeholder and no stored or environment-provided address exists yet; the
+ * caller is expected to run the console setup dialog.
  */
 nsresult XRE_ParseEnterpriseServerURL(mozilla::XREAppData& aAppData,
                                       const char* aServerUrl);
+
+/**
+ * Read the enterprise console address out of the AutoConfig file
+ * (firefox.cfg in aAppData.xreDirectory, byte shift decoded) without
+ * evaluating it. AutoConfig proper only runs once the pref service is up in
+ * XRE_mainRun; this gives pre-profile startup code the address so it can
+ * decide whether the console setup dialog must be shown.
+ */
+nsresult XRE_ReadEnterpriseConsoleAddress(const mozilla::XREAppData& aAppData,
+                                          nsACString& aConsoleAddress);
+
+/**
+ * Remove the console address persisted in felt.json so the console setup
+ * dialog runs again on a generic build. Backs the --reset-console-url
+ * command line flag.
+ */
+nsresult XRE_ClearStoredEnterpriseConsoleUrl();
 #endif
 
 const char* XRE_GeckoProcessTypeToString(GeckoProcessType aProcessType);


### PR DESCRIPTION
### Description <!-- REQUIRED -->

I'll edit this later, opening for sharing early.

Bugzilla: Bug-2068283

Every enterprise deployment currently requires a per-customer repack that bakes the console address into the AutoConfig file (`firefox.cfg`). This adds a *generic build*: one artifact that ships without a console address and gets configured at first startup, so the same build can serve any organization (downloads, evaluations, QA).

 **Implementation Details:**

- `--with-enterprise-console-url` still bakes a real address in for repacks. Without it the build is generic and `firefox.cfg` carries the placeholder `FIREFOX_ENTERPRISE_GENERIC`
- At startup, before profile selection, the placeholder is resolved in this order:
  1. the `MOZ_ENTERPRISE_CONSOLE_URL` environment variable (test harness override),
  2. the `consoleAddress` persisted in `felt.json` (UAppData) by the setup dialog,
  3. otherwise a modal pre-profile setup dialog (`chrome://felt/content/consoleSetup.xhtml`, FELT UI only; skipped under `MOZ_AUTOMATION` and in background-task mode) asks for the address, persists it to `felt.json`, and relaunches so the early consumers (crash reporter `ServerURL`, update URL, FELT connection) see the configured value from the start.
- `--reset-console-address` clears the stored address so the dialog runs again.
- The resolution logic lives once, in the new IO-free `enterprise-console` crate (`toolkit/components/enterprise/rust`), shared by all native consumers: browser startup through the `felt` crate's FFI (`XRE_ReadEnterpriseConsoleAddress` / `XRE_ParseEnterpriseServerURL` in `toolkit/xre/CreateAppData.cpp`), and the standalone crash reporter client. `ConsoleClient.sys.mjs` mirrors it in JS.
- mozrunner and Marionette set `MOZ_ENTERPRISE_CONSOLE_URL` to a closed local port by default so generic builds never block on the dialog under automation.

---

### Screenshots <!-- REQUIRED (if applicable) -->

<img width="1678" height="1776" alt="image" src="https://github.com/user-attachments/assets/ae9d1fb2-8e1a-43c5-9378-4d09e1723079" />

---

### Testing <!-- OPTIONAL -->

* [ ] Added tests
* [x] Manual testing performed

<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
