### PR TITLE
Bug 2068751 - Compile out enterprise standalone-launch escapes on shipping builds

### DIFF
--- a/browser/moz.configure
+++ b/browser/moz.configure
@@ -72,6 +72,21 @@ def enable_enterprise(value):
 set_config("MOZ_ENTERPRISE", enable_enterprise)
 set_define("MOZ_ENTERPRISE", enable_enterprise)
 
+
+# Permit standalone launch only for non shipping builds
+@depends(enable_enterprise, update_channel)
+def enterprise_standalone_launch(enterprise, channel):
+    if enterprise and channel not in (
+        "release-enterprise",
+        "beta-enterprise",
+        "nightly-enterprise",
+    ):
+        return True
+
+
+set_define("MOZ_ENTERPRISE_STANDALONE_LAUNCH", enterprise_standalone_launch)
+
+
 # Clear the default value to avoid mozilla.com url compiled into product
 imply_option("--with-crashreporter-url", "", when="--enable-enterprise")
 

--- a/toolkit/xre/nsAppRunner.cpp
+++ b/toolkit/xre/nsAppRunner.cpp
@@ -6987,6 +6987,7 @@ int XREMain::XRE_main(int argc, char* argv[], const BootstrapConfig& aConfig) {
     bool allowStandaloneLaunch = false;
 #  endif
 
+#  ifdef MOZ_ENTERPRISE_STANDALONE_LAUNCH
     const bool requestedHeadless = RequestedHeadlessMode();
     // Allow standalone launch for automated testing and development
     allowStandaloneLaunch =
@@ -6994,6 +6995,7 @@ int XREMain::XRE_main(int argc, char* argv[], const BootstrapConfig& aConfig) {
         PR_GetEnv("MOZ_RUN_GTEST") || requestedHeadless ||
         CheckArgExists("marionette") ||
         CheckArgExists("remote-debugging-port") || IsLaunchingBrowserDevtools();
+#  endif
 
     if (!allowStandaloneLaunch && !is_felt_ui() && !is_felt_browser()) {
       Output(true,


### PR DESCRIPTION
Fix: https://bugzilla.mozilla.org/show_bug.cgi?id=2068751

## Description

Gates the enterprise standalone-launch escapes behind a new MOZ_ENTERPRISE_STANDALONE_LAUNCH define compiled out of shipping builds.
