### PR TITLE
Bug 2069847 - Remove enterprise badge as expected toolbar button

### DIFF
--- a/browser/modules/test/browser/browser_UsageTelemetry_toolbars.js
+++ b/browser/modules/test/browser/browser_UsageTelemetry_toolbars.js
@@ -135,10 +135,6 @@ function assertVisibilityScalars(expected) {
     expected.push("menubar-items_pinned_menu-bar");
   }
 
-  if (AppConstants.MOZ_ENTERPRISE) {
-    expected.push("enterprise-badge-toolbar-button_pinned_nav-bar-end");
-  }
-
   // FIXME(bug 1883857): object metric type not available in artefact builds.
   const widgetPositions = Glean.browserUi.toolbarWidgets?.testGetValue();
   Services.fog.testResetFOG();


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2069847

Update `browser/modules/test/browser/browser_UsageTelemetry_toolbars.js` to not expect the enterprise badge as it was made removable in Bug-2039213.