### PR TITLE
Bug 2068876 - Run SecurityLogging test only on browser app

### DIFF
--- a/toolkit/mozapps/extensions/test/xpcshell/xpcshell.toml
+++ b/toolkit/mozapps/extensions/test/xpcshell/xpcshell.toml
@@ -150,7 +150,9 @@ run-if = [
 ["test_embedderDisabled.js"]
 
 ["test_enterprise_install_telemetry_policy.js"]
-run-if = ["enterprise"]
+run-if = [
+  "appname != 'thunderbird' && enterprise", # Policy does not exists on Thunderbird
+]
 
 ["test_error.js"]
 skip-if = [


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2068876

Per https://docs.google.com/spreadsheets/d/1h-UmrLEBVmLVEl9eIVQlNkrP-NkgGXfxpzN5tJWCWv4/edit?gid=1904079787#gid=1904079787 the policy does not exists on Thunderbird