### PR TITLE
Bug 2068749 - Lock policy-critical preferences in the enterprise AutoConfig file

### DIFF
--- a/browser/branding/enterprise/firefox.cfg.in
+++ b/browser/branding/enterprise/firefox.cfg.in
@@ -8,4 +8,3 @@ lockPref("general.config.filename", "firefox.cfg"); // AutoConfig file name
 lockPref("general.config.vendor", "firefox"); // AutoConfig vendor check value
 lockPref("autoadmin.global_config_url", ""); // remote AutoConfig URL
 lockPref("toolkit.policies.perUserDir", false); // per-user policy directory
-lockPref("enterprise.policies.live.enabled", false); // live (console) policy provider

--- a/browser/branding/enterprise/firefox.cfg.in
+++ b/browser/branding/enterprise/firefox.cfg.in
@@ -1,3 +1,11 @@
 // Firefox enterprise AutoConfig. The first line is intentionally skipped by
 // the AutoConfig parser; managed preferences belong on the lines below.
 lockPref("enterprise.console.address", "@MOZ_ENTERPRISE_CONSOLE_URL@");
+
+// AutoConfig and enterprise policy source preferences, locked to their
+// defaults.
+lockPref("general.config.filename", "firefox.cfg"); // AutoConfig file name
+lockPref("general.config.vendor", "firefox"); // AutoConfig vendor check value
+lockPref("autoadmin.global_config_url", ""); // remote AutoConfig URL
+lockPref("toolkit.policies.perUserDir", false); // per-user policy directory
+lockPref("enterprise.policies.live.enabled", false); // live (console) policy provider

--- a/extensions/pref/autoconfig/src/nsReadConfig.cpp
+++ b/extensions/pref/autoconfig/src/nsReadConfig.cpp
@@ -249,7 +249,7 @@ nsresult nsReadConfig::readConfigFile() {
   if (NS_SUCCEEDED(rv)) {
     fileNameLen = strlen(lockFileName.get());
 
-    // lockVendor and lockFileName should be the same with the addtion of
+    // lockVendor and lockFileName should be the same with the addition of
     // .cfg to the filename by checking this post reading of the cfg file
     // this value can be set within the cfg file adding a level of security.
 


### PR DESCRIPTION
Fix: https://bugzilla.mozilla.org/show_bug.cgi?id=2068749

## Description

This PR closes two bugs via one shared firefox.cfg change:
  - general.config.filename / general.config.vendor / autoadmin.global_config_url → Bug [2068749](https://bugzilla.mozilla.org/show_bug.cgi?id=2068749) (this bug)
  - toolkit.policies.perUserDir → Bug [2068747](https://bugzilla.mozilla.org/show_bug.cgi?id=2068747)

