### PR TITLE
Bug 2067784 - Expect 'default' as distribution id

### DIFF
--- a/toolkit/components/normandy/test/browser/browser_ClientEnvironment.js
+++ b/toolkit/components/normandy/test/browser/browser_ClientEnvironment.js
@@ -64,7 +64,7 @@ add_task(async function testUserId() {
 add_task(async function testDistribution() {
   // distribution id defaults to "default" for most builds,
   // "mozilla-MSIX" for MSIX builds, "mozilla-official" for
-  // official Mozilla builds, and "enterprise-local" for enterprise builds.
+  // official Mozilla builds
   let expectedDistribution = "default";
   if (
     AppConstants.platform === "win" &&

--- a/toolkit/components/normandy/test/browser/browser_ClientEnvironment.js
+++ b/toolkit/components/normandy/test/browser/browser_ClientEnvironment.js
@@ -71,8 +71,6 @@ add_task(async function testDistribution() {
     Services.sysinfo.getProperty("hasWinPackageId")
   ) {
     expectedDistribution = "mozilla-MSIX";
-  } else if (AppConstants.MOZ_ENTERPRISE) {
-    expectedDistribution = "enterprise-local";
   } else if (AppConstants.BUILT_BY_MOZILLA) {
     expectedDistribution = "mozilla-official";
   }


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2067784

Reverts that the test `toolkit/components/normandy/test/browser/browser_ClientEnvironment.js` expects "enterprise-local" as distribution id since Bug-2048644 switched to resolving the console address from AutoConfig instead of the distribution.ini. 
