### PR TITLE
Bug 2067799 - Test custom UI reset with enterprise badge

### DIFF
--- a/browser/components/customizableui/test/browser_923857_customize_mode_event_wrapping_during_reset.js
+++ b/browser/components/customizableui/test/browser_923857_customize_mode_event_wrapping_during_reset.js
@@ -8,14 +8,18 @@
 add_task(async function () {
   await startCustomizing();
   let devButton = document.getElementById("developer-button");
-  let fxaButton = document.getElementById("fxa-toolbar-menu-button");
+  let accountButton = document.getElementById(
+    AppConstants.MOZ_ENTERPRISE
+      ? "enterprise-badge-toolbar-button"
+      : "fxa-toolbar-menu-button"
+  );
   let stopReloadButton = document.getElementById("stop-reload-button");
   let palette = document.getElementById("customization-palette");
   ok(
-    devButton && fxaButton && stopReloadButton && palette,
+    devButton && accountButton && stopReloadButton && palette,
     "Stuff should exist"
   );
-  simulateItemDrag(devButton, fxaButton);
+  simulateItemDrag(devButton, accountButton);
   simulateItemDrag(stopReloadButton, palette);
   await gCustomizeMode.reset();
   ok(CustomizableUI.inDefaultState, "Should be back in default state");


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2067799

Replaces the hidden fxa button with the enterprise toolbar button to test custom UI reset.
