### PR TITLE
Bug 2067262 - Disable all Enterprise Security logging by default

### DIFF
--- a/browser/components/downloads/DownloadsTelemetry.enterprise.sys.mjs
+++ b/browser/components/downloads/DownloadsTelemetry.enterprise.sys.mjs
@@ -58,7 +58,7 @@ export const DownloadsTelemetryEnterprise = {
   _isEnabled() {
     return Services.prefs.getBoolPref(
       "browser.download.enterprise.telemetry.enabled",
-      true
+      false
     );
   },
 

--- a/browser/components/enterprisepolicies/helpers/WebsiteFilter.sys.mjs
+++ b/browser/components/enterprisepolicies/helpers/WebsiteFilter.sys.mjs
@@ -225,7 +225,7 @@ export let WebsiteFilter = {
   _recordBlocklistDomainBrowsed(originalUrl, resolvedUrl, referrer) {
     const isEnabled = Services.prefs.getBoolPref(
       "browser.policies.enterprise.telemetry.blocklistDomainBrowsed.enabled",
-      true
+      false
     );
     if (!isEnabled) {
       return;

--- a/browser/components/enterprisepolicies/tests/browser/browser_policy_websitefilter_telemetry.js
+++ b/browser/components/enterprisepolicies/tests/browser/browser_policy_websitefilter_telemetry.js
@@ -67,6 +67,38 @@ add_task(async function test_policy_enterprise_telemetry() {
   await clearWebsiteFilter();
 });
 
+add_task(async function test_no_telemetry_without_security_logging_policy() {
+  await setupPolicyEngineWithJson({
+    policies: {
+      WebsiteFilter: `{
+        "Block": ["*://mochi.test/*policy_websitefilter_block*"]
+      }`,
+    },
+  });
+
+  const newTab = BrowserTestUtils.addTab(gBrowser);
+  gBrowser.selectedTab = newTab;
+  try {
+    const browser = newTab.linkedBrowser;
+    const errorPage = BrowserTestUtils.waitForErrorPage(browser);
+    BrowserTestUtils.startLoadingURIString(
+      browser,
+      SUPPORT_FILES_PATH + BLOCKED_PAGE
+    );
+    await errorPage;
+
+    Assert.ok(
+      !Glean.contentPolicy.blocklistDomainBrowsed.testGetValue("enterprise")
+        ?.length,
+      "Blocking a domain records nothing without the SecurityLogging policy"
+    );
+  } finally {
+    BrowserTestUtils.removeTab(newTab);
+    Services.fog.testResetFOG();
+    await clearWebsiteFilter();
+  }
+});
+
 // Checks that a page was blocked by seeing if it was replaced with about:neterror
 async function checkBlockedPageTelemetry(
   url,

--- a/browser/components/safebrowsing/content/test/browser_enterprise_unsafe_site_telemetry.js
+++ b/browser/components/safebrowsing/content/test/browser_enterprise_unsafe_site_telemetry.js
@@ -427,6 +427,24 @@ add_task(async function test_simultaneous_bursts_in_two_tabs() {
   }
 });
 
+add_task(async function test_default_records_nothing() {
+  await SpecialPowers.pushPrefEnv({
+    clear: [
+      ["browser.safebrowsing.enterprise.telemetry.unsafeSiteVisit.enabled"],
+    ],
+  });
+
+  let tab = await loadUnsafeSite(UNSAFE_SITES[0].url);
+  try {
+    let events = Glean.safebrowsing.siteVisit.testGetValue("enterprise");
+    Assert.ok(!events?.length, "Should not record without an enabling policy");
+  } finally {
+    BrowserTestUtils.removeTab(tab);
+    Services.fog.testResetFOG();
+    await SpecialPowers.popPrefEnv();
+  }
+});
+
 add_task(async function test_disabled_records_nothing() {
   await SpecialPowers.pushPrefEnv({
     set: [

--- a/dom/security/nsContentSecurityManager.cpp
+++ b/dom/security/nsContentSecurityManager.cpp
@@ -116,7 +116,7 @@ class RecentBlockedUrlCache {
 static bool BlocklistDomainBrowsedTelemetryIsEnabled() {
   return Preferences::GetBool(
       "browser.policies.enterprise.telemetry.blocklistDomainBrowsed.enabled",
-      true);
+      false);
 }
 
 static nsCString BlocklistDomainBrowsedTelemetryUrlLoggingPolicy() {

--- a/netwerk/url-classifier/nsChannelClassifier.cpp
+++ b/netwerk/url-classifier/nsChannelClassifier.cpp
@@ -426,7 +426,7 @@ static void RecordUnsafeSiteVisit(nsIChannel* aChannel, nsresult aErrorCode,
 
   constexpr auto kPrefEnabled =
       "browser.safebrowsing.enterprise.telemetry.unsafeSiteVisit.enabled"_ns;
-  if (!Preferences::GetBool(kPrefEnabled.get(), true)) {
+  if (!Preferences::GetBool(kPrefEnabled.get(), false)) {
     return;
   }
 

--- a/toolkit/components/downloads/DownloadCore.sys.mjs
+++ b/toolkit/components/downloads/DownloadCore.sys.mjs
@@ -432,7 +432,7 @@ Download.prototype = {
       if (
         Services.prefs.getBoolPref(
           "browser.download.enterprise.telemetry.enabled",
-          true
+          false
         )
       ) {
         this._recordDownloadAttempt();

--- a/toolkit/components/enterprisepolicies/tests/xpcshell/live/test_live_policy_SecurityLogging.js
+++ b/toolkit/components/enterprisepolicies/tests/xpcshell/live/test_live_policy_SecurityLogging.js
@@ -181,11 +181,9 @@ add_task(async function test_security_logging_applied_updated_removed_live() {
   );
   EnterprisePolicyTesting.checkPolicyPref(DOWNLOAD_URL_PREF, undefined, false);
   EnterprisePolicyTesting.checkPolicyPref(DOWNLOAD_FILE_PREF, undefined, false);
-  Assert.ok(DownloadsTelemetryEnterprise._isEnabled());
-  Assert.equal(
-    DownloadsTelemetryEnterprise._processSourceUrl(TEST_URL),
-    TEST_URL,
-    "the download recorder returns to its default after policy removal"
+  Assert.ok(
+    !DownloadsTelemetryEnterprise._isEnabled(),
+    "the download recorder returns to its disabled default after policy removal"
   );
 });
 

--- a/toolkit/components/printing/content/print.js
+++ b/toolkit/components/printing/content/print.js
@@ -452,7 +452,7 @@ var PrintEventHandler = {
   _recordPagePrinted(aSettings) {
     const isEnabled = Services.prefs.getBoolPref(
       "print.enterprise.telemetry.printPage.enabled",
-      true
+      false
     );
     if (!isEnabled) {
       return;

--- a/toolkit/components/reputationservice/ApplicationReputation.cpp
+++ b/toolkit/components/reputationservice/ApplicationReputation.cpp
@@ -1509,7 +1509,7 @@ static void RecordUnsafeDownload(nsIApplicationReputationQuery* aQuery,
 
   constexpr auto kPrefEnabled =
       "browser.safebrowsing.enterprise.telemetry.unsafeDownload.enabled"_ns;
-  if (!Preferences::GetBool(kPrefEnabled.get(), true)) {
+  if (!Preferences::GetBool(kPrefEnabled.get(), false)) {
     return;
   }
 

--- a/toolkit/components/reputationservice/test/unit/test_app_rep_enterprise.js
+++ b/toolkit/components/reputationservice/test/unit/test_app_rep_enterprise.js
@@ -293,6 +293,24 @@ add_task(async function test_every_detection_submits_a_ping() {
   }
 });
 
+add_task(async function test_default_records_nothing() {
+  Services.prefs.clearUserPref(
+    "browser.safebrowsing.enterprise.telemetry.unsafeDownload.enabled"
+  );
+  try {
+    let { shouldBlock } = await queryReputation({
+      sourceURI: blocklistedURI,
+      fileSize: 12,
+    });
+    Assert.ok(shouldBlock, "Download is still blocked without the policy");
+
+    let events = Glean.safebrowsing.download.testGetValue("enterprise");
+    Assert.ok(!events?.length, "Should not record without an enabling policy");
+  } finally {
+    Services.fog.testResetFOG();
+  }
+});
+
 add_task(async function test_disabled_records_nothing() {
   Services.prefs.setBoolPref(
     "browser.safebrowsing.enterprise.telemetry.unsafeDownload.enabled",

--- a/toolkit/mozapps/extensions/AddonManager.sys.mjs
+++ b/toolkit/mozapps/extensions/AddonManager.sys.mjs
@@ -5849,7 +5849,7 @@ AMTelemetry = {
       AppConstants.MOZ_ENTERPRISE &&
       Services.prefs.getBoolPref(
         "extensions.enterprise.telemetry.addonInstall.enabled",
-        true
+        false
       ) &&
       eventMethod === "install" &&
       extraVars?.step === "completed"

--- a/toolkit/mozapps/extensions/test/xpcshell/test_enterprise_install_telemetry_policy.js
+++ b/toolkit/mozapps/extensions/test/xpcshell/test_enterprise_install_telemetry_policy.js
@@ -79,5 +79,8 @@ add_task(async function test_addon_install_telemetry_policy() {
     "the preference is unlocked"
   );
   events = await installExtension("default@example.com");
-  Assert.equal(events?.length, 1, "removing the policy restores collection");
+  Assert.ok(
+    !events?.length,
+    "removing the policy restores the disabled-by-default collection"
+  );
 });


### PR DESCRIPTION
### Description <!-- REQUIRED -->

Bugzilla: Bug-2067262

The following prefs should be false by default:

```
browser.download.enterprise.telemetry.enabled
browser.policies.enterprise.telemetry.blocklistDomainBrowsed.enabled
browser.safebrowsing.enterprise.telemetry.unsafeDownload.enabled
browser.safebrowsing.enterprise.telemetry.unsafeSiteVisit.enabled
extensions.enterprise.telemetry.addonInstall.enabled
print.enterprise.telemetry.printPage.enabled
```

All related prefs:

```
browser.download.enterprise.telemetry.enabled
browser.download.enterprise.telemetry.fileLogging
browser.download.enterprise.telemetry.urlLogging
browser.policies.enterprise.telemetry.blocklistDomainBrowsed.enabled
browser.policies.enterprise.telemetry.blocklistDomainBrowsed.urlLogging
browser.safebrowsing.enterprise.telemetry.unsafeDownload.enabled
browser.safebrowsing.enterprise.telemetry.unsafeDownload.urlLogging
browser.safebrowsing.enterprise.telemetry.unsafeSiteVisit.enabled
browser.safebrowsing.enterprise.telemetry.unsafeSiteVisit.urlLogging
extensions.enterprise.telemetry.addonInstall.enabled
print.enterprise.telemetry.printPage.enabled
print.enterprise.telemetry.printPage.urlLogging
```


Note that `browser.contentanalysis.enterprise.telemetry.enabled` is not affected since that's controlled in https://firefox-admin-docs.mozilla.org/reference/policies/contentanalysistelemetry/

### Testing <!-- OPTIONAL -->

* [x] Added tests
* [x] Manual testing performed

**Steps to verify changes:**
1. ./mach run
2. print page / download a resource

**Expected result:**

No `*.enterprise.telemetry.*` is sent by default