### PR TITLE
Bug 2068088 -  Fix stale TabStateFlusher import paths in enterprise browser_policyDisabled.js

### DIFF
--- a/browser/base/content/test/tabcrashed/browser_policyDisabled.js
+++ b/browser/base/content/test/tabcrashed/browser_policyDisabled.js
@@ -12,7 +12,7 @@ const { EnterprisePolicyTesting, PoliciesPrefTracker } =
   );
 
 const { TabStateFlusher } = ChromeUtils.importESModule(
-  "resource:///modules/sessionstore/TabStateFlusher.sys.mjs"
+  "moz-src:///browser/components/sessionstore/TabStateFlusher.sys.mjs"
 );
 
 // On debug builds, crashing tabs results in much thinking, which


### PR DESCRIPTION

<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2068088
