### PR TITLE
Bug 2067909 - Fix test environment for content analysis browser tests.

### DIFF
--- a/toolkit/components/contentanalysis/tests/browser/head.js
+++ b/toolkit/components/contentanalysis/tests/browser/head.js
@@ -71,15 +71,20 @@ async function mockContentAnalysisService(mockCAServiceTemplate) {
   // Some of the C++ code that tests if CA is active checks this
   // pref (even though it would perhaps be better to just ask
   // nsIContentAnalysis)
-  await SpecialPowers.pushPrefEnv({
-    set: [["browser.contentanalysis.enabled", true]],
-  });
-  registerCleanupFunction(async function () {
-    SpecialPowers.popPrefEnv();
+  // Avoid pushPrefEnv to work around Bug 2067888 with unbalanced
+  // popPrefEnvs in PrintHelper.withTestPage.
+  Services.prefs.setBoolPref("browser.contentanalysis.enabled", true);
+  registerCleanupFunction(function () {
+    Services.prefs.clearUserPref("browser.contentanalysis.enabled");
   });
   let realCAService = SpecialPowers.Cc[
     "@mozilla.org/contentanalysis;1"
   ].getService(SpecialPowers.Ci.nsIContentAnalysis);
+  // Set command line arg property so CA can be active without policy.
+  realCAService.testOnlySetCACmdLineArg(true);
+  registerCleanupFunction(function () {
+    realCAService.testOnlySetCACmdLineArg(false);
+  });
   let mockCAService = mockService(
     ["nsIContentAnalysis"],
     "@mozilla.org/contentanalysis;1",


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2067909

Changes in #1218 triggered failures for various content analysis browser tests, due to inconsistent mock setup. This fixes the test setup to account for the changes.
- Set testing CLI arg so content analysis is considered to be enabled.
- Work around bare popPrefEnv calls in PrintHelper.withTestPage by just setting pref and clearing it directly.

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Fixes regressions from: #1218 

---

### Testing <!-- OPTIONAL -->

* [x] Fixed tests

<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
