### PR TITLE
Bug-2059720, Bug-2059723, Bug-2059726 - Clean up Relay, breach alerts, and data collection sections in about:preferences

### DIFF
--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -532,8 +532,13 @@ pref("browser.urlbar.trackerCount.featureGate", false);
 pref("browser.urlbar.trackerCount.enabled", true);
 
 pref("browser.urlbar.trustPanel.featureGate", true);
+#ifdef MOZ_ENTERPRISE
+pref("browser.urlbar.trustPanel.breachAlerts.featureGate", false);
+pref("browser.urlbar.trustPanel.breachAlerts", false);
+#else
 pref("browser.urlbar.trustPanel.breachAlerts.featureGate", true);
 pref("browser.urlbar.trustPanel.breachAlerts", true);
+#endif
 
 // Whether or not Unified Search Button is shown always.
 pref("browser.urlbar.unifiedSearchButton.always", false);

--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -3049,7 +3049,11 @@ pref("browser.migrate.preferences-entrypoint.enabled", true);
 // "offered"        - we have offered feature to user and they have not yet made a decision.
 // "enabled"        - user opted in to the feature.
 // "disabled"       - user opted out of the feature.
+#ifdef MOZ_ENTERPRISE
+pref("signon.firefoxRelay.feature", "unavailable");
+#else
 pref("signon.firefoxRelay.feature", "available");
+#endif
 pref("signon.management.page.breach-alerts.enabled", true);
 pref("signon.management.page.vulnerable-passwords.enabled", true);
 pref("signon.management.page.sort", "name");

--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -2314,7 +2314,11 @@ pref("nimbus.profilesdatastoreservice.sync.enabled", true);
 #endif
 
 // Enable Rollouts by default.
+#ifdef MOZ_ENTERPRISE
+pref("nimbus.rollouts.enabled", false);
+#else
 pref("nimbus.rollouts.enabled", true);
+#endif
 
 // Nimbus QA prefs. Used to monitor pref-setting test experiments.
 pref("nimbus.qa.pref-1", "default");
