### PR TITLE
Bug 2061703, Bug 2070214 - Hide sync menu items and promos when sync is disabled and locked

### DIFF
--- a/browser/base/content/browser-menubar.inc.xhtml
+++ b/browser/base/content/browser-menubar.inc.xhtml
@@ -282,8 +282,8 @@
                 command="Browser:ShowAllBookmarks"
                 key="manBookmarkKb"
                 data-l10n-id="menu-bookmarks-manage"/>
-      <menuitem id="bookmarksRemoteTabsPromo"
-                data-l10n-id="menu-bookmarks-remote-tabs-promo"/>
+      <menuitem id="bookmarksRemoteTabsPromo" class="sync-ui-item"
+                hidden="true" data-l10n-id="menu-bookmarks-remote-tabs-promo"/>
       <menuseparator id="organizeBookmarksSeparator"/>
       <menuitem id="menu_bookmarkThisPage"
                 command="Browser:AddBookmarkAs"

--- a/browser/base/content/browser-menubar.js
+++ b/browser/base/content/browser-menubar.js
@@ -252,6 +252,11 @@ document.addEventListener(
             );
           }
           break;
+        case "menu_ToolsPopup":
+          if (AppConstants.MOZ_ENTERPRISE) {
+            gSync.refreshSyncMenuItems();
+          }
+          break;
         case "menu_HelpPopup":
           buildHelpMenu();
           break;

--- a/browser/base/content/browser-places.js
+++ b/browser/base/content/browser-places.js
@@ -706,6 +706,16 @@ class HistoryMenu extends PlacesMenu {
       return;
     }
 
+    // Neither the menuitem nor the promo's sign-in flow can lead anywhere once
+    // the policy locks synced tabs off.
+    if (gSync.isSyncTabsLocked) {
+      this.syncTabsMenuitem.hidden = true;
+      if (this.remoteTabsPromo) {
+        this.remoteTabsPromo.hidden = true;
+      }
+      return;
+    }
+
     // Show the promo to users who can't yet see remote tabs (see
     // getSyncPromoState). Clicking it performs the state-specific action, which
     // we stash in a data-action attribute for the command handler. When it

--- a/browser/base/content/browser-sync.js
+++ b/browser/base/content/browser-sync.js
@@ -1268,6 +1268,12 @@ var gSync = {
     return AppConstants.MOZ_ENTERPRISE && !Services.policies.isAllowed("sync");
   },
 
+  get isSyncTabsLocked() {
+    return (
+      AppConstants.MOZ_ENTERPRISE && !Services.policies.isAllowed("sync-tabs")
+    );
+  },
+
   // Returns the call to action ("signin", "turnonsync", or "connectdevice") for
   // showing the remote tabs promo, or null when the promo should be hidden.
   // Disabled `requiredEngines` also select "turnonsync" when provided.
@@ -1279,14 +1285,14 @@ var gSync = {
     switch (state.status) {
       case UIState.STATUS_NOT_CONFIGURED:
       case UIState.STATUS_NOT_VERIFIED:
-        return "signin";
+        return this.isSyncStateLocked ? null : "signin";
       case UIState.STATUS_SIGNED_IN: {
         const engineDisabled = requiredEngines.some(
           engine =>
             !Services.prefs.getBoolPref(`services.sync.engine.${engine}`, true)
         );
         if (!state.syncEnabled || engineDisabled) {
-          return "turnonsync";
+          return this.isSyncStateLocked ? null : "turnonsync";
         }
         // A null list means it's still loading, so defer to the existing
         // synced-tabs menuitem rather than promoting "connect a device". The

--- a/browser/base/content/browser-sync.js
+++ b/browser/base/content/browser-sync.js
@@ -1184,6 +1184,7 @@ const AVATAR_MENU_ONLY_PROFILES_EVENT_TYPES = new Set([
 
 var gSync = {
   _initialized: false,
+  _lastUIState: null,
   _isCurrentlySyncing: false,
   // The last sync start time. Used to calculate the leftover animation time
   // once syncing completes (bug 1239042).
@@ -1259,6 +1260,12 @@ var gSync = {
 
   get hasNoSendTabTargets() {
     return this.getSendTabTargets().length === 0;
+  },
+
+  // The Sync policy disallows the sync feature to pin sync's on/off state, not
+  // to make sync unavailable, so only the UI that changes it is a dead end.
+  get isSyncStateLocked() {
+    return AppConstants.MOZ_ENTERPRISE && !Services.policies.isAllowed("sync");
   },
 
   // Returns the call to action ("signin", "turnonsync", or "connectdevice") for
@@ -2646,38 +2653,59 @@ var gSync = {
     appMenuStatus.removeAttribute("tooltiptext");
   },
 
+  /**
+   * Re-gates the Tools menu sync items when the menu opens. The Sync policy can
+   * be applied or removed while the window is open, and nothing else recomputes
+   * these items when it changes.
+   */
+  refreshSyncMenuItems() {
+    // Windows we never init in, like the macOS hidden window, have no app menu
+    // views for updateState to touch; when FxA is disabled onFxaDisabled() has
+    // already hidden these items.
+    if (!this._initialized) {
+      return;
+    }
+    // UIState.get() returns its default until the first refresh resolves.
+    this.updateState(this._lastUIState ?? UIState.get());
+  },
+
   updateState(state) {
-    for (let [shown, menuId, boxId] of [
+    this._lastUIState = state;
+    for (let [shown, menuId, boxId, changesSyncState] of [
       [
         state.status == UIState.STATUS_NOT_CONFIGURED,
         "sync-setup",
         "PanelUI-remotetabs-setupsync",
+        true,
       ],
       [
         state.status == UIState.STATUS_SIGNED_IN && !state.syncEnabled,
         "sync-enable",
         "PanelUI-remotetabs-syncdisabled",
+        true,
       ],
       [
         state.status == UIState.STATUS_LOGIN_FAILED,
         "sync-reauthitem",
         "PanelUI-remotetabs-reauthsync",
+        false,
       ],
       [
         state.status == UIState.STATUS_NOT_VERIFIED,
         "sync-unverifieditem",
         "PanelUI-remotetabs-unverified",
+        false,
       ],
       [
         state.status == UIState.STATUS_SIGNED_IN && state.syncEnabled,
         "sync-syncnowitem",
         "PanelUI-remotetabs-main",
+        false,
       ],
     ]) {
-      document.getElementById(menuId).hidden = PanelMultiView.getViewNode(
-        document,
-        boxId
-      ).hidden = !shown;
+      document.getElementById(menuId).hidden =
+        !shown || (changesSyncState && this.isSyncStateLocked);
+      PanelMultiView.getViewNode(document, boxId).hidden = !shown;
     }
   },
 

--- a/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_policy_Sync.js
+++ b/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_policy_Sync.js
@@ -79,6 +79,34 @@ async function withPinnedUIState(state, assertionCallback) {
   }
 }
 
+async function checkHistoryMenuSyncedTabsHidden(expectedHidden) {
+  await withPinnedUIState(SIGNED_IN_SYNC_OFF, () => {
+    fireMenuPopupCycle("historyMenuPopup", () => {
+      is(
+        document.getElementById("historyRemoteTabsPromo").hidden,
+        expectedHidden,
+        `History menu synced tabs promo hidden=${expectedHidden}`
+      );
+      ok(
+        document.getElementById("sync-tabs-menuitem").hidden,
+        "The synced tabs menuitem stays hidden while Sync is off"
+      );
+    });
+  });
+}
+
+async function checkBookmarksMenuPromoHidden(expectedHidden) {
+  await withPinnedUIState(SIGNED_IN_SYNC_OFF, () => {
+    fireMenuPopupCycle("bookmarksMenuPopup", () => {
+      is(
+        document.getElementById("bookmarksRemoteTabsPromo").hidden,
+        expectedHidden,
+        `Bookmarks menu sync promo hidden=${expectedHidden}`
+      );
+    });
+  });
+}
+
 // Firefox View reads the sync-tabs gating on load, so open a fresh tab to check
 // how the "Tabs from other devices" nav renders under the current policy.
 async function checkFirefoxViewSyncedTabsHidden(expectedHidden) {
@@ -272,6 +300,19 @@ add_task(async function test_synced_tabs_visibility_follows_sync_policy() {
   checkSyncTabsFeatureAllowed(true);
   await checkSyncedTabsTool(false);
   await checkFirefoxViewSyncedTabsHidden(false);
+  await checkHistoryMenuSyncedTabsHidden(false);
+
+  // Omitting 'Enabled' is the only way to lock the tabs engine off while the
+  // sync feature stays allowed, so it's the only case that gates on sync-tabs.
+  info("Tabs engine locked off on its own: the synced tabs surfaces hide.");
+  await updatePolicies({
+    policies: { Sync: { Locked: true, OpenTabs: false } },
+  });
+  checkSyncTabsFeatureAllowed(false);
+  checkSyncFeatureAllowed(true);
+  await checkSyncedTabsTool(true);
+  await checkFirefoxViewSyncedTabsHidden(true);
+  await checkHistoryMenuSyncedTabsHidden(true);
 
   info("Sync disabled and locked: the synced tabs surfaces are hidden.");
   await updatePolicies({
@@ -280,6 +321,7 @@ add_task(async function test_synced_tabs_visibility_follows_sync_policy() {
   checkSyncTabsFeatureAllowed(false);
   await checkSyncedTabsTool(true);
   await checkFirefoxViewSyncedTabsHidden(true);
+  await checkHistoryMenuSyncedTabsHidden(true);
 
   info("Tabs engine disabled and locked: the synced tabs surfaces are hidden.");
   await updatePolicies({
@@ -288,6 +330,7 @@ add_task(async function test_synced_tabs_visibility_follows_sync_policy() {
   checkSyncTabsFeatureAllowed(false);
   await checkSyncedTabsTool(true);
   await checkFirefoxViewSyncedTabsHidden(true);
+  await checkHistoryMenuSyncedTabsHidden(true);
 
   info("Sync locked on with tabs: the synced tabs surfaces stay visible.");
   await updatePolicies({
@@ -301,12 +344,16 @@ add_task(async function test_synced_tabs_visibility_follows_sync_policy() {
   checkSyncTabsFeatureAllowed(true);
   await checkSyncedTabsTool(false);
   await checkFirefoxViewSyncedTabsHidden(false);
+  // The History menu promo is the exception: locking sync on also locks the sync
+  // feature, and the promo's only call to action here is to turn sync on.
+  await checkHistoryMenuSyncedTabsHidden(true);
 
   info("Policy removed: the synced tabs surfaces are visible again.");
   await updatePolicies({ policies: {} });
   checkSyncTabsFeatureAllowed(true);
   await checkSyncedTabsTool(false);
   await checkFirefoxViewSyncedTabsHidden(false);
+  await checkHistoryMenuSyncedTabsHidden(false);
 });
 
 // The Tools menu sync items (the native menubar on macOS) follow the sync
@@ -363,6 +410,85 @@ add_task(async function test_tools_menu_sync_items_follow_sync_policy() {
   );
 
   gSync.updateState(UIState.get());
+});
+
+// The menubar History and Bookmarks promos and both app menu sync promos all
+// read gSync.getSyncPromoState(), so the gate lives there rather than on each
+// surface. Its sign-in and turn-on-sync states are the ones the policy pins.
+add_task(async function test_sync_promos_follow_sync_policy() {
+  await EnterprisePolicyTesting.setupEngineWithRemotePolicies(
+    { policies: {} },
+    null
+  );
+
+  const oldGet = UIState.get;
+  try {
+    UIState.get = () => ({ status: UIState.STATUS_NOT_CONFIGURED });
+    is(
+      gSync.getSyncPromoState(),
+      "signin",
+      "Signed out offers the sign-in promo without a policy"
+    );
+
+    UIState.get = () => SIGNED_IN_SYNC_OFF;
+    is(
+      gSync.getSyncPromoState(),
+      "turnonsync",
+      "Sync off offers the turn-on-sync promo without a policy"
+    );
+    is(
+      gSync.getSyncPromoState(["bookmarks"]),
+      "turnonsync",
+      "The bookmarks promo is offered without a policy"
+    );
+    await checkBookmarksMenuPromoHidden(false);
+
+    await updatePolicies({
+      policies: { Sync: { Enabled: false, Locked: true, Bookmarks: true } },
+    });
+    await TestUtils.waitForCondition(
+      () => !Services.policies.isAllowed(SYNC_FEATURE),
+      "the sync feature is locked"
+    );
+
+    UIState.get = () => ({ status: UIState.STATUS_NOT_CONFIGURED });
+    is(
+      gSync.getSyncPromoState(),
+      null,
+      "The sign-in promo is gone while the sync state is locked"
+    );
+
+    UIState.get = () => SIGNED_IN_SYNC_OFF;
+    is(
+      gSync.getSyncPromoState(),
+      null,
+      "The turn-on-sync promo is gone while the sync state is locked"
+    );
+    is(
+      gSync.getSyncPromoState(["bookmarks"]),
+      null,
+      "The bookmarks promo is gone while the sync state is locked"
+    );
+    await checkBookmarksMenuPromoHidden(true);
+
+    info("Policy removed: the promos come back.");
+    await updatePolicies({ policies: {} });
+    checkSyncFeatureAllowed(true);
+    is(
+      gSync.getSyncPromoState(),
+      "turnonsync",
+      "The turn-on-sync promo returns once the policy is removed"
+    );
+    await checkBookmarksMenuPromoHidden(false);
+
+    info("Policy present but unlocked: the promos stay.");
+    await updatePolicies({ policies: { Sync: { Enabled: false } } });
+    checkSyncFeatureAllowed(true);
+    await checkBookmarksMenuPromoHidden(false);
+    await updatePolicies({ policies: {} });
+  } finally {
+    UIState.get = oldGet;
+  }
 });
 
 // Locking sync ON disallows the sync feature too, but syncing now and repairing

--- a/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_policy_Sync.js
+++ b/toolkit/components/enterprisepolicies/tests/browser/live/browser_live_policy_Sync.js
@@ -55,6 +55,30 @@ async function checkSyncedTabsTool(expectedHidden) {
   );
 }
 
+// The gating runs from a popupshowing handler, and the menubar is drawn natively
+// on macOS where a test can't open its menus, so dispatch the events instead.
+// popuphidden has to follow: showing opens the view's Places container, and
+// leaving it open past the end of the test hangs shutdown.
+function fireMenuPopupCycle(popupId, assertionCallback) {
+  const popup = document.getElementById(popupId);
+  popup.dispatchEvent(new Event("popupshowing", { bubbles: true }));
+  try {
+    assertionCallback();
+  } finally {
+    popup.dispatchEvent(new Event("popuphidden", { bubbles: true }));
+  }
+}
+
+async function withPinnedUIState(state, assertionCallback) {
+  const oldGet = UIState.get;
+  UIState.get = () => state;
+  try {
+    await assertionCallback();
+  } finally {
+    UIState.get = oldGet;
+  }
+}
+
 // Firefox View reads the sync-tabs gating on load, so open a fresh tab to check
 // how the "Tabs from other devices" nav renders under the current policy.
 async function checkFirefoxViewSyncedTabsHidden(expectedHidden) {
@@ -183,6 +207,9 @@ function mockSignedInAccount() {
 }
 
 add_setup(async function () {
+  // gSync.init() runs in a requestIdleCallback; the gating no-ops until it has.
+  gSync.init();
+
   await SpecialPowers.pushPrefEnv({
     // The mocked signed-in UIState has no real FxA account, so the urlbar trust
     // panel's breach check logs NO_ACCOUNT errors on the tab switch into the sync
@@ -280,4 +307,109 @@ add_task(async function test_synced_tabs_visibility_follows_sync_policy() {
   checkSyncTabsFeatureAllowed(true);
   await checkSyncedTabsTool(false);
   await checkFirefoxViewSyncedTabsHidden(false);
+});
+
+// The Tools menu sync items (the native menubar on macOS) follow the sync
+// feature gate, since the Sync policy leaves FxA enabled and gSync would
+// otherwise show them (Bug 2061703). Re-gating needs no restart.
+add_task(async function test_tools_menu_sync_items_follow_sync_policy() {
+  await EnterprisePolicyTesting.setupEngineWithRemotePolicies(
+    { policies: {} },
+    null
+  );
+
+  const syncEnableItem = document.getElementById("sync-enable");
+
+  info("No policy: the turn-on-sync item is shown.");
+  gSync.updateState(SIGNED_IN_SYNC_OFF);
+  ok(!syncEnableItem.hidden, "sync-enable is shown without a policy");
+
+  info("Sync disabled and locked: the sync menu items are hidden.");
+  await updatePolicies({
+    policies: { Sync: { Enabled: false, Locked: true } },
+  });
+  await TestUtils.waitForCondition(
+    () => !Services.policies.isAllowed(SYNC_FEATURE),
+    "the sync feature is locked"
+  );
+  await withPinnedUIState(SIGNED_IN_SYNC_OFF, () =>
+    fireMenuPopupCycle("menu_ToolsPopup", () => {
+      ok(syncEnableItem.hidden, "sync-enable hides once the policy applies");
+    })
+  );
+
+  info("A UIState update while locked keeps the items hidden.");
+  gSync.updateState(SIGNED_IN_SYNC_OFF);
+  ok(
+    syncEnableItem.hidden,
+    "sync-enable stays hidden while sync is disallowed"
+  );
+
+  // Only the menubar items are gated; the app menu's synced tabs views keep
+  // following UIState, since the panel is reachable without the menubar.
+  ok(
+    !PanelMultiView.getViewNode(document, "PanelUI-remotetabs-syncdisabled")
+      .hidden,
+    "the synced tabs panel view is not gated on the policy"
+  );
+
+  info("Policy removed: the items follow UIState again.");
+  await updatePolicies({ policies: {} });
+  checkSyncFeatureAllowed(true);
+  await withPinnedUIState(SIGNED_IN_SYNC_OFF, () =>
+    fireMenuPopupCycle("menu_ToolsPopup", () => {
+      ok(!syncEnableItem.hidden, "sync-enable is shown again without a policy");
+    })
+  );
+
+  gSync.updateState(UIState.get());
+});
+
+// Locking sync ON disallows the sync feature too, but syncing now and repairing
+// the account are not state changes, so those items have to survive the lock —
+// the same line the settings sync section draws.
+add_task(async function test_tools_menu_keeps_actions_when_sync_locked_on() {
+  const restoreFxa = mockSignedInAccount();
+
+  try {
+    await EnterprisePolicyTesting.setupEngineWithRemotePolicies(
+      { policies: { Sync: { Enabled: true, Locked: true } } },
+      null
+    );
+    // Enabling awaits connectSync before disallowFeature, so wait for the lock.
+    await TestUtils.waitForCondition(
+      () => !Services.policies.isAllowed(SYNC_FEATURE),
+      "the sync feature is locked"
+    );
+
+    gSync.updateState(SIGNED_IN_SYNC_ON);
+    ok(
+      !document.getElementById("sync-syncnowitem").hidden,
+      "sync-syncnowitem stays shown when the policy locks sync on"
+    );
+
+    gSync.updateState({ status: UIState.STATUS_LOGIN_FAILED });
+    ok(
+      !document.getElementById("sync-reauthitem").hidden,
+      "sync-reauthitem stays shown so a locked-on sync can be repaired"
+    );
+
+    gSync.updateState({ status: UIState.STATUS_NOT_VERIFIED });
+    ok(
+      !document.getElementById("sync-unverifieditem").hidden,
+      "sync-unverifieditem stays shown so the account can be verified"
+    );
+
+    gSync.updateState(SIGNED_IN_SYNC_OFF);
+    ok(
+      document.getElementById("sync-enable").hidden,
+      "sync-enable is still gated, since turning sync on is a state change"
+    );
+
+    await updatePolicies({ policies: {} });
+  } finally {
+    restoreFxa();
+    Services.prefs.clearUserPref("services.sync.username");
+    gSync.updateState(UIState.get());
+  }
 });


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2061703, Bug-2070214

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

The menus contain a few sync-related items that do not get properly hidden according to the `Sync` policy configuration. This PR adds policy-driven gating and observers to maintain the live nature of the policy for the sync promos and macOS native toolbar menu item. 

- Hide `Tools > Turn on sync` in macOS native toolbar
- Hide `History > Tabs From Other Devices` in macOS native toolbar
- Hide `Bookmarks > Sync Bookmarks to Mobile` in macOS native toolbar
- Hide sync promos in both Bookmarks and History hamburger menu panels

---

### Screenshots <!-- REQUIRED (if applicable) -->

<!-- Please provide screenshots of UI changes (before/after if applicable). -->

|Before|After|
|-|-|
|<img width="251" height="228" alt="before-macos-tools" src="https://github.com/user-attachments/assets/ca528629-e24d-49a6-ac6a-822741d4689c" />|<img width="282" height="206" alt="after-macos-tools" src="https://github.com/user-attachments/assets/4298cd67-c845-4a93-be4c-53da6362d678" />|
|_macOS tools menu_ | _macOS tools menu_ |
|<img width="1512" height="933" alt="before-history" src="https://github.com/user-attachments/assets/29b48ae3-4a8e-4ce1-8a78-aaadfde17480" />|<img width="1512" height="933" alt="after-history" src="https://github.com/user-attachments/assets/c77b5558-dd3a-49c3-875b-cb31a3848621" />|
| _History menus_ | _History menus_ |
|<img width="1512" height="933" alt="before-bookmarks" src="https://github.com/user-attachments/assets/3bf9cc47-be22-4b97-9463-498e60294b58" />|<img width="1512" height="933" alt="after-bookmarks" src="https://github.com/user-attachments/assets/d0437955-1ed2-4aa3-8037-cedbc83a8a15" />|
| _Bookmarks menus_ | _Bookmarks menus_ |

---

### Testing <!-- OPTIONAL -->

* [x] Added tests
* [x] Manual testing performed

**Steps to verify changes:**

1. Apply a `Sync` policy with `{ "Enabled": false, "Locked": true, "OpenTabs": true, "Bookmarks": true }`
2. Open and inspect the menus in the native macOS menubar and the hamburger menu
3. Remove the policy and re-check the menu

**Expected result:**

When Sync is disabled and locked by policy... 

- "Turn on Sync…" / "Sync Now" does not appear in the macOS Tools menu
- "Tabs From Other Devices" does not appear in the macOS History menu
- "Sync Bookmarks to Mobile" does not appear in the macOS Bookmarks menu
- No promos are present in the History/Bookmarks hamburger menu panels

When Sync is enabled, unlocked, or policy is unset, these items reappear.