### PR TITLE
Bug 2068135 - Gate the DownloadsTelemetry enterprise import on AppConstants.MOZ_ENTERPRISE

### DIFF
--- a/browser/components/downloads/DownloadsTelemetry.sys.mjs
+++ b/browser/components/downloads/DownloadsTelemetry.sys.mjs
@@ -11,20 +11,20 @@
  * - In regular builds: No-op implementation (enterprise code completely absent)
  */
 
+import { AppConstants } from "resource://gre/modules/AppConstants.sys.mjs";
+
 let DownloadsTelemetryImpl;
 
-try {
-  // Attempt to import enterprise implementation (only available in MOZ_ENTERPRISE builds)
+// The enterprise module is only packaged in MOZ_ENTERPRISE builds. Gate on
+// AppConstants rather than catching an import failure: in automation, loading a
+// missing chrome/moz-src URL aborts via CheckForBrokenChromeURL before any
+// exception can be caught.
+if (AppConstants.MOZ_ENTERPRISE) {
   const { DownloadsTelemetryEnterprise } = ChromeUtils.importESModule(
     "moz-src:///browser/components/downloads/DownloadsTelemetry.enterprise.sys.mjs"
   );
   DownloadsTelemetryImpl = DownloadsTelemetryEnterprise;
-} catch (ex) {
-  console.warn(
-    "[DownloadsTelemetry] Enterprise implementation not available, using no-op shim. Error:",
-    ex.message
-  );
-  // Enterprise implementation not available, use no-op shim
+} else {
   DownloadsTelemetryImpl = {
     recordFileDownloaded: _download => {},
   };


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2068135

The shim used try/catch around importing DownloadsTelemetry.enterprise.sys.mjs so it could be imported unconditionally. That does not work in non-MOZ_ENTERPRISE builds under automation: CheckForBrokenChromeURL aborts on the missing moz-src URL before the loader can throw a catchable exception, so test_DownloadsTelemetry.js crashes instead of falling back to the no-op shim.

Check AppConstants.MOZ_ENTERPRISE instead, which matches the moz.build condition that packages the enterprise module, and never attempts the import when the file is absent.

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Testing <!-- OPTIONAL -->

* [x] [Try push](https://treeherder.mozilla.org/jobs?repo=enterprise-firefox-try&revision=e324228fc354aa4b11de072b9a6c01d60ecd273e&selectedTaskRun=brqEJkKAQzSy7LEsOdZURA.0) with previously failing test-linux2204-64-wayland/debug-mochitest-remote

<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
