### PR TITLE
Bug 2069857 - Add enterprise-thunderbird for macOS provisioning enterprise profile

### DIFF
--- a/taskcluster/gecko_taskgraph/transforms/hardened_signing.py
+++ b/taskcluster/gecko_taskgraph/transforms/hardened_signing.py
@@ -115,6 +115,8 @@ def add_provisioning_profile_config(config, jobs):
             elif config.params["project"] in (
                 "enterprise-firefox",
                 "enterprise-firefox-try",
+                "enterprise-thunderbird",
+                "enterprise-thunderbird-try",
             ):
                 # Enterprise
                 filename = PROVISIONING_PROFILE_FILENAMES["enterprise"]


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2069857