### PR TITLE
Bug 2070187 - Remove curated/sponsored stories and top sites from new tab

### DIFF
--- a/browser/app/profile/firefox.js
+++ b/browser/app/profile/firefox.js
@@ -2232,6 +2232,14 @@ pref("browser.newtabpage.activity-stream.improvesearch.handoffToAwesomebar", tru
 
 pref("browser.newtabpage.activity-stream.logowordmark.alwaysVisible", true);
 
+#ifdef MOZ_ENTERPRISE
+// Enterprise removes its stories and sponsored content
+pref("browser.newtabpage.activity-stream.feeds.system.topstories", false, locked);
+pref("browser.newtabpage.activity-stream.showSponsored", false, locked);
+pref("browser.newtabpage.activity-stream.showSponsoredCheckboxes", false, locked);
+pref("browser.newtabpage.activity-stream.showSponsoredTopSites", false, locked);
+#endif
+
 // URLs from the user's history that contain this search param will be hidden
 // from the top sites. The value is a string with one of the following forms:
 // - "" (empty) - Disable this feature

--- a/browser/components/enterprisepolicies/Policies.sys.mjs
+++ b/browser/components/enterprisepolicies/Policies.sys.mjs
@@ -2211,13 +2211,6 @@ export var Policies = {
           param.Locked
         );
       }
-      if ("SponsoredTopSites" in param) {
-        lazy.PoliciesUtils.setDefaultPref(
-          "browser.newtabpage.activity-stream.showSponsoredTopSites",
-          param.SponsoredTopSites,
-          param.Locked
-        );
-      }
       if ("Highlights" in param) {
         lazy.PoliciesUtils.setDefaultPref(
           "browser.newtabpage.activity-stream.feeds.section.highlights",
@@ -2225,47 +2218,56 @@ export var Policies = {
           param.Locked
         );
       }
-      if ("Pocket" in param) {
-        lazy.PoliciesUtils.setDefaultPref(
-          "browser.newtabpage.activity-stream.feeds.section.topstories",
-          param.Pocket,
-          param.Locked
-        );
-      }
-      if ("Stories" in param) {
-        lazy.PoliciesUtils.setDefaultPref(
-          "browser.newtabpage.activity-stream.feeds.section.topstories",
-          param.Stories,
-          param.Locked
-        );
-      }
-      if ("SponsoredPocket" in param) {
-        lazy.PoliciesUtils.setDefaultPref(
-          "browser.newtabpage.activity-stream.showSponsored",
-          param.SponsoredPocket,
-          param.Locked
-        );
-      }
-      if ("SponsoredStories" in param) {
-        lazy.PoliciesUtils.setDefaultPref(
-          "browser.newtabpage.activity-stream.showSponsored",
-          param.SponsoredStories,
-          param.Locked
-        );
-      }
-      // The "Support Firefox" toggle in the settings UI is a parent control for
-      // the two sponsored child settings. When both are locked by policy, lock
-      // it to their combined value so it can't be toggled to no effect.
-      if (
-        param.Locked &&
-        "SponsoredTopSites" in param &&
-        "SponsoredStories" in param
-      ) {
-        lazy.PoliciesUtils.setDefaultPref(
-          "browser.newtabpage.activity-stream.showSponsoredCheckboxes",
-          param.SponsoredTopSites || param.SponsoredStories,
-          param.Locked
-        );
+      if (!AppConstants.MOZ_ENTERPRISE) {
+        if ("SponsoredTopSites" in param) {
+          lazy.PoliciesUtils.setDefaultPref(
+            "browser.newtabpage.activity-stream.showSponsoredTopSites",
+            param.SponsoredTopSites,
+            param.Locked
+          );
+        }
+        if ("Pocket" in param) {
+          lazy.PoliciesUtils.setDefaultPref(
+            "browser.newtabpage.activity-stream.feeds.section.topstories",
+            param.Pocket,
+            param.Locked
+          );
+        }
+        if ("Stories" in param) {
+          lazy.PoliciesUtils.setDefaultPref(
+            "browser.newtabpage.activity-stream.feeds.section.topstories",
+            param.Stories,
+            param.Locked
+          );
+        }
+        if ("SponsoredPocket" in param) {
+          lazy.PoliciesUtils.setDefaultPref(
+            "browser.newtabpage.activity-stream.showSponsored",
+            param.SponsoredPocket,
+            param.Locked
+          );
+        }
+        if ("SponsoredStories" in param) {
+          lazy.PoliciesUtils.setDefaultPref(
+            "browser.newtabpage.activity-stream.showSponsored",
+            param.SponsoredStories,
+            param.Locked
+          );
+        }
+        // The "Support Firefox" toggle in the settings UI is a parent control for
+        // the two sponsored child settings. When both are locked by policy, lock
+        // it to their combined value so it can't be toggled to no effect.
+        if (
+          param.Locked &&
+          "SponsoredTopSites" in param &&
+          "SponsoredStories" in param
+        ) {
+          lazy.PoliciesUtils.setDefaultPref(
+            "browser.newtabpage.activity-stream.showSponsoredCheckboxes",
+            param.SponsoredTopSites || param.SponsoredStories,
+            param.Locked
+          );
+        }
       }
       if (param.Widgets) {
         if ("Enabled" in param.Widgets) {

--- a/browser/components/enterprisepolicies/tests/browser/browser_policy_firefoxhome.js
+++ b/browser/components/enterprisepolicies/tests/browser/browser_policy_firefoxhome.js
@@ -176,6 +176,11 @@ add_task(async function test_firefoxhome_preferences_set() {
           Highlights:
             "browser.newtabpage.activity-stream.feeds.section.highlights",
         };
+    if (AppConstants.MOZ_ENTERPRISE) {
+      // SponsoredTopSites isn't applied in enterprise builds because sponsored content
+      // is disabled. Hence the policy can't lock its control.
+      delete data.SponsoredTopSites;
+    }
     for (let [section, key] of Object.entries(data)) {
       const el = srdEnabled
         ? browser.contentDocument.getElementById(key)

--- a/browser/components/preferences/tests/browser_legacy_pane_mappings.js
+++ b/browser/components/preferences/tests/browser_legacy_pane_mappings.js
@@ -253,6 +253,11 @@ add_task(async function test_legacy_name_routing_and_subcategory_attr() {
     ],
     ["privacy-logins", "#passwordsAutofill", "panePasswordsAutofill", "logins"],
   ]) {
+    // Stories are disabled in enterprise builds, so the topstories subcategory
+    // isn't rendered; only verify routing (hash/pane), not the highlight.
+    if (AppConstants.MOZ_ENTERPRISE && expectedSubcategory === "topstories") {
+      expectedSubcategory = null;
+    }
     let friendlyCategoryName = getFriendlyPaneName(expectedPane);
     let loaded = TestUtils.topicObserved(`${friendlyCategoryName}-pane-loaded`);
     let prefs = await openPreferencesViaOpenPreferencesAPI(arg, {

--- a/browser/components/preferences/tests/home/browser-srd.toml
+++ b/browser/components/preferences/tests/home/browser-srd.toml
@@ -36,25 +36,35 @@ tags = "os_integration"
 
 ["browser_homepage_firefox_home_disabled_windows_on.js"]
 
+["browser_homepage_firefox_home_enterprise_defaults.js"]
+run-if = ["enterprise"]
+
 ["browser_homepage_firefox_home_firefox_logo.js"]
 
 ["browser_homepage_firefox_home_manage_topics_opens_in_tab.js"]
+skip-if = ["enterprise"] # Manage Topics requires stories, disabled in enterprise builds
 
 ["browser_homepage_firefox_home_manage_topics_opens_in_window.js"]
+skip-if = ["enterprise"] # Manage Topics requires stories, disabled in enterprise builds
 
 ["browser_homepage_firefox_home_recent_activity.js"]
 
 ["browser_homepage_firefox_home_shortcuts.js"]
 
 ["browser_homepage_firefox_home_sponsored_shortcuts.js"]
+skip-if = ["enterprise"] # Sponsored content is disabled in enterprise builds
 
 ["browser_homepage_firefox_home_sponsored_stories.js"]
+skip-if = ["enterprise"] # Sponsored content is disabled in enterprise builds
 
 ["browser_homepage_firefox_home_stories.js"]
+skip-if = ["enterprise"] # Curated stories are disabled in enterprise builds
 
 ["browser_homepage_firefox_home_stories_personalization.js"]
+skip-if = ["enterprise"] # Curated stories are disabled in enterprise builds
 
 ["browser_homepage_firefox_home_support_firefox.js"]
+skip-if = ["enterprise"] # Sponsored content is disabled in enterprise builds
 
 ["browser_homepage_firefox_home_widgets.js"]
 

--- a/browser/components/preferences/tests/home/browser_homepage_firefox_home_disabled_tabs_on.js
+++ b/browser/components/preferences/tests/home/browser_homepage_firefox_home_disabled_tabs_on.js
@@ -48,7 +48,8 @@ async function assertSectionEnabled(win) {
     "widgets",
     "shortcuts",
     "stories",
-    "supportFirefox",
+    // supportFirefox is locked off in enterprise builds, so it is never enabled.
+    ...(AppConstants.MOZ_ENTERPRISE ? [] : ["supportFirefox"]),
     "recentActivity",
     ...(novaEnabled ? ["firefoxLogo"] : []),
   ]) {

--- a/browser/components/preferences/tests/home/browser_homepage_firefox_home_disabled_tabs_on.js
+++ b/browser/components/preferences/tests/home/browser_homepage_firefox_home_disabled_tabs_on.js
@@ -47,9 +47,9 @@ async function assertSectionEnabled(win) {
     "weather",
     "widgets",
     "shortcuts",
-    "stories",
-    // supportFirefox is locked off in enterprise builds, so it is never enabled.
-    ...(AppConstants.MOZ_ENTERPRISE ? [] : ["supportFirefox"]),
+    // stories and supportFirefox are locked off in enterprise builds, so they
+    // are never enabled.
+    ...(AppConstants.MOZ_ENTERPRISE ? [] : ["stories", "supportFirefox"]),
     "recentActivity",
     ...(novaEnabled ? ["firefoxLogo"] : []),
   ]) {

--- a/browser/components/preferences/tests/home/browser_homepage_firefox_home_disabled_windows_on.js
+++ b/browser/components/preferences/tests/home/browser_homepage_firefox_home_disabled_windows_on.js
@@ -51,7 +51,8 @@ async function assertSectionEnabled(win) {
     "widgets",
     "shortcuts",
     "stories",
-    "supportFirefox",
+    // supportFirefox is locked off in enterprise builds, so it is never enabled.
+    ...(AppConstants.MOZ_ENTERPRISE ? [] : ["supportFirefox"]),
     "recentActivity",
     ...(novaEnabled ? ["firefoxLogo"] : []),
   ]) {

--- a/browser/components/preferences/tests/home/browser_homepage_firefox_home_disabled_windows_on.js
+++ b/browser/components/preferences/tests/home/browser_homepage_firefox_home_disabled_windows_on.js
@@ -50,9 +50,9 @@ async function assertSectionEnabled(win) {
     "weather",
     "widgets",
     "shortcuts",
-    "stories",
-    // supportFirefox is locked off in enterprise builds, so it is never enabled.
-    ...(AppConstants.MOZ_ENTERPRISE ? [] : ["supportFirefox"]),
+    // stories and supportFirefox are locked off in enterprise builds, so they
+    // are never enabled.
+    ...(AppConstants.MOZ_ENTERPRISE ? [] : ["stories", "supportFirefox"]),
     "recentActivity",
     ...(novaEnabled ? ["firefoxLogo"] : []),
   ]) {

--- a/browser/components/preferences/tests/home/browser_homepage_firefox_home_enterprise_defaults.js
+++ b/browser/components/preferences/tests/home/browser_homepage_firefox_home_enterprise_defaults.js
@@ -1,0 +1,46 @@
+/* Any copyright is dedicated to the Public Domain.
+ * https://creativecommons.org/publicdomain/zero/1.0/ */
+
+"use strict";
+
+// Enterprise builds ship with sponsored content and curated stories disabled and
+// the backing prefs locked off (see the MOZ_ENTERPRISE block in firefox.js).
+
+add_task(
+  async function test_enterprise_home_preferences_reflect_locked_defaults() {
+    let { win, tab } = await openHomePreferences();
+
+    info("The Support Firefox toggle is unchecked and disabled");
+    // and Sponsored top sites have no visibility gate, so they
+    // stay visible but are locked off (disabled and unchecked).
+    let supportFirefox = await settingControlRenders("supportFirefox", win);
+    ok(BrowserTestUtils.isVisible(supportFirefox), "Support Firefox is shown");
+    ok(supportFirefox.disabled, "Support Firefox is disabled (locked)");
+    is(supportFirefox.value, false, "Support Firefox is off");
+
+    info("The Sponsored Shortcuts toggle is unchecked and disabled");
+    let sponsoredShortcuts = await settingControlRenders(
+      "sponsoredShortcuts",
+      win
+    );
+    ok(sponsoredShortcuts.disabled, "Sponsored top sites is disabled (locked)");
+    is(sponsoredShortcuts.value, false, "Sponsored top sites is off");
+
+    // Stories and Sponsored stories are gated on
+    // browser.newtabpage.activity-stream.feeds.system.topstories,
+    // which is locked off, so they are not rendered.
+    let stories = getSettingControl("stories", win);
+    ok(
+      !stories || !BrowserTestUtils.isVisible(stories),
+      "Stories setting is not shown"
+    );
+
+    let sponsoredStories = getSettingControl("sponsoredStories", win);
+    ok(
+      !sponsoredStories || !BrowserTestUtils.isVisible(sponsoredStories),
+      "Sponsored stories setting is not shown"
+    );
+
+    BrowserTestUtils.removeTab(tab);
+  }
+);


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2070187

Sets and locks the following prefs: 
- `browser.newtabpage.activity-stream.feeds.system.topstories=false` to disable curated stories
- `browser.newtabpage.activity-stream.showSponsored=false` to disable sponsored content
- `browser.newtabpage.activity-stream.showSponsoredCheckboxes=false` to disable the "Support Firefox" toggle
- `browser.newtabpage.activity-stream.showSponsoredTopSites=false` to disable sponsored top sites

(Note: Firefox Home Search, (non-sponsored) Top Sites, Weather, Widgets, and Recent activity are unaffected.)

Additionally, adds a guard to make sure the policy engine doesn't apply the policy FirefoxHome's keys `SponsoredTopSites`, `SponsoredPocket`, `SponsoredStories`, `Pocket`, `Stories` in enterprise builds.

---

### Testing <!-- OPTIONAL -->

* [x] Added tests