### PR TITLE
Bug 2068141 - Revert to expecting distribution id 'default'

### DIFF
--- a/browser/components/uitour/test/browser_UITour.js
+++ b/browser/components/uitour/test/browser_UITour.js
@@ -513,16 +513,14 @@ var tests = [
         "Check distribution isn't undefined."
       );
       // distribution id defaults to "default" for most builds,
-      // "mozilla-MSIX" for MSIX builds, "mozilla-official" for
-      // official Mozilla builds, and "enterprise-local" for enterprise builds.
+      // "mozilla-MSIX" for MSIX builds, and "mozilla-official" for
+      // official Mozilla builds.
       let expectedDistribution = "default";
       if (
         AppConstants.platform === "win" &&
         Services.sysinfo.getProperty("hasWinPackageId")
       ) {
         expectedDistribution = "mozilla-MSIX";
-      } else if (AppConstants.MOZ_ENTERPRISE) {
-        expectedDistribution = "enterprise-local";
       } else if (AppConstants.BUILT_BY_MOZILLA) {
         expectedDistribution = "mozilla-official";
       }


### PR DESCRIPTION
This reverts commit 7cd0635c05df4d7021bfbd7b17104a72f73ab0a5.

<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2068141

 Revert to expecting distribution id 'default' in enterprise builds since we switched from distribution.ini to AutoConfig in Bug-2048644.