### PR TITLE
Bug 2069344 - Make sure COMM_* env variables are here where relevant

### DIFF
--- a/taskcluster/gecko_taskgraph/transforms/task.py
+++ b/taskcluster/gecko_taskgraph/transforms/task.py
@@ -2762,6 +2762,27 @@ def update_treeherder_platform_comm(config, tasks):
 
 
 @transforms.add
+def update_tasks_env_comm(config, tasks):
+    """
+    Make sure that when running as Comm Decision for Thunderbird Enterprise,
+    correct COMM_* environment variables are set. Chain of Trust verification
+    will depend on it.
+    """
+    for task in tasks:
+        if (
+            "enterprise" in config.params["project"]
+            and "comm_base_repository" in config.params
+            and "env" in task["task"]["payload"]
+        ):
+            task["task"]["payload"]["env"].update({
+                "COMM_BASE_REPOSITORY": config.params["comm_base_repository"],
+                "COMM_HEAD_REPOSITORY": config.params["comm_head_repository"],
+                "COMM_HEAD_REV": config.params["comm_head_rev"],
+            })
+        yield task
+
+
+@transforms.add
 def chain_of_trust(config, tasks):
     for task in tasks:
         if task["task"].get("payload", {}).get("features", {}).get("chainOfTrust"):


### PR DESCRIPTION
Tasks of Comm Decision that have an "env" field should make sure to reflect the correct repository and rev, so that scriptworker chain of trust cannot fail for misidentifying this as a legit comm repo.

<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2069344
