### PR TITLE
Bug 2070179 - Restrict MOZ_BYPASS_FELT, and remove MOZ_AUTOMATION checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2318,6 +2318,7 @@ dependencies = [
  "libc",
  "log",
  "moz_task",
+ "mozbuild",
  "nserror",
  "nsstring",
  "serde",

--- a/mozglue/misc/PreXULSkeletonUI.cpp
+++ b/mozglue/misc/PreXULSkeletonUI.cpp
@@ -23,6 +23,7 @@
 #include "mozilla/FStream.h"
 #include "mozilla/GetKnownFolderPath.h"
 #include "mozilla/HashFunctions.h"
+#include "mozilla/HelperMacros.h"
 #include "mozilla/glue/Debug.h"
 #include "mozilla/Maybe.h"
 #include "mozilla/mscom/ProcessRuntime.h"
@@ -1501,6 +1502,12 @@ static bool EnvHasValue(const char* name) {
   return (val && *val);
 }
 
+#if defined(MOZ_ENTERPRISE)
+static bool FeltBypassAllowed() {
+  return !strcmp(MOZ_STRINGIFY(MOZ_UPDATE_CHANNEL), "default");
+}
+#endif
+
 // Ensures that we only see arguments in the command line which are acceptable.
 // This is based on manual inspection of the list of arguments listed in the MDN
 // page for Gecko/Firefox commandline options:
@@ -1661,8 +1668,9 @@ static Result<Ok, PreXULSkeletonUIError> ValidateCmdlineArguments(
   // executing and thus no `-felt <socket>` argument can be found to verify if
   // this is running a browser. By essence of that variable it is known the
   // browser is running and not Felt UI so explicitely use the PreSkeletonUI
-  // in this case.
-  if (EnvHasValue("MOZ_BYPASS_FELT")) {
+  // in this case. Like felt_init(), only trust it on builds that cannot ship
+  // to users, since libxul ignores it everywhere else.
+  if (FeltBypassAllowed() && EnvHasValue("MOZ_BYPASS_FELT")) {
     return Ok();
   }
 

--- a/taskcluster/kinds/source-test/puppeteer.yml
+++ b/taskcluster/kinds/source-test/puppeteer.yml
@@ -6,6 +6,10 @@ task-defaults:
     platform: linux2404-64/opt
     require-build:
         by-project:
+            enterprise-firefox:
+                linux2404-64/opt: build-linux64-enterprise/opt
+            enterprise-firefox-try:
+                linux2404-64/opt: build-linux64-enterprise/opt
             try:
                 linux2404-64/opt: build-linux64/opt
             default:

--- a/testing/enterprise/test_firefox_start.py
+++ b/testing/enterprise/test_firefox_start.py
@@ -16,7 +16,6 @@ from marionette_driver.by import By
 class EnterpriseTests(EnterpriseTestsBase):
     EXTRA_ENV = {
         "MOZ_BYPASS_FELT": "1",
-        "MOZ_AUTOMATION": "1",
     }
 
     def test_firefox_start(self):

--- a/toolkit/components/felt/rust/Cargo.toml
+++ b/toolkit/components/felt/rust/Cargo.toml
@@ -10,6 +10,7 @@ xpcom = { path = "../../../../xpcom/rust/xpcom" }
 nserror = { path = "../../../../xpcom/rust/nserror" }
 cstr = "0.2"
 ipc-channel = "0.21.0"
+mozbuild = "0.1"
 moz_task = { path = "../../../../xpcom/rust/moz_task" }
 nsstring = { path = "../../../../xpcom/rust/nsstring" }
 thin-vec = "0.2.12"

--- a/toolkit/components/felt/rust/src/lib.rs
+++ b/toolkit/components/felt/rust/src/lib.rs
@@ -53,13 +53,22 @@ fn has_env(target: &str) -> bool {
     }
 }
 
+/// MOZ_BYPASS_FELT starts the browser UI without Felt, which is only ever
+/// wanted for local development and automation. Restrict it to builds that
+/// cannot ship to users, i.e. those with the "default" channel a plain
+/// mozconfig produces.
+fn bypass_allowed() -> bool {
+    matches!(mozbuild::config::MOZ_UPDATE_CHANNEL, "default")
+}
+
 #[no_mangle]
 pub extern "C" fn felt_init() {
     trace!("felt_init()");
     env_logger::init();
 
     let found_felt_ui_env = has_env("MOZ_FELT_UI");
-    let bypass_env = has_env("MOZ_BYPASS_FELT");
+    let bypass_env = has_env("MOZ_BYPASS_FELT") && bypass_allowed();
+    trace!("felt_init(): bypass_env={}", bypass_env);
 
     // There may be a -chrome ... being passed on the CLI, e.g. for jsdebugger
     // in this case, it is not expected the FELT UI is shown, not the browser UI

--- a/toolkit/xre/nsAppRunner.cpp
+++ b/toolkit/xre/nsAppRunner.cpp
@@ -4628,6 +4628,16 @@ static void SetupConsoleForBackgroundTask(
 }
 #endif
 
+#if defined(MOZ_ENTERPRISE)
+// Whether this build can ever reach a user, and thus whether the enterprise
+// restrictions have anything to protect. A build with the "default" channel a
+// plain mozconfig produces, is a developer or automation build. Same criteria
+// as MOZ_BYPASS_FELT in felt_init().
+static bool IsNonShippingBuild() {
+  return !strcmp(MOZ_STRINGIFY(MOZ_UPDATE_CHANNEL), "default");
+}
+#endif
+
 /*
  * XRE_mainInit - Initial setup and command line parameter processing.
  * Main() will exit early if either return value != 0 or if aExitFlag is
@@ -4688,9 +4698,9 @@ int XREMain::XRE_mainInit(bool* aExitFlag) {
   bool allowHeadlessMode = true;
 #  ifdef MOZ_BACKGROUNDTASKS
   allowHeadlessMode =
-      BackgroundTasks::IsBackgroundTaskMode() || EnvHasValue("MOZ_AUTOMATION");
+      BackgroundTasks::IsBackgroundTaskMode() || IsNonShippingBuild();
 #  else
-  allowHeadlessMode = EnvHasValue("MOZ_AUTOMATION");
+  allowHeadlessMode = IsNonShippingBuild();
 #  endif
 #endif
 
@@ -4707,8 +4717,8 @@ int XREMain::XRE_mainInit(bool* aExitFlag) {
 #  if defined(MOZ_ENTERPRISE)
     if (!allowHeadlessMode) {
       Output(true,
-             "Error: Headless mode is only supported when Firefox runs in "
-             "automation.\n");
+             "Error: Headless mode is only supported in non shippable Firefox "
+             "builds.\n");
       return 1;
     }
 #  endif
@@ -4746,8 +4756,8 @@ int XREMain::XRE_mainInit(bool* aExitFlag) {
 #if defined(MOZ_ENTERPRISE)
   if (requestedHeadless && !allowHeadlessMode) {
     Output(true,
-           "Error: Headless mode is only supported when Firefox runs in "
-           "automation.\n");
+           "Error: Headless mode is only supported in non shippable Firefox "
+           "builds.\n");
     return 1;
   }
 #endif
@@ -4763,8 +4773,8 @@ int XREMain::XRE_mainInit(bool* aExitFlag) {
 #if defined(MOZ_ENTERPRISE)
   if (PR_GetEnv("MOZ_HEADLESS") && !allowHeadlessMode) {
     Output(true,
-           "Error: Headless mode is only supported when Firefox runs in "
-           "automation.\n");
+           "Error: Headless mode is only supported in non shippable Firefox "
+           "builds.\n");
     return 1;
   }
 #endif
@@ -5134,7 +5144,7 @@ int XREMain::XRE_mainInit(bool* aExitFlag) {
 
 #if defined(MOZ_ENTERPRISE)
   if (safeModeRequested.value() && is_felt_ui()) {
-    if (!EnvHasValue("MOZ_AUTOMATION")) {
+    if (!IsNonShippingBuild()) {
       Output(
           false,
           "Warning: Safe Mode is inhibited in Firefox Enterprise Launcher but "
@@ -6987,13 +6997,12 @@ int XREMain::XRE_main(int argc, char* argv[], const BootstrapConfig& aConfig) {
     bool allowStandaloneLaunch = false;
 #  endif
 
-    const bool requestedHeadless = RequestedHeadlessMode();
-    // Allow standalone launch for automated testing and development
-    allowStandaloneLaunch =
-        allowStandaloneLaunch || EnvHasValue("MOZ_AUTOMATION") ||
-        PR_GetEnv("MOZ_RUN_GTEST") || requestedHeadless ||
-        CheckArgExists("marionette") ||
-        CheckArgExists("remote-debugging-port") || IsLaunchingBrowserDevtools();
+    // Allow standalone launch for automated testing and development. The ways
+    // of asking for it -- gtests, headless, -marionette,
+    // -remote-debugging-port, devtools -- are all developer and automation
+    // entry points, so the build itself is what decides: on anything that can
+    // reach a user, only background tasks may start without Felt.
+    allowStandaloneLaunch = allowStandaloneLaunch || IsNonShippingBuild();
 
     if (!allowStandaloneLaunch && !is_felt_ui() && !is_felt_browser()) {
       Output(true,


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2070179

MOZ_BYPASS_FELT is still required to perform some automation execution, but previously it was gated against MOZ_AUTOMATION. Remove this and limit allowance to MOZ_UPDATE_CHANNEL being non existent or default value: this will exclude MOZ_BYPASS_FELT from working on shippable builds.

Also update checks that were done against MOZ_AUTOMATION to allow some features and gate then the sameway: marionette, remote debugging and devtools.