### PR TITLE
Bug 2040418 - Address enterprise localization review comments

### DIFF
--- a/toolkit/content/aboutSupport.xhtml
+++ b/toolkit/content/aboutSupport.xhtml
@@ -144,7 +144,7 @@
           </tr>
 
           <tr id="machine-id-row" class="no-copy">
-            <th class="column" data-l10n-id="app-basics-machine-id"/>
+            <th class="column" data-l10n-id="app-basics-device-id"/>
 
             <td id="machine-id-box">
             </td>

--- a/toolkit/locales/en-US/toolkit/enterprise/enterprise.ftl
+++ b/toolkit/locales/en-US/toolkit/enterprise/enterprise.ftl
@@ -6,9 +6,10 @@
 -enterprise-feature-access-connector = Access Connector
 
 # Shown in the about:support "Application Basics" table on enterprise builds.
-app-basics-machine-id = Machine ID
+app-basics-device-id = Device ID
 
 # Shown in the about:support "Security Software" section on enterprise builds.
+# Endpoint Detection and Response is an industry term and must remain in English.
 security-software-edr = Endpoint Detection and Response
 
 enterprise-toolbar-button =


### PR DESCRIPTION
Addresses the review feedback from https://github.com/mozilla-l10n/enterprise-firefox-l10n/pull/27:

- Uses Device ID instead of Machine ID for the about:support label.
- Clarifies that Endpoint Detection and Response is an industry term that must remain in English.

Validation: python3.9 ./mach lint toolkit/content/aboutSupport.xhtml toolkit/locales/en-US/toolkit/enterprise/enterprise.ftl