### PR TITLE
Bug 2068527 - Force MOZ_BYPASS_FELT=1 on puppeteer test

### DIFF
--- a/taskcluster/kinds/source-test/puppeteer.yml
+++ b/taskcluster/kinds/source-test/puppeteer.yml
@@ -43,6 +43,7 @@ puppeteer-{this_chunk}:
     run:  # Bug 1651542: Use screenshot feature to warm-up the font cache before the actual test
         using: run-task
         command: >
+            export MOZ_BYPASS_FELT=1 &&
             cd $GECKO_PATH/ &&
             cp -r $MOZ_FETCHES_DIR/puppeteer remote/test/ &&
             $MOZ_FETCHES_DIR/firefox/firefox --screenshot http://example.org &&

--- a/toolkit/xre/nsAppRunner.cpp
+++ b/toolkit/xre/nsAppRunner.cpp
@@ -4777,6 +4777,10 @@ int XREMain::XRE_mainInit(bool* aExitFlag,
 #endif
 
   if (requestedHeadless) {
+    // Upstream uses CheckArg() directly that consumes the argument, but
+    // we have RequestedHeadlessMode() that does not, so let's make sure it
+    // is consumed to avoid leaking it.
+    CheckArg("headless");
     PR_SetEnv("MOZ_HEADLESS=1");
   }
 


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2068527

The test can end up executed against an enterprise build because of how PGOs schedules jobs. Make sure to account for the bypass env variable to make the test execute properly.