### PR TITLE
Bug 2070240 - Fix artifact job name suffix typo in "enterprise"

### DIFF
--- a/python/mozbuild/mozbuild/artifacts.py
+++ b/python/mozbuild/mozbuild/artifacts.py
@@ -1458,7 +1458,7 @@ class Artifacts:
             self._substs.get("MOZ_ENTERPRISE")
             and not self._substs.get("MOZ_BUILD_APP", "") == "comm/mail"
         ):
-            target_suffix = "-enteprise" + target_suffix
+            target_suffix = "-enterprise" + target_suffix
 
         if self._substs.get("MOZ_BUILD_APP", "") == "mobile/android":
             if self._substs["ANDROID_CPU_ARCH"] == "x86_64":


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2070240

Corrects the typo (missing "r" in "ente**r**prise") in the artifact job name.