### PR TITLE
Bug 2063400 - Retry relaunch warnings after browser startup

### DIFF
--- a/toolkit/components/enterprise/modules/RelaunchEnforcer.sys.mjs
+++ b/toolkit/components/enterprise/modules/RelaunchEnforcer.sys.mjs
@@ -433,7 +433,12 @@ export const RelaunchEnforcer = {
    */
   _barWindow() {
     for (const win of Services.wm.getEnumerator("navigator:browser")) {
-      if (win.gBrowser && lazy.InfoBar.isValidInfobarWindow(win)) {
+      if (
+        win.gBrowser &&
+        // TODO(Bug 2066128): Remove once InfoBar handles loading windows.
+        win.document.readyState === "complete" &&
+        lazy.InfoBar.isValidInfobarWindow(win)
+      ) {
         return win;
       }
     }

--- a/toolkit/components/enterprise/tests/browser/browser_relaunch_enforcer.js
+++ b/toolkit/components/enterprise/tests/browser/browser_relaunch_enforcer.js
@@ -317,7 +317,7 @@ add_task(async function test_retries_after_the_browser_window_loads() {
   const loadingWin = win.OpenBrowserWindow();
   const started = TestUtils.topicObserved(
     "browser-delayed-startup-finished",
-    subject => subject === loadingWin
+    subject => subject == loadingWin
   );
   try {
     await BrowserTestUtils.waitForEvent(loadingWin, "DOMContentLoaded");

--- a/toolkit/components/enterprise/tests/browser/browser_relaunch_enforcer.js
+++ b/toolkit/components/enterprise/tests/browser/browser_relaunch_enforcer.js
@@ -310,6 +310,50 @@ add_task(async function test_takes_the_slot_from_another_infobar() {
   );
 });
 
+add_task(async function test_retries_after_the_browser_window_loads() {
+  const win = Services.wm.getMostRecentBrowserWindow();
+  await reset(win);
+
+  const loadingWin = win.OpenBrowserWindow();
+  const started = TestUtils.topicObserved(
+    "browser-delayed-startup-finished",
+    subject => subject === loadingWin
+  );
+  try {
+    await BrowserTestUtils.waitForEvent(loadingWin, "DOMContentLoaded");
+    Assert.equal(
+      loadingWin.document.readyState,
+      "interactive",
+      "The new window is still loading"
+    );
+
+    // Model startup by making the loading window the only eligible target.
+    win.document.documentElement.setAttribute("taskbartab", "true");
+    RelaunchEnforcer.onConsolePoll({ MinutesRemaining: 45 });
+    await RelaunchEnforcer._refreshNotification();
+    win.document.documentElement.removeAttribute("taskbartab");
+
+    await started;
+    const shown = BrowserTestUtils.waitForGlobalNotificationBar(
+      loadingWin,
+      WARNING_ID
+    );
+    RelaunchEnforcer.onConsolePoll({ MinutesRemaining: 45 });
+    await shown;
+
+    Assert.deepEqual(
+      notificationValues(loadingWin),
+      [WARNING_ID],
+      "The warning is shown after the window loads"
+    );
+  } finally {
+    win.document.documentElement.removeAttribute("taskbartab");
+    RelaunchEnforcer.onConsolePoll(null);
+    await started;
+    await BrowserTestUtils.closeWindow(loadingWin);
+  }
+});
+
 add_task(async function test_warns_in_a_window_that_can_take_a_bar() {
   const win = Services.wm.getMostRecentBrowserWindow();
   await reset(win);


### PR DESCRIPTION
Follow-up to [PR #1270](https://github.com/mozilla/enterprise-firefox/pull/1270).

The relaunch warning browser tests can intermittently time out when the first console poll races browser-window startup. InfoBar tracks the universal message before the window finishes loading but does not show its notification, so later polls do not recover.

Until [Bug 2066128](https://bugzilla.mozilla.org/show_bug.cgi?id=2066128) fixes loading-window handling upstream, make RelaunchEnforcer skip loading windows and retry on the next console poll.

The regression test uses a real loading browser window and verifies that the actual warning appears after startup.

## Testing

- Focused browser test: 30 passed, 0 failed
- Negative control: the new test times out without the guard
- ESLint: clean
