### PR TITLE
Bug 2067787 - Expect 'FirefoxEnterprise' as app name in har logs

### DIFF
--- a/devtools/client/netmonitor/src/har/test/browser_net_har_copy_all_as_har.js
+++ b/devtools/client/netmonitor/src/har/test/browser_net_har_copy_all_as_har.js
@@ -39,10 +39,14 @@ async function testSimpleReload() {
 
   const har = await reloadAndCopyAllAsHar({ tab, monitor, toolbox });
 
+  const appName = AppConstants.MOZ_ENTERPRISE
+    ? "FirefoxEnterprise"
+    : "Firefox";
+
   // Check out HAR log
   isnot(har.log, null, "The HAR log must exist");
-  is(har.log.creator.name, "Firefox", "The creator field must be set");
-  is(har.log.browser.name, "Firefox", "The browser field must be set");
+  is(har.log.creator.name, appName, "The creator field must be set");
+  is(har.log.browser.name, appName, "The browser field must be set");
   is(har.log.pages.length, 1, "There must be one page");
   is(har.log.entries.length, 1, "There must be one request");
 


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2067787