### PR TITLE
Bug 2040659 - Name the browser run that reports a posture

### DIFF
--- a/testing/enterprise/manifest-generic.toml
+++ b/testing/enterprise/manifest-generic.toml
@@ -18,6 +18,8 @@ subsuite = "enterprise"
 
 ["test_felt_device_posture_refresh_rejected.py"]
 
+["test_felt_device_posture_session_id.py"]
+
 ["test_felt_email_input_focus.py"]
 
 ["test_felt_exit_tokens.py"]

--- a/testing/enterprise/test_felt_device_posture.py
+++ b/testing/enterprise/test_felt_device_posture.py
@@ -8,6 +8,7 @@ import platform
 import re
 import sys
 import time
+import uuid
 
 sys.path.append(os.path.dirname(__file__))
 
@@ -151,6 +152,9 @@ class FeltDevicePosture(FeltTests):
             f"Expected device posture to report applicationName: '{expected_app_name}' but got '{device_posture['build']['applicationName']}'"
         )
         assert "secureBootEnabled" in device_posture
+
+        # Validate the browser-run identifier.
+        uuid.UUID(device_posture["clientSessionId"])
 
         assert "isDomainJoined" in device_posture
         assert isinstance(device_posture["isDomainJoined"], bool), (

--- a/testing/enterprise/test_felt_device_posture_session_id.py
+++ b/testing/enterprise/test_felt_device_posture_session_id.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import os
+import sys
+import uuid
+
+sys.path.append(os.path.dirname(__file__))
+
+import requests
+from felt_tests import FeltTests
+from marionette_driver.errors import (
+    NoSuchWindowException,
+    UnknownException,
+)
+
+
+class FeltDevicePostureSessionId(FeltTests):
+    """The posture session ID changes when Felt relaunches the browser."""
+
+    EXTRA_PREFS = {
+        "toolkit.telemetry.enabled": False,
+        "datareporting.healthreport.uploadEnabled": False,
+    }
+
+    def test_client_session_id_changes_across_restart(self):
+        super().run_felt_base()
+        self.connect_child_browser()
+
+        before = self.session_ids()
+        assert len(before) == 1, (
+            f"One browser run reports one session id, got {sorted(before)}"
+        )
+        for session_id in before:
+            uuid.UUID(session_id)
+
+        self.restart_browser()
+
+        # Wait for the relaunched browser to report its new session ID.
+        ids = self._wait_for_new_session_id(before)
+        new_ids = ids - before
+        assert len(new_ids) == 1, (
+            f"The relaunched browser reports one new session id, got {sorted(new_ids)}"
+        )
+        for session_id in new_ids:
+            uuid.UUID(session_id)
+
+    def session_ids(self):
+        console_addr = f"http://localhost:{self.console_port}"
+        r = requests.get(f"{console_addr}/sso/get_device_posture_history")
+        return {p["clientSessionId"] for p in r.json()}
+
+    def _wait_for_new_session_id(self, before):
+        ids = self._longwait.until(
+            lambda _: (self.session_ids() - before) or None,
+            message="No posture from the relaunched browser",
+        )
+        return before | ids
+
+    def restart_browser(self):
+        browser_pid = self._child_driver.session_capabilities["moz:processID"]
+        self._child_driver.set_context("chrome")
+        try:
+            self._child_driver.execute_script(
+                "Services.startup.quit(Ci.nsIAppStartup.eRestart | Ci.nsIAppStartup.eAttemptQuit);"
+            )
+        except (UnknownException, NoSuchWindowException, OSError):
+            # The browser goes away while the command is in flight.
+            pass
+        self.wait_process_exit(browser_pid)
+        self.connect_child_browser()
+        assert (
+            self._child_driver.session_capabilities["moz:processID"] != browser_pid
+        ), "Felt started a new browser process"

--- a/toolkit/components/enterprise/modules/DevicePosture.sys.mjs
+++ b/toolkit/components/enterprise/modules/DevicePosture.sys.mjs
@@ -28,6 +28,33 @@ ChromeUtils.defineLazyGetter(lazy, "log", () => {
 // empty or malformed means "probe nothing".
 export const EDR_AGENTS_PREF = "enterprise.posture.edr_agents";
 
+/**
+ * Identifies the managed browser run in posture reports. The random id is kept
+ * in module state so it works without telemetry and is never persisted.
+ */
+export const ClientSession = {
+  _id: null,
+
+  /**
+   * Replaces the id for a new browser run.
+   *
+   * @returns {string} The new id.
+   */
+  renew() {
+    this._id = globalThis.crypto.randomUUID();
+    return this._id;
+  },
+
+  /**
+   * The current session id, created on first use.
+   *
+   * @returns {string}
+   */
+  get id() {
+    return (this._id ??= globalThis.crypto.randomUUID());
+  },
+};
+
 /** The write side of EDR_AGENTS_PREF. */
 export const EdrAgents = {
   /**
@@ -210,6 +237,7 @@ export const DevicePosture = {
    * @property {boolean} secureBootEnabled Whether Secure Boot is enabled.
    * @property {boolean} isDomainJoined Whether the machine is joined to a domain (Windows on-prem AD or Azure AD/Entra).
    * @property {DeviceEdr[]} presentEdrs Detected EDR agents (empty if none, or if the console asked us to probe none).
+   * @property {string} clientSessionId Identifies the browser run reporting this posture; see ClientSession.
    */
 
   /**
@@ -314,6 +342,7 @@ export const DevicePosture = {
         Services.sysinfo.getPropertyAsBool("secureBootEnabled"),
       isDomainJoined: Services.sysinfo.getPropertyAsBool("isDomainJoined"),
       presentEdrs,
+      clientSessionId: ClientSession.id,
     };
     return devicePosturePayload;
   },
@@ -414,6 +443,14 @@ export const PostureMonitor = {
   record(posture, measuredAt) {
     this._lastJson = JSON.stringify(posture);
     this._lastAt = measuredAt;
+  },
+
+  /**
+   * Clears the baseline so the next refresh collects a new posture.
+   */
+  forget() {
+    this._lastJson = null;
+    this._lastAt = 0;
   },
 
   /**

--- a/toolkit/components/felt/content/FeltProcessParent.sys.mjs
+++ b/toolkit/components/felt/content/FeltProcessParent.sys.mjs
@@ -6,6 +6,7 @@ const lazy = {};
 
 ChromeUtils.defineESModuleGetters(lazy, {
   Subprocess: "resource://gre/modules/Subprocess.sys.mjs",
+  ClientSession: "resource://gre/modules/enterprise/DevicePosture.sys.mjs",
   ConsoleClient: "resource://gre/modules/enterprise/ConsoleClient.sys.mjs",
   DevicePosture: "resource://gre/modules/enterprise/DevicePosture.sys.mjs",
   EDR_AGENTS_PREF: "resource://gre/modules/enterprise/DevicePosture.sys.mjs",
@@ -537,6 +538,15 @@ export class FeltProcessParent extends JSProcessActorParent {
   }
 
   async startFirefox(startReason, ssoCollectedCookies = []) {
+    // Finish refreshes from the previous browser before replacing its session
+    // id and clearing the posture baseline.
+    if (startReason !== PROCESS_START_REASON.INITIAL_START) {
+      await lazy.PostureMonitor.idle();
+      await gBrowserRefresh;
+      lazy.ClientSession.renew();
+      lazy.PostureMonitor.forget();
+    }
+
     this.restartReported = false;
     this.logoutReported = false;
     this.exitReported = false;
@@ -1104,6 +1114,8 @@ export class FeltProcessParent extends JSProcessActorParent {
           const { path: profileDir } = await this._resolveProfile();
           let posture;
           const measuredAt = Date.now();
+          // Include the new browser's session id in its initial posture.
+          lazy.ClientSession.renew();
           try {
             posture = await lazy.DevicePosture.collect({ profileDir });
           } catch (e) {


### PR DESCRIPTION
Device posture now includes a random `clientSessionId` that stays constant for one managed browser run and changes on relaunch. This lets the console detect restarts even when no other posture values change.

The ID is kept only in `DevicePosture` module state, so it works with telemetry disabled and is never persisted. Felt waits for outstanding refreshes before replacing it and clearing the monitor's baseline, preventing stale posture from being reused.

Tested locally: `test_felt_device_posture_session_id.py` and the existing posture and restart tests pass.
