### PR TITLE
Bug 2068176 - Add macOS 27 to the list of known macOS versions, to return the OS name in the posture

### DIFF
--- a/toolkit/components/enterprise/modules/EnterpriseOSInfo.sys.mjs
+++ b/toolkit/components/enterprise/modules/EnterpriseOSInfo.sys.mjs
@@ -108,6 +108,7 @@ function getWindowsServerVersion(buildNumber) {
 }
 
 const MACOS_NAMES = [
+  ["27", "Golden Gate"],
   ["26", "Tahoe"],
   ["15", "Sequoia"],
   ["14", "Sonoma"],


### PR DESCRIPTION
### Description

Bugzilla: Bug-2068176

macOS 27 is newly released and is named Golden Gate. So that the code name is posted in the posture, this patch adds this version to the array matched when the posture is sent.


Not sure I need comprehensive tests for this, but you'll tell me :-)