### PR TITLE
Bug 2071363 - Enterprise: end-to-end GitHub dispatch and monitoring

### DIFF
--- a/python/mozbuild/mozbuild/schedules.py
+++ b/python/mozbuild/mozbuild/schedules.py
@@ -68,6 +68,7 @@ EXCLUSIVE_COMPONENTS = [
     "web-platform-tests",
     # specific test suites
     "crashtest",
+    "enterprise-end2end",
     "mochitest-a11y",
     "mochitest-browser-a11y",
     "mochitest-browser-media",

--- a/taskcluster/gecko_taskgraph/transforms/task.py
+++ b/taskcluster/gecko_taskgraph/transforms/task.py
@@ -2067,6 +2067,26 @@ def setup_raptor(config, tasks):
 
 
 @transforms.add
+def setup_enterprise_end2end(config, tasks):
+    """Add options that are specific to enterprise_end2end jobs (identified by suite=enterprise_end2end).
+
+    This variant uses a separate set of transforms for manipulating the tests at the
+    task-level. Currently only used for setting the taskcluster proxy setting and
+    the scopes required for enterprise end2end github api secrets.
+    """
+    from gecko_taskgraph.transforms.test.enterprise import (
+        task_transforms as enterprise_end2end_transforms,
+    )
+
+    for task in tasks:
+        if task.get("extra", {}).get("suite", "") != "enterprise-end2end":
+            yield task
+            continue
+
+        yield from enterprise_end2end_transforms(config, [task])
+
+
+@transforms.add
 def task_name_from_label(config, tasks):
     for task in tasks:
         taskname = task.pop("name", None)

--- a/taskcluster/gecko_taskgraph/transforms/test/enterprise.py
+++ b/taskcluster/gecko_taskgraph/transforms/test/enterprise.py
@@ -1,0 +1,43 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from taskgraph.transforms.base import TransformSequence
+
+task_transforms = TransformSequence()
+
+
+@task_transforms.add
+def force_optimization(config, tasks):
+    for task in tasks:
+        task["optimization"] = {"never": None}
+        yield task
+
+
+@task_transforms.add
+def force_test_manifests(config, tasks):
+    for task in tasks:
+        task["attributes"]["test_manifests"] = ["empty.toml"]
+        yield task
+
+
+@task_transforms.add
+def add_scopes_and_proxy(config, tasks):
+    for task in tasks:
+        task.setdefault("worker", {})["taskcluster-proxy"] = True
+        task.setdefault("scopes", []).append(
+            "secrets:get:project/enterprise/level-{level}/enterprise-console-backend-apitoken"
+        )
+        yield task
+
+
+@task_transforms.add
+def add_upstream_tasks(config, tasks):
+    for task in tasks:
+        task["worker"].setdefault("env", {})["UPSTREAM_TASKIDS"] = {
+            # We only want signing related tasks here, not build (used by mac builds for signing artifact resolution)
+            "task-reference": " ".join([
+                f"<{dep}>" for dep in task["dependencies"] if ("build" in dep)
+            ])
+        }
+        yield task

--- a/taskcluster/gecko_taskgraph/transforms/test/other.py
+++ b/taskcluster/gecko_taskgraph/transforms/test/other.py
@@ -214,13 +214,14 @@ def set_download_symbols(config, tasks):
     on demand for everything else. ASAN builds shouldn't download
     symbols since they don't product symbol zips see bug 1283879"""
     for task in tasks:
-        if task["test-platform"].split("/")[-1] == "debug":
-            task["mozharness"]["download-symbols"] = True
-        elif "asan" in task["build-platform"] or "tsan" in task["build-platform"]:
-            if "download-symbols" in task["mozharness"]:
-                del task["mozharness"]["download-symbols"]
-        else:
-            task["mozharness"]["download-symbols"] = "ondemand"
+        if task["suite"] != "enterprise-end2end":
+            if task["test-platform"].split("/")[-1] == "debug":
+                task["mozharness"]["download-symbols"] = True
+            elif "asan" in task["build-platform"] or "tsan" in task["build-platform"]:
+                if "download-symbols" in task["mozharness"]:
+                    del task["mozharness"]["download-symbols"]
+            else:
+                task["mozharness"]["download-symbols"] = "ondemand"
         yield task
 
 
@@ -818,6 +819,7 @@ def ensure_spi_disabled_on_all_but_spi(config, tasks):
         has_no_setpref = (
             "gtest",
             "cppunit",
+            "enterprise-end2end",
             "jittest",
             "junit",
             "raptor",
@@ -1064,6 +1066,7 @@ def enable_webrender(config, tasks):
             "gtest",
             "jittest",
             "raptor",
+            "enterprise-end2end",
         ]:
             extra_options.append("--setpref=layers.d3d11.enable-blacklist=false")
 

--- a/taskcluster/kinds/test/enterprise-end2end.yml
+++ b/taskcluster/kinds/test/enterprise-end2end.yml
@@ -1,0 +1,21 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+---
+enterprise-end2end:
+    run-on-projects: built-projects
+    tier: default
+    attributes:
+        code-review: true
+    worker-type: default
+    treeherder-symbol: Ent-End2End
+    # treeherder-machine-platform: gecko-decision/opt
+    suite: enterprise-end2end
+    description: Running Enterprise end-to-end tests
+    allow-software-gl-layers: false
+    max-run-time: 7200
+    mozharness:
+        script: enterprise-end2end.py
+        config:
+            - enterprise/end2end.py
+            - remove_executables.py

--- a/taskcluster/kinds/test/kind.yml
+++ b/taskcluster/kinds/test/kind.yml
@@ -32,6 +32,7 @@ tasks-from:
     - awsy.yml
     - compiled.yml
     - devtools-compat.yml
+    - enterprise-end2end.yml
     - firefox-ui.yml
     - marionette.yml
     - misc.yml

--- a/taskcluster/test_configs/test-sets.yml
+++ b/taskcluster/test_configs/test-sets.yml
@@ -223,6 +223,7 @@ linux-tests:
     - xpcshell
 
 linux-tests-enterprise:
+    - enterprise-end2end
     - gtest
     - marionette-integration
     - marionette-enterprise
@@ -385,6 +386,7 @@ windows11-25h2-tests:
     - xpcshell
 
 windows11-25h2-tests-enterprise:
+    - enterprise-end2end
     - gtest
     - marionette-integration
     - marionette-enterprise
@@ -498,6 +500,7 @@ macosx1500-64-tests:
     - web-platform-tests-webrtc
 
 macosx1500-64-tests-enterprise:
+    - enterprise-end2end
     - gtest
     - marionette-integration
     - marionette-enterprise

--- a/testing/mozbase/moztest/moztest/resolve.py
+++ b/testing/mozbase/moztest/moztest/resolve.py
@@ -59,6 +59,11 @@ TEST_SUITES = {
             "test-verify($|.*(-1|[^0-9])$)",
         ],
     },
+    "enterprise-end2end": {
+        "aliases": ("e-e2e",),
+        "build_flavor": "enterprise",
+        "task_regex": ["enterprise-end2end($|.*(-1|[^0-9])$)"],
+    },
     "firefox-ui-functional": {
         "aliases": ("fxfn",),
         "mach_command": "firefox-ui-functional",
@@ -536,6 +541,7 @@ _test_flavors = {
     "browser-chrome": "mochitest-browser-chrome",
     "chrome": "mochitest-chrome",
     "crashtest": "crashtest",
+    "enterprise-end2end": "enterprise-end2end",
     "firefox-ui-functional": "firefox-ui-functional",
     "firefox-ui-update": "firefox-ui-update",
     "marionette": "marionette",
@@ -562,6 +568,7 @@ _test_subsuites = {
     ("browser-chrome", "screenshots"): "mochitest-browser-screenshots",
     ("browser-chrome", "translations"): "mochitest-browser-translations",
     ("chrome", "gpu"): "mochitest-chrome-gpu",
+    ("enterprise-end2end", "integration"): "enterprise-end2end",
     ("marionette", "enterprise"): "marionette-enterprise",
     ("marionette", "integration"): "marionette-integration",
     ("marionette", "unittest"): "marionette-unittest",

--- a/testing/mozharness/configs/enterprise/end2end.py
+++ b/testing/mozharness/configs/enterprise/end2end.py
@@ -1,0 +1,18 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+#####
+config = {
+    "owner": "mozilla",
+    "repo": "enterprise-console",
+    "secret_files": [
+        {
+            "filename": "enterprise-console-backend-apitoken",
+            "secret_name": "project/enterprise/level-%(scm-level)s/enterprise-console-backend-apitoken",
+            "min_scm_level": 1,
+            "mode": 0o600,
+        },
+    ],
+}

--- a/testing/mozharness/scripts/enterprise-end2end.py
+++ b/testing/mozharness/scripts/enterprise-end2end.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import io
+import json
+import os
+import sys
+import time
+import zipfile
+from urllib.error import HTTPError
+from urllib.request import Request, urlopen
+
+# load modules from parent dir
+sys.path.insert(1, os.path.dirname(sys.path[0]))
+
+from mozharness.base.vcs.vcsbase import MercurialScript
+from mozharness.mozilla.automation import (
+    TBPL_FAILURE,
+    TBPL_STATUS_DICT,
+    TBPL_SUCCESS,
+)
+from mozharness.mozilla.secrets import SecretsMixin
+from mozharness.mozilla.testing.testbase import TestingMixin
+
+
+class EnterpriseEnd2EndTest(TestingMixin, MercurialScript, SecretsMixin):
+    config_options = ()
+
+    repos = []
+
+    def __init__(self, require_config_file=False):
+        super().__init__(
+            config_options=self.config_options,
+            all_actions=[
+                "clobber",
+                "get-secrets",
+                "run-tests",
+            ],
+            default_actions=[
+                "clobber",
+                "get-secrets",
+                "run-tests",
+            ],
+            require_config_file=require_config_file,
+            config={"require_test_zip": True},
+        )
+
+    def query_abs_dirs(self):
+        if self.abs_dirs:
+            return self.abs_dirs
+        abs_dirs = super().query_abs_dirs()
+        dirs = {}
+        dirs["abs_blob_upload_dir"] = os.path.join(
+            abs_dirs["abs_work_dir"], "blobber_upload_dir"
+        )
+
+        for key in dirs.keys():
+            if key not in abs_dirs:
+                abs_dirs[key] = dirs[key]
+        self.abs_dirs = abs_dirs
+        return self.abs_dirs
+
+    def github_api(self, url, headers, payload=None, raw=False):
+        """Perform a GitHub API call, returning (status code, decoded body).
+
+        With `raw`, the body is returned as bytes instead of being decoded as
+        JSON: the log download endpoints redirect to an archive, so the body
+        that comes back is not JSON at all.
+        """
+        data = None
+        if payload is not None:
+            data = json.dumps(payload).encode("utf-8")
+            headers = dict(headers, **{"Content-Type": "application/json"})
+
+        try:
+            with urlopen(Request(url, data=data, headers=headers)) as response:
+                status, body = response.status, response.read()
+        except HTTPError as error:
+            status, body = error.code, error.read()
+
+        if raw:
+            return status, body
+
+        if not body:
+            return status, {}
+
+        try:
+            return status, json.loads(body)
+        except ValueError:
+            return status, {"message": body.decode("utf-8", "replace")}
+
+    def run_tests(self):
+        dirs = self.query_abs_dirs()
+
+        raw_log_file = os.path.join(
+            dirs["abs_blob_upload_dir"], "enterprise_end2end_raw.log"
+        )
+        error_summary_file = os.path.join(
+            dirs["abs_blob_upload_dir"], "enterprise_end2end_errorsummary.log"
+        )
+
+        config_fmt_args = {
+            "raw_log_file": raw_log_file,
+            "error_summary_file": error_summary_file,
+            "gecko_log": dirs["abs_blob_upload_dir"],
+            "this_chunk": self.config.get("this_chunk", 1),
+            "total_chunks": self.config.get("total_chunks", 1),
+            "repo": self.config.get("repo"),
+            "owner": self.config.get("owner"),
+            "workflow_id": "EMPTY",
+        }
+
+        # python = self.query_python_path("python")
+        # cmd = [python, "-u", os.path.join(dirs["abs_enterprise_end2end_dir"], "runtests.py")]
+
+        if self.mkdir_p(dirs["abs_blob_upload_dir"]) == -1:
+            # Make sure that the logging directory exists
+            self.fatal("Could not create blobber upload directory")
+
+        env = {}
+        env["MOZ_UPLOAD_DIR"] = self.query_abs_dirs()["abs_blob_upload_dir"]
+
+        if not os.path.isdir(env["MOZ_UPLOAD_DIR"]):
+            self.mkdir_p(env["MOZ_UPLOAD_DIR"])
+
+        env = self.query_env(partial_env=env)
+
+        build_task = os.environ.get("UPSTREAM_TASKIDS", None)
+        assert build_task, "There should be an upstream task ID"
+
+        self.log(f"GitHub Workflow against: {build_task}")
+
+        token = None
+        with open("enterprise-console-backend-apitoken") as token_file:
+            token = token_file.read().strip()
+
+        base_url = (
+            "https://api.github.com/repos/%(owner)s/%(repo)s/actions" % config_fmt_args
+        )
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2026-03-10",
+        }
+
+        workflows_url = f"{base_url}/workflows"
+        self.log(f"GitHub Workflows URL: {workflows_url}")
+        status_code, data = self.github_api(workflows_url, headers)
+        if status_code != 200:
+            self.log(f"GitHub Workflow list failed: {data.get('message')}")
+            raise ValueError(f"github workflow list failed: {status_code}")
+        self.log(f"GitHub Workflows URL: {workflows_url}: returned {status_code}")
+
+        config_fmt_args["workflow_id"] = next(
+            w
+            for w in data["workflows"]
+            if w["state"] == "active" and w["name"] == "Test"
+        )["id"]
+
+        dispatches_url = (
+            base_url + "/workflows/%(workflow_id)s/dispatches" % config_fmt_args
+        )
+        payload = {
+            "ref": "main",
+            "inputs": {
+                "fxe_task_id": f"{build_task}",
+                "affected_scopes": json.dumps('["e2e"]'),
+            },
+        }
+
+        self.log(
+            f"GitHub Workflow Dispatches: {dispatches_url}: returned {status_code}"
+        )
+        status_code, data = self.github_api(dispatches_url, headers, payload=payload)
+        if status_code != 200:
+            self.log(f"GitHub Workflow dispatch failed: {data.get('message')}")
+            raise ValueError(f"github workflow dispatch failed: {status_code}")
+        self.log(
+            f"GitHub Workflow Dispatches: {dispatches_url}: returned {status_code}"
+        )
+
+        run_url = data["run_url"]
+        self.log(f"GitHub Workflow Run: {run_url}")
+
+        return_code = 1
+        while True:
+            status_code, data = self.github_api(run_url, headers)
+            self.log(f"GitHub Workflow Run: {run_url}: status {data['status']}")
+
+            if data["status"] == "completed":  # adjust condition as needed
+                return_code = 0 if data["conclusion"] == "success" else 1
+                break
+
+            self.log("GitHub Workflow: wait 30s")
+            time.sleep(30)
+
+        raw_log_link = os.path.join(dirs["abs_blob_upload_dir"], "github_logs.txt")
+        with open(raw_log_link, "w") as log_link:
+            log_link.write(f"{run_url}/logs")
+
+        status_code, logs = self.github_api(f"{run_url}/logs", headers, raw=True)
+        if status_code != 200:
+            self.log(
+                f"GitHub Workflow logs failed: {logs[:512].decode('utf-8', 'replace')}"
+            )
+            raise ValueError(f"github workflow logs failed: {status_code}")
+
+        logs_zip_file = os.path.join(dirs["abs_blob_upload_dir"], "github_logs.zip")
+        with open(logs_zip_file, "wb") as zip_file:
+            zip_file.write(logs)
+
+        def log_order(name):
+            """Order "<index>_<job name>.txt" entries by their numeric index."""
+            index = name.split("_", 1)[0]
+            return (int(index) if index.isdigit() else -1, name)
+
+        with zipfile.ZipFile(io.BytesIO(logs)) as archive:
+            # The archive holds one text file per job at its top level, and the
+            # same content split per step in a directory per job below that.
+            entries = [name for name in archive.namelist() if name.endswith(".txt")]
+            per_job = sorted(
+                [name for name in entries if "/" not in name] or entries, key=log_order
+            )
+            for name in per_job:
+                # Replayed line by line by the logger, so the GitHub workflow
+                # output ends up in the task log rather than in an artifact
+                # nobody thinks to open.
+                self.log(f"===== GitHub Workflow log: {name} =====")
+                self.log(archive.read(name).decode("utf-8", "replace"))
+
+        # The work happens in the GitHub workflow, so its conclusion is the
+        # whole result: there is no local output for an output parser to read,
+        # and `evaluate_parser` would call every run a failure for want of a
+        # `passed: N` line to count.
+        tbpl_status = TBPL_SUCCESS if return_code == 0 else TBPL_FAILURE
+        log_level = TBPL_STATUS_DICT[tbpl_status]
+
+        self.log(
+            "Enterprise End-to-end exited with return code %s: %s"
+            % (return_code, tbpl_status),
+            level=log_level,
+        )
+        self.record_status(tbpl_status, level=log_level)
+
+
+if __name__ == "__main__":
+    enterpriseEnd2EndTest = EnterpriseEnd2EndTest()
+    enterpriseEnd2EndTest.run_and_exit()


### PR DESCRIPTION
Bugzilla: Bug-2071363

Trigger Enterprise console's End-to-end tests from TaskCluster, report the status. Should mirror the logs as well.