### PR TITLE
Bug 2068069 - Remove tabindex to the browser's enterprise toolbar

### DIFF
--- a/toolkit/components/enterprise/content/enterprise-badge.inc.xhtml
+++ b/toolkit/components/enterprise/content/enterprise-badge.inc.xhtml
@@ -5,7 +5,16 @@
 <html:link rel="stylesheet" href="chrome://enterprise/content/enterprise-badge.css" overflows="false"/>
 <html:link rel="localization" href="toolkit/enterprise/enterprise.ftl" overflows="false"/>
 
-<toolbarbutton id="enterprise-badge-toolbar-button" class="toolbarbutton-1 chromeclass-toolbar-additional" delegatesanchor="true" data-l10n-id="enterprise-toolbar-button" removable="true" cui-areatype="toolbar" tabindex="0">
+<toolbarbutton id="enterprise-badge-toolbar-button"
+               class="toolbarbutton-1 chromeclass-toolbar-additional"
+               delegatesanchor="true"
+               data-l10n-id="enterprise-toolbar-button"
+               removable="true"
+               cui-areatype="toolbar"
+#ifdef MOZ_THUNDERBIRD
+               tabindex="0"
+#endif
+               >
   <hbox>
     <div class="enterprise-badge">
       <div id="enterprise-company-logo__wrapper" class="is-hidden">


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2068069

Wraps the enterprise toolbar button's `tabindex="0"` in a `MOZ_THUNDERBIRD` build flag. 