@@ -3154,7 +3158,7 @@ pref("app.normandy.shieldLearnMoreUrl", "https://support.mozilla.org/1/firefox/%
 #endif
 pref("app.normandy.last_seen_buildid", "");
 pref("app.normandy.onsync_skew_sec", 600);
-#ifdef MOZ_DATA_REPORTING
+#if defined(MOZ_DATA_REPORTING) && !defined(MOZ_ENTERPRISE)
   pref("app.shield.optoutstudies.enabled", true);
 #else
   pref("app.shield.optoutstudies.enabled", false);
@@ -3195,7 +3199,11 @@ pref("toolkit.coverage.endpoint.base", "https://coverage.mozilla.org");
 #endif
 
 // Enable personalized extension recommendations
+#ifdef MOZ_ENTERPRISE
+pref("browser.discovery.enabled", false);
+#else
 pref("browser.discovery.enabled", true);
+#endif
 
 pref("browser.engagement.recent_visited_origins.expiry", 86400); // 24 * 60 * 60 (24 hours in seconds)
 pref("browser.engagement.downloads-button.has-used", false);

--- a/browser/components/preferences/config/permissions-data.mjs
+++ b/browser/components/preferences/config/permissions-data.mjs
@@ -293,6 +293,15 @@ Preferences.addSetting({
   deps: ["privacySegmentation"],
   visible: ({ privacySegmentation }) =>
     lazy.AppConstants.MOZ_DATA_REPORTING || privacySegmentation.value,
+  getControlConfig(config) {
+    if (lazy.AppConstants.MOZ_ENTERPRISE) {
+      return {
+        ...config,
+        l10nId: "data-collection-enterprise",
+      };
+    }
+    return config;
+  },
 });
 Preferences.addSetting({
   id: "dataCollectionLink",
@@ -331,7 +340,10 @@ Preferences.addSetting({
   id: "telemetryContainer",
   deps: ["submitHealthReportBox"],
   visible: deps => {
-    if (!lazy.AppConstants.MOZ_DATA_REPORTING) {
+    if (
+      !lazy.AppConstants.MOZ_DATA_REPORTING ||
+      lazy.AppConstants.MOZ_ENTERPRISE
+    ) {
       return false;
     }
     return !deps.submitHealthReportBox.value;
@@ -344,6 +356,7 @@ Preferences.addSetting({
 Preferences.addSetting({
   id: "submitHealthReportBox",
   pref: PREF_UPLOAD_ENABLED,
+  visible: () => !lazy.AppConstants.MOZ_ENTERPRISE,
   getControlConfig(config, _, setting) {
     if (!setting.value) {
       return {
@@ -361,7 +374,8 @@ Preferences.addSetting({
   id: "addonRecommendationEnabled",
   pref: PREF_ADDON_RECOMMENDATIONS_ENABLED,
   deps: ["submitHealthReportBox"],
-  visible: () => lazy.AppConstants.MOZ_DATA_REPORTING,
+  visible: () =>
+    lazy.AppConstants.MOZ_DATA_REPORTING && !lazy.AppConstants.MOZ_ENTERPRISE,
   get: (value, deps) => {
     return value && deps.submitHealthReportBox.pref.value;
   },
@@ -373,7 +387,8 @@ Preferences.addSetting({
 
 Preferences.addSetting({
   id: "optOutStudiesEnabled",
-  visible: () => lazy.AppConstants.MOZ_NORMANDY,
+  visible: () =>
+    lazy.AppConstants.MOZ_NORMANDY && !lazy.AppConstants.MOZ_ENTERPRISE,
   pref: PREF_OPT_OUT_STUDIES_ENABLED,
   deps: ["submitHealthReportBox", "normandyEnabled"],
   disabled: ({ submitHealthReportBox, normandyEnabled }) => {
@@ -414,12 +429,15 @@ Preferences.addSetting({
 });
 Preferences.addSetting({
   id: "viewShieldStudies",
+  visible: () => !lazy.AppConstants.MOZ_ENTERPRISE,
 });
 Preferences.addSetting({
   id: "enableNimbusRollouts",
   pref: "nimbus.rollouts.enabled",
   visible: () =>
-    lazy.AppConstants.MOZ_DATA_REPORTING && lazy.AppConstants.MOZ_NORMANDY,
+    lazy.AppConstants.MOZ_DATA_REPORTING &&
+    lazy.AppConstants.MOZ_NORMANDY &&
+    !lazy.AppConstants.MOZ_ENTERPRISE,
   disabled: () => !Services.policies.isAllowed("NimbusRollouts"),
   get: value => {
     if (!Services.policies.isAllowed("NimbusRollouts")) {
@@ -431,13 +449,24 @@ Preferences.addSetting({
 Preferences.addSetting({
   id: "submitUsagePingBox",
   pref: "datareporting.usage.uploadEnabled",
-  visible: () => lazy.AppConstants.MOZ_DATA_REPORTING,
+  visible: () =>
+    lazy.AppConstants.MOZ_DATA_REPORTING && !lazy.AppConstants.MOZ_ENTERPRISE,
 });
 Preferences.addSetting({
   id: "automaticallySubmitCrashesBox",
   pref: "browser.crashReports.unsubmittedCheck.autoSubmit2",
   visible: () =>
     lazy.AppConstants.MOZ_DATA_REPORTING && lazy.AppConstants.MOZ_CRASHREPORTER,
+  getControlConfig(config) {
+    if (lazy.AppConstants.MOZ_ENTERPRISE) {
+      return {
+        ...config,
+        l10nId: "data-collection-backlogged-crash-reports-enterprise",
+        supportPage: undefined,
+      };
+    }
+    return config;
+  },
 });
 Preferences.addSetting(
   /** @type {{ _originalStateOfDataCollectionPrefs: Map<string, any>} & SettingConfig} */ ({

--- a/browser/components/preferences/preferences.xhtml
+++ b/browser/components/preferences/preferences.xhtml
@@ -45,6 +45,9 @@
   <link rel="localization" href="browser/preferences/fonts.ftl"/>
   <link rel="localization" href="browser/preferences/moreFromMozilla.ftl"/>
   <link rel="localization" href="browser/preferences/preferences.ftl"/>
+#ifdef MOZ_ENTERPRISE
+  <link rel="localization" href="toolkit/enterprise/enterprise.ftl"/>
+#endif
   <link rel="localization" href="toolkit/branding/brandings.ftl"/>
   <link rel="localization" href="toolkit/firefoxlabs/features.ftl"/>
   <link rel="localization" href="toolkit/global/mozPageHeader.ftl"/>

--- a/browser/components/preferences/tests/privacy/browser-srd.toml
+++ b/browser/components/preferences/tests/privacy/browser-srd.toml
@@ -39,6 +39,9 @@ skip-if = ["enterprise"] # Enterprise builds repurpose the VPN as the Access Con
 ["browser_privacy_syncDataClearing_v2.js"]
 
 ["browser_privacy_uploadEnabled.js"]
+# Enterprise builds hide the data collection checkboxes, so the
+# submitHealthReportBox checkbox this test targets is never rendered.
+skip-if = ["enterprise"]
 
 ["browser_privacypane_2_srd.js"]
 skip-if = [

--- a/browser/components/preferences/tests/privacy/browser.toml
+++ b/browser/components/preferences/tests/privacy/browser.toml
@@ -59,6 +59,9 @@ skip-if = ["enterprise"] # Enterprise builds repurpose the VPN as the Access Con
 ["browser_privacy_syncDataClearing_v2.js"]
 
 ["browser_privacy_uploadEnabled.js"]
+# Enterprise builds hide the data collection checkboxes, so the
+# submitHealthReportBox checkbox this test targets is never rendered.
+skip-if = ["enterprise"]
 
 ["browser_privacypane_2.js"]
 skip-if = [

--- a/modules/libpref/init/all.js
+++ b/modules/libpref/init/all.js
@@ -3800,7 +3800,11 @@ pref("toolkit.legacyUserProfileCustomizations.stylesheets", false);
     // Health Report is enabled by default on all channels.
     // Do note that the toggle on Fenix and Focus does NOT reflect to this pref.
     pref("datareporting.healthreport.uploadEnabled", true);
-    pref("datareporting.usage.uploadEnabled", true);
+    #ifdef MOZ_ENTERPRISE
+      pref("datareporting.usage.uploadEnabled", false);
+    #else
+      pref("datareporting.usage.uploadEnabled", true);
+    #endif
   #endif
 #endif
 

--- a/toolkit/locales/en-US/toolkit/enterprise/enterprise.ftl
+++ b/toolkit/locales/en-US/toolkit/enterprise/enterprise.ftl
@@ -123,3 +123,16 @@ fp-neterror-access-connector-error-contact-admin = Try again later, or contact y
 # Labels the message an administrator wrote for the data protection rule that
 # was matched, shown in the warn and block dialogs above that message.
 contentanalysis-admin-message-label = Message from your administrator
+
+# Shown in the about:preferences data collection section.
+# Variant of data-collection (preferences.ftl) without the description.
+data-collection-enterprise =
+    .label = { -brand-short-name } data collection and use
+    .searchkeywords = telemetry
+
+# Shown in the about:preferences data collection section.
+# Variant of data-collection-backlogged-crash-reports (preferences.ftl).
+data-collection-backlogged-crash-reports-enterprise =
+    .label = Automatically send crash reports
+    .description = Crash reports help your organization diagnose and fix issues with the browser. Reports may include personal or sensitive data.
+    .accesskey = c


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2059720, Bug-2059723, Bug-2059726

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

This PR spans a few different bugs related to `about:preferences` and either removes or updates different sections for Enterprise builds.

- Bug-2059720: Removed with `signon.firefoxRelay.feature="unavailable"`
- Bug-2059723: Removed with `browser.urlbar.trustPanel.breachAlerts=false` and `browser.urlbar.trustPanel.breachAlerts.featureGate=false`
- Bug-2059726:
  - Only remaining item is the Crash Report checkbox. This is togglable by default, and is locked + checked/unchecked by the `CrashReportsSubmit` policy.
  - Hid the health report, usage ping, add-on recommendations, studies, and Nimbus rollouts checkboxes with MOZ_ENTERPRISE guards in `permissions-data.mjs`
  - Flipped pref defaults for associated checkboxes
    - `datareporting.usage.uploadEnabled=false` - Disable daily usage ping
    - `app.shield.optoutstudies.enabled=false` - Disable feature studies
    - `nimbus.rollouts.enabled=false` - Disable remote rollouts / Nimbus
    - `browser.discovery.enabled=false` - Disable add-on recommendations
    - `datareporting.healthreport.uploadEnabled=true` - left this one alone as it disables all Glean telemetry, which the current Enterprise metrics ride on. This should probably be locked, but deferring that to bug-2046816.
    - Added Enterprise variants of the section heading (no consumer-focused description) and the crash reports string (organization-focused copy, no Learn More link).

---

### Dependencies / Related Issues <!-- OPTIONAL -->

- `datareporting.healthreport.uploadEnabled` deferred to Bug-2046816

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->
|||
|-|-|
|<img width="604" height="528" alt="image" src="https://github.com/user-attachments/assets/fc7d7485-8475-41ea-95e8-f13a41096413" /><br>_Before: Data Collection_|<img width="637" height="184" alt="image" src="https://github.com/user-attachments/assets/b4a518de-38e7-48cd-a8bb-b525590dcadf" /><br>_After: Data Collection_|
|<img width="603" height="422" alt="image" src="https://github.com/user-attachments/assets/321655bd-e2a4-4d13-9ab8-e6e5b37b1fbc" /><br>_Before: Breach Alerts_|<img width="603" height="422" alt="image" src="https://github.com/user-attachments/assets/ed9e8b8f-ae5c-4593-b9a5-20396774853a" /><br>_After: Breach Alerts_|
|<img width="603" height="161" alt="image" src="https://github.com/user-attachments/assets/39c1d8e7-ffe1-4151-a44c-c0a0e9c00fca" /><br>_Before: Firefox Relay_|<img width="603" height="105" alt="image" src="https://github.com/user-attachments/assets/204b553a-c6ec-4308-aa91-d60462a5435f" /><br>_After: Firefox Relay_|

