### PR TITLE
Bug 2069825 - Anchor confirmation hint to enterprise badge

### DIFF
--- a/browser/base/content/browser-sync.js
+++ b/browser/base/content/browser-sync.js
@@ -2686,8 +2686,9 @@ var gSync = {
 
   /**
    * Sends the given tabs to the target devices and, if any send succeeds,
-   * shows the "Sent!" confirmation hint anchored to the FxA toolbar button
-   * (falling back to the app menu button when it isn't available).
+   * shows the "Sent!" confirmation hint anchored to the FxA toolbar button -
+   * in enterprise builds it's anchored to the enterprise badge. (falling back
+   * to the app menu button when it isn't available).
    *
    * @param {object[]} tabsToSend - tabs (as passed to sendTabToDevice) to send.
    * @param {object[]} targets - the devices to send the tabs to.
@@ -2700,16 +2701,26 @@ var gSync = {
     );
     // Show the Sent! confirmation if any of the sends succeeded.
     if (results.includes(true)) {
-      // FxA button could be hidden with CSS since the user is logged out,
-      // although it seems likely this would only happen in testing...
-      let fxastatus = document.documentElement.getAttribute("fxastatus");
-      let anchorNode =
-        (fxastatus &&
-          fxastatus != "not_configured" &&
-          document.getElementById("fxa-toolbar-menu-button")?.parentNode?.id !=
-            "widget-overflow-list" &&
-          document.getElementById("fxa-toolbar-menu-button")) ||
-        document.getElementById("PanelUI-menu-button");
+      let anchorNode;
+      if (AppConstants.MOZ_ENTERPRISE) {
+        // The FxA button is replaced by the enterprise badge, so anchor the
+        // hint there (falling back to the app menu button if it overflowed).
+        let badge = document.getElementById("enterprise-badge-toolbar-button");
+        anchorNode =
+          (badge?.parentNode?.id != "widget-overflow-list" && badge) ||
+          document.getElementById("PanelUI-menu-button");
+      } else {
+        // FxA button could be hidden with CSS since the user is logged out,
+        // although it seems likely this would only happen in testing...
+        let fxastatus = document.documentElement.getAttribute("fxastatus");
+        anchorNode =
+          (fxastatus &&
+            fxastatus != "not_configured" &&
+            document.getElementById("fxa-toolbar-menu-button")?.parentNode
+              ?.id != "widget-overflow-list" &&
+            document.getElementById("fxa-toolbar-menu-button")) ||
+          document.getElementById("PanelUI-menu-button");
+      }
       ConfirmationHint.show(anchorNode, "confirmation-hint-send-to-device");
     }
     fxAccounts.flushLogFile();

--- a/browser/base/content/browser-sync.js
+++ b/browser/base/content/browser-sync.js
@@ -2706,13 +2706,18 @@ var gSync = {
         ? "enterprise-badge-toolbar-button"
         : "fxa-toolbar-menu-button";
 
-      const preferredButton = CustomizableUI.getPlacementOfWidget(preferredButtonId)
+      const preferredButton = CustomizableUI.getPlacementOfWidget(
+        preferredButtonId
+      )
         ? document.getElementById(preferredButtonId)
         : null;
 
       const usePreferredButton =
         preferredButton?.parentNode?.id != "widget-overflow-list" &&
-        preferredButton?.checkVisibility({ checkVisibilityCSS: true, flush: false });
+        preferredButton?.checkVisibility({
+          checkVisibilityCSS: true,
+          flush: false,
+        });
 
       const anchorNode = usePreferredButton ? preferredButton : appMenuButton;
       ConfirmationHint.show(anchorNode, "confirmation-hint-send-to-device");

--- a/browser/base/content/browser-sync.js
+++ b/browser/base/content/browser-sync.js
@@ -2701,26 +2701,20 @@ var gSync = {
     );
     // Show the Sent! confirmation if any of the sends succeeded.
     if (results.includes(true)) {
-      let anchorNode;
-      if (AppConstants.MOZ_ENTERPRISE) {
-        // The FxA button is replaced by the enterprise badge, so anchor the
-        // hint there (falling back to the app menu button if it overflowed).
-        let badge = document.getElementById("enterprise-badge-toolbar-button");
-        anchorNode =
-          (badge?.parentNode?.id != "widget-overflow-list" && badge) ||
-          document.getElementById("PanelUI-menu-button");
-      } else {
-        // FxA button could be hidden with CSS since the user is logged out,
-        // although it seems likely this would only happen in testing...
-        let fxastatus = document.documentElement.getAttribute("fxastatus");
-        anchorNode =
-          (fxastatus &&
-            fxastatus != "not_configured" &&
-            document.getElementById("fxa-toolbar-menu-button")?.parentNode
-              ?.id != "widget-overflow-list" &&
-            document.getElementById("fxa-toolbar-menu-button")) ||
-          document.getElementById("PanelUI-menu-button");
-      }
+      const appMenuButton = document.getElementById("PanelUI-menu-button");
+      const preferredButtonId = AppConstants.MOZ_ENTERPRISE
+        ? "enterprise-badge-toolbar-button"
+        : "fxa-toolbar-menu-button";
+
+      const preferredButton = CustomizableUI.getPlacementOfWidget(preferredButtonId)
+        ? document.getElementById(preferredButtonId)
+        : null;
+
+      const usePreferredButton =
+        preferredButton?.parentNode?.id != "widget-overflow-list" &&
+        preferredButton?.checkVisibility({ checkVisibilityCSS: true, flush: false });
+
+      const anchorNode = usePreferredButton ? preferredButton : appMenuButton;
       ConfirmationHint.show(anchorNode, "confirmation-hint-send-to-device");
     }
     fxAccounts.flushLogFile();

--- a/browser/base/content/test/sync/browser_contextmenu_sendtab.js
+++ b/browser/base/content/test/sync/browser_contextmenu_sendtab.js
@@ -108,7 +108,11 @@ add_task(async function test_sendTabToDevice_showsConfirmationHint_fxa() {
     "FxA button is hidden"
   );
   document.documentElement.setAttribute("fxastatus", "foo");
-  await checkForConfirmationHint("fxa-toolbar-menu-button");
+  await checkForConfirmationHint(
+    AppConstants.MOZ_ENTERPRISE
+      ? "enterprise-badge-toolbar-button"
+      : "fxa-toolbar-menu-button"
+  );
   document.documentElement.setAttribute("fxastatus", "not_configured");
 });
 


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2069825

Updates the confirmation hint after sending  a tab to be anchored to the enterprise toolbar button instead of the fxa toolbar button.

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->