### PR TITLE
Bug 2069950 - Handle non-string securitySoftware values in broken site report

### DIFF
--- a/toolkit/components/reportbrokensite/ReportBrokenSiteParent.sys.mjs
+++ b/toolkit/components/reportbrokensite/ReportBrokenSiteParent.sys.mjs
@@ -640,9 +640,14 @@ export class ReportBrokenSiteParent extends JSWindowActorParent {
   #getSecurityInfo(troubleshootingInfo) {
     const result = {};
     for (const [k, v] of Object.entries(troubleshootingInfo.securitySoftware)) {
-      result[k.replace("registered", "").toLowerCase()] = v
-        ? v.split(";")
-        : null;
+      const key = k.replace("registered", "").toLowerCase();
+      if (Array.isArray(v)) {
+        result[key] = v;
+      } else if (v) {
+        result[key] = v.split(";");
+      } else {
+        result[key] = null;
+      }
     }
 
     // Right now, security data is only available for Windows builds, and


### PR DESCRIPTION


<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2069950

`securitySoftware` includes `presentEdrs`, an array, so `#getSecurityInfo`'s `v.split(";")` threw "v.split is not a function", aborting webcompat info gathering and breaking Report Broken Site (and its tests). So pass arrays through, split strings, null otherwise.