### PR TITLE
Bug 2068746 - Refuse remote agent system access on shipping enterprise builds

### DIFF
--- a/remote/components/RemoteAgent.sys.mjs
+++ b/remote/components/RemoteAgent.sys.mjs
@@ -20,7 +20,8 @@ ChromeUtils.defineESModuleGetters(lazy, {
 ChromeUtils.defineLazyGetter(lazy, "logger", () => lazy.Log.get());
 
 // A remote client with system access can run privileged JavaScript in the parent
-// process and undo enterprise policy. Deny it on non-default enterprise builds.
+// process and any other privileged context, such as WebExtension processes, and
+// undo enterprise policy. Deny it on non-default enterprise builds.
 const PREVENT_SYSTEM_ACCESS =
   AppConstants.MOZ_ENTERPRISE && AppConstants.MOZ_UPDATE_CHANNEL !== "default";
 

--- a/remote/components/RemoteAgent.sys.mjs
+++ b/remote/components/RemoteAgent.sys.mjs
@@ -2,6 +2,8 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+import { AppConstants } from "resource://gre/modules/AppConstants.sys.mjs";
+
 const lazy = {};
 
 ChromeUtils.defineESModuleGetters(lazy, {
@@ -16,6 +18,11 @@ ChromeUtils.defineESModuleGetters(lazy, {
 });
 
 ChromeUtils.defineLazyGetter(lazy, "logger", () => lazy.Log.get());
+
+// A remote client with system access can run privileged JavaScript in the parent
+// process and undo enterprise policy. Deny it on non-default enterprise builds.
+const PREVENT_SYSTEM_ACCESS =
+  AppConstants.MOZ_ENTERPRISE && AppConstants.MOZ_UPDATE_CHANNEL !== "default";
 
 const DEFAULT_HOST = "localhost";
 const DEFAULT_PORT = 9222;
@@ -51,7 +58,9 @@ class RemoteAgentParentProcess {
   constructor() {
     this.#allowHosts = null;
     this.#allowOrigins = null;
-    this.#allowSystemAccess = Services.env.get(ENV_ALLOW_SYSTEM_ACCESS) == "1";
+    this.#allowSystemAccess =
+      !PREVENT_SYSTEM_ACCESS &&
+      Services.env.get(ENV_ALLOW_SYSTEM_ACCESS) == "1";
 
     this.#browserStartupFinished = lazy.Deferred();
     this.#enabled = false;
@@ -111,6 +120,13 @@ class RemoteAgentParentProcess {
     // There is also no possibility to disallow once it got allowed except
     // quitting Firefox and starting it again.
     if (this.#allowSystemAccess || !value) {
+      return;
+    }
+
+    if (PREVENT_SYSTEM_ACCESS) {
+      lazy.logger.warn(
+        "Ignoring request for system access: not available on this build."
+      );
       return;
     }
 


### PR DESCRIPTION
Fix: https://bugzilla.mozilla.org/show_bug.cgi?id=2068746

## Description

Gates RemoteAgent.allowSystemAccess on enterprise builds carrying a non-default update channel.

Verified across all three request routes (env Marionette, flag Marionette, flag BiDi): each grants privileged scope without the fix and is refused with it.
