### PR TITLE
Bug 2069904 - Skip content sandbox test on windows for access to felt.json

### DIFF
--- a/security/sandbox/test/browser_content_sandbox_fs_tests.js
+++ b/security/sandbox/test/browser_content_sandbox_fs_tests.js
@@ -117,18 +117,23 @@ async function testFileAccessAllPlatforms() {
   }
 
   if (AppConstants.MOZ_ENTERPRISE) {
-    const uAppDataDir = GetUserAppDataDir();
-    const feltJson = uAppDataDir.clone();
-    feltJson.append("felt.json");
-    await IOUtils.writeUTF8(feltJson.path, "{}");
-    tests.push({
-      desc: "felt storage", // description
-      ok: false, // expected to succeed?
-      browser: webBrowser, // browser to run test in
-      file: feltJson, // nsIFile object
-      minLevel: minProfileReadSandboxLevel(), // min level to enable test
-      func: readFile,
-    });
+    if (AppConstants.platform != "win") {
+      // felt.json lives in UAppData, not the profile.
+      // The Windows content sandbox does not deny access to
+      // UAppData (bug 2069930), so there it is currently readable.
+      const uAppDataDir = GetUserAppDataDir();
+      const feltJson = uAppDataDir.clone();
+      feltJson.append("felt.json");
+      await IOUtils.writeUTF8(feltJson.path, "{}");
+      tests.push({
+        desc: "felt storage", // description
+        ok: false, // expected to succeed?
+        browser: webBrowser, // browser to run test in
+        file: feltJson, // nsIFile object
+        minLevel: minProfileReadSandboxLevel(), // min level to enable test
+        func: readFile,
+      });
+    }
 
     const feltPendingURLs = GetProfileEntry("pendingURLs.json");
     await IOUtils.writeUTF8(feltPendingURLs.path, "{}");

--- a/security/sandbox/test/browser_content_sandbox_fs_tests.js
+++ b/security/sandbox/test/browser_content_sandbox_fs_tests.js
@@ -117,7 +117,7 @@ async function testFileAccessAllPlatforms() {
   }
 
   if (AppConstants.MOZ_ENTERPRISE) {
-    if (AppConstants.platform != "win") {
+    if (AppConstants.platform !== "win") {
       // felt.json lives in UAppData, not the profile.
       // The Windows content sandbox does not deny access to
       // UAppData (bug 2069930), so there it is currently readable.

--- a/toolkit/components/felt/FeltStorage.sys.mjs
+++ b/toolkit/components/felt/FeltStorage.sys.mjs
@@ -9,11 +9,11 @@ ChromeUtils.defineESModuleGetters(lazy, {
 });
 
 /**
- * Storage helper for reading and writing felt-related profile data to felt.json
+ * Storage helper for reading and writing felt-related data to felt.json
  */
 export const FeltStorage = {
   /**
-   * Absolute path to the felt.json file in the current profile.
+   * Absolute path to the felt.json file in the user's app-data directory (UAppData).
    *
    * @type {string}
    */


### PR DESCRIPTION

<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2069904

Skips the content sandbox 

`browser_content_sandbox_fs_tests.js` asserts that a web content process cannot read the felt storage. felt.json lives in UAppData rather than the profile, and the Windows content sandbox hardens the profile directory but not UAppData. Hence felt.json is currently readable from content on Windows.

This wraps the felt.json read assertion in a non-Windows check. It also corrects the `FeltStorage` docs comment to state that felt.json is stored in UAppData.

Follow-up work done in Bug-2069930.

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->