### PR TITLE
Bug 2070440 - Limit task scheduling on enterprise push: no tsan, asan on non enterprise builds

### DIFF
--- a/taskcluster/gecko_taskgraph/target_tasks.py
+++ b/taskcluster/gecko_taskgraph/target_tasks.py
@@ -625,6 +625,13 @@ def target_tasks_enterprise_firefox_with_tests(
 
             if test_platform and "enterprise" not in test_platform:
                 return False
+        # Reduce CI workload: do not schedule asan/tsan builds or tests
+        # for non enterprise builds on level 3 pushes
+        elif ("asan" in task.label or "tsan" in task.label) and (
+            (build_platform and "enterprise" not in build_platform)
+            or (test_platform and "enterprise" not in test_platform)
+        ):
+            return False
 
         if "thunderbird" in parameters["project"] and level == 3:
             if build_platform and "enterprise" not in build_platform:


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2070440