### PR TITLE
Bug 2070529 - Reject incompatible policies

### DIFF
--- a/browser/components/enterprisepolicies/schemas/schema.sys.mjs
+++ b/browser/components/enterprisepolicies/schemas/schema.sys.mjs
@@ -70,9 +70,31 @@ const resolvedSchema = dereference(
 
 export let schema = resolvedSchema;
 
+// Metadata the meta-schema makes mandatory on every real policy. Fill in
+// permissive defaults because the existing custom test schemas may omit them.
+const TEST_METADATA_DEFAULTS = {
+  "x-compatibility": {
+    firefox: { version_added: "1" },
+    firefox_esr: { version_added: "1" },
+    firefox_enterprise: { version_added: "1" },
+  },
+  "x-restart-required": true,
+};
+
+function withTestMetadataDefaults(customSchema) {
+  for (let entry of Object.values(customSchema.properties ?? {})) {
+    for (let [key, value] of Object.entries(TEST_METADATA_DEFAULTS)) {
+      if (!(key in entry)) {
+        entry[key] = value;
+      }
+    }
+  }
+  return customSchema;
+}
+
 export function modifySchemaForTests(customSchema) {
   if (customSchema) {
-    schema = customSchema;
+    schema = withTestMetadataDefaults(customSchema);
   } else {
     schema = resolvedSchema;
   }

--- a/browser/components/enterprisepolicies/tests/browser/browser.toml
+++ b/browser/components/enterprisepolicies/tests/browser/browser.toml
@@ -64,6 +64,7 @@ https_first_disabled = true
 ["browser_policy_disable_feedback_commands.js"]
 
 ["browser_policy_disable_fxaccounts.js"]
+skip-if = ["enterprise"] # Applies DisableFirefoxAccounts/DisableAccounts, unsupported in enterprise builds
 
 ["browser_policy_disable_launch_on_login.js"]
 run-if = [
@@ -71,6 +72,7 @@ run-if = [
 ]
 
 ["browser_policy_disable_masterpassword.js"]
+skip-if = ["enterprise"] # Applies DisableMasterPasswordCreation, unsupported in enterprise builds
 
 ["browser_policy_disable_password_reveal.js"]
 
@@ -93,8 +95,10 @@ support-files = [
 ["browser_policy_disable_safemode.js"]
 
 ["browser_policy_disable_shield.js"]
+skip-if = ["enterprise"] # Applies DisableFirefoxStudies, unsupported in enterprise builds
 
 ["browser_policy_disable_telemetry.js"]
+skip-if = ["enterprise"] # Applies DisableTelemetry, unsupported in enterprise builds
 
 ["browser_policy_display_bookmarks.js"]
 
@@ -107,6 +111,7 @@ support-files = [
 ]
 
 ["browser_policy_extensions.js"]
+skip-if = ["enterprise"] # Applies Extensions, unsupported in enterprise builds
 
 ["browser_policy_extensionsettings.js"]
 https_first_disabled = true
@@ -123,12 +128,16 @@ support-files = [
 ["browser_policy_handlers.js"]
 
 ["browser_policy_masterpassword.js"]
+skip-if = ["enterprise"] # Applies PrimaryPassword, unsupported in enterprise builds
 
 ["browser_policy_masterpassword_aboutlogins.js"]
+skip-if = ["enterprise"] # Applies PrimaryPassword, unsupported in enterprise builds
 
 ["browser_policy_masterpassword_doorhanger.js"]
+skip-if = ["enterprise"] # Applies PrimaryPassword, unsupported in enterprise builds
 
 ["browser_policy_mv3_force_installed_host_permissions.js"]
+skip-if = ["enterprise"] # Applies Extensions, unsupported in enterprise builds
 
 ["browser_policy_offertosavelogins.js"]
 
@@ -185,6 +194,7 @@ support-files = [
 ["browser_policy_translateenabled.js"]
 
 ["browser_policy_usermessaging.js"]
+skip-if = ["enterprise"] # Applies UserMessaging/SkipTermsOfUse, unsupported in enterprise builds
 
 ["browser_policy_watermark.js"]
 support-files = ["policy_watermark.html", "policy_watermark.sjs"]

--- a/browser/components/enterprisepolicies/tests/browser/browser_policy_block_about.js
+++ b/browser/components/enterprisepolicies/tests/browser/browser_policy_block_about.js
@@ -18,6 +18,8 @@ const policiesToTest = [
     urls: ["about:config", "about:Config"],
   },
   {
+    // BlockAboutProfiles is not supported on enterprise builds.
+    skipInEnterprise: true,
     policies: {
       BlockAboutProfiles: true,
     },
@@ -33,6 +35,9 @@ const policiesToTest = [
 
 add_task(async function testAboutTask() {
   for (let policyToTest of policiesToTest) {
+    if (policyToTest.skipInEnterprise && AppConstants.MOZ_ENTERPRISE) {
+      continue;
+    }
     let policyJSON = { policies: {} };
     policyJSON.policies = policyToTest.policies;
     for (let url of policyToTest.urls) {

--- a/browser/components/enterprisepolicies/tests/xpcshell/test_policy_compatibility.js
+++ b/browser/components/enterprisepolicies/tests/xpcshell/test_policy_compatibility.js
@@ -1,0 +1,90 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+"use strict";
+
+// Tests that the engine enforces "x-compatibility" from policies-schema.json.
+
+const { PolicyFailures } = ChromeUtils.importESModule(
+  "resource://gre/modules/PoliciesHelpers.sys.mjs"
+);
+const { Policies } = ChromeUtils.importESModule(
+  "resource:///modules/policies/Policies.sys.mjs"
+);
+
+const POLICY_NAME = "CompatTestPolicy";
+
+add_setup(function () {
+  Policies[POLICY_NAME] = {};
+  registerCleanupFunction(() => {
+    delete Policies[POLICY_NAME];
+  });
+});
+
+function getFailures() {
+  return PolicyFailures.getAll()[POLICY_NAME] ?? [];
+}
+
+function isCompatPolicyActive() {
+  return POLICY_NAME in Services.policies.getActivePolicies();
+}
+
+function schemaWithCompatibility(versionAdded) {
+  let entry = { type: "boolean" };
+  if (versionAdded !== undefined) {
+    entry["x-compatibility"] = {
+      firefox: { version_added: versionAdded },
+      firefox_esr: { version_added: versionAdded },
+      firefox_enterprise: { version_added: versionAdded },
+    };
+  }
+  return { type: "object", properties: { [POLICY_NAME]: entry } };
+}
+
+add_task(async function test_unsupported_build_is_rejected() {
+  await setupPolicyEngineWithJson(
+    { policies: { [POLICY_NAME]: true } },
+    schemaWithCompatibility(false)
+  );
+
+  ok(
+    !isCompatPolicyActive(),
+    "A policy unsupported by this build is not applied"
+  );
+  let failures = getFailures();
+  equal(failures.length, 1, "One failure was recorded for the policy");
+  ok(
+    failures[0].includes("is not supported"),
+    `The failure explains the rejection: ${failures[0]}`
+  );
+});
+
+add_task(async function test_supported_version_is_applied() {
+  await setupPolicyEngineWithJson(
+    { policies: { [POLICY_NAME]: true } },
+    schemaWithCompatibility("149")
+  );
+
+  ok(isCompatPolicyActive(), "A policy supported by this build is applied");
+  deepEqual(
+    PolicyFailures.getAll(),
+    {},
+    "No failure is reported for a compatible policy"
+  );
+});
+
+add_task(async function test_metadata_defaults_are_applied() {
+  await setupPolicyEngineWithJson(
+    { policies: { [POLICY_NAME]: true } },
+    schemaWithCompatibility(undefined)
+  );
+
+  ok(
+    isCompatPolicyActive(),
+    "A policy whose test schema omits metadata gets the injected defaults"
+  );
+  deepEqual(
+    PolicyFailures.getAll(),
+    {},
+    "No failure is reported when metadata defaults are injected"
+  );
+});

--- a/browser/components/enterprisepolicies/tests/xpcshell/test_simple_pref_policies.js
+++ b/browser/components/enterprisepolicies/tests/xpcshell/test_simple_pref_policies.js
@@ -3,6 +3,10 @@
 
 "use strict";
 
+const { AppConstants } = ChromeUtils.importESModule(
+  "resource://gre/modules/AppConstants.sys.mjs"
+);
+
 /*
  * Use this file to add tests to policies that are
  * simple pref flips.
@@ -593,6 +597,7 @@ const POLICIES_TESTS = [
 
   // POLICY: DisableShield
   {
+    skipInEnterprise: true,
     policies: {
       DisableFirefoxStudies: true,
     },
@@ -625,6 +630,7 @@ const POLICIES_TESTS = [
 
   // POLICY: FirefoxHome
   {
+    skipInEnterprise: true,
     policies: {
       FirefoxHome: {
         Stories: false,
@@ -655,6 +661,7 @@ const POLICIES_TESTS = [
   // POLICY: FirefoxHome (locking both sponsored settings locks the parent
   // "Support Firefox" toggle to their combined value)
   {
+    skipInEnterprise: true,
     policies: {
       FirefoxHome: {
         SponsoredTopSites: false,
@@ -735,6 +742,7 @@ const POLICIES_TESTS = [
 
   // POLICY: UserMessaging
   {
+    skipInEnterprise: true,
     policies: {
       UserMessaging: {
         SkipOnboarding: true,
@@ -748,6 +756,7 @@ const POLICIES_TESTS = [
 
   // POLICY: UserMessaging->SkipOnboarding false (bug 1697566)
   {
+    skipInEnterprise: true,
     policies: {
       UserMessaging: {
         SkipOnboarding: false,
@@ -760,6 +769,7 @@ const POLICIES_TESTS = [
   },
 
   {
+    skipInEnterprise: true,
     policies: {
       UserMessaging: {
         ExtensionRecommendations: false,
@@ -772,6 +782,7 @@ const POLICIES_TESTS = [
   },
 
   {
+    skipInEnterprise: true,
     policies: {
       UserMessaging: {
         FeatureRecommendations: false,
@@ -1197,6 +1208,7 @@ const POLICIES_TESTS = [
 
   // Bug 1772503
   {
+    skipInEnterprise: true,
     policies: {
       DisableFirefoxStudies: true,
     },
@@ -1309,6 +1321,7 @@ const POLICIES_TESTS = [
 
   // POLICY: SkipTermsOfUse
   {
+    skipInEnterprise: true,
     policies: {
       SkipTermsOfUse: true,
     },
@@ -1512,6 +1525,17 @@ add_task(async function test_policy_simple_prefs() {
   });
 
   for (let test of POLICIES_TESTS) {
+    // Some policies (or subkeys) are not applied on enterprise
+    // builds, so their cases are marked skipInEnterprise.
+    if (test.skipInEnterprise && AppConstants.MOZ_ENTERPRISE) {
+      info(
+        `Skipping ${Object.keys(test.policies).join(
+          ", "
+        )}: not supported on enterprise builds`
+      );
+      continue;
+    }
+
     await setupPolicyEngineWithJson({
       policies: test.policies,
     });

--- a/browser/components/enterprisepolicies/tests/xpcshell/xpcshell.toml
+++ b/browser/components/enterprisepolicies/tests/xpcshell/xpcshell.toml
@@ -20,8 +20,10 @@ support-files = [
 run-if = ["enterprise"]
 
 ["test_appupdatepin.js"]
+skip-if = ["enterprise"] # Applies AppUpdateURL, unsupported on enterprise (x-compatibility)
 
 ["test_appupdateurl.js"]
+skip-if = ["enterprise"] # Applies AppUpdateURL, unsupported on enterprise (x-compatibility)
 
 ["test_bug1658259.js"]
 
@@ -38,6 +40,7 @@ run-if = ["enterprise"]
 ["test_exempt_domain_file_type_pairs_from_file_type_download_warnings.js"]
 
 ["test_extensions.js"]
+skip-if = ["enterprise"] # Applies Extensions, unsupported on enterprise (x-compatibility)
 
 ["test_extensionsettings.js"]
 
@@ -64,6 +67,8 @@ support-files = [
   "../../schemas/policies-schema.json",
   "../../schemas/policies-schema.meta.json",
 ]
+
+["test_policy_compatibility.js"]
 
 ["test_policy_descriptions.js"]
 

--- a/toolkit/components/enterprisepolicies/EnterprisePoliciesParent.sys.mjs
+++ b/toolkit/components/enterprisepolicies/EnterprisePoliciesParent.sys.mjs
@@ -622,6 +622,14 @@ EnterprisePoliciesManager.prototype = {
       return { isValid: false, parsedParams: null };
     }
 
+    if (!this._isPolicyCompatible(policyName)) {
+      this._reportPolicyError(
+        policyName,
+        `Policy ${policyName} is not supported.`
+      );
+      return { isValid: false, parsedParams: null };
+    }
+
     const policyImpl = lazy.Policies[policyName];
     // A few policies still accept an old syntax that the schema can't
     // describe. Convert it before we validate.
@@ -673,9 +681,36 @@ EnterprisePoliciesManager.prototype = {
    * @returns {boolean} whether policy requires a restart to be applied
    */
   _isStartupPolicy(policyName) {
-    const requiresRestart =
-      lazy.schemaModule.schema.properties[policyName]["x-restart-required"];
-    return requiresRestart ?? true;
+    return lazy.schemaModule.schema.properties[policyName][
+      "x-restart-required"
+    ];
+  },
+
+  /**
+   * The build variant key used by "x-compatibility" in policies-schema.json.
+   *
+   * @returns {"firefox_enterprise"|"firefox_esr"|"firefox"} variant key
+   */
+  _currentBuildVariant() {
+    if (AppConstants.MOZ_ENTERPRISE) {
+      return "firefox_enterprise";
+    }
+    if (AppConstants.IS_ESR) {
+      return "firefox_esr";
+    }
+    return "firefox";
+  },
+
+  /**
+   * Whether a policy is supported by the running build
+   *
+   * @param {string} policyName policy name
+   * @returns {boolean} whether the policy applies to this build variant
+   */
+  _isPolicyCompatible(policyName) {
+    const compatibility =
+      lazy.schemaModule.schema.properties[policyName]["x-compatibility"];
+    return compatibility[this._currentBuildVariant()].version_added !== false;
   },
 
   /**


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2070529

The policy engine validates the policy's compatibility and rejects a policy whose current build variant is incompatible (version_added === false).

Also lets `modifySchemaForTests` backfill the `x-compatibility` and `x-restart-required` defaults the meta-schema mandates, so custom test schemas need not declare them and skips tests that rely on enterprise incompatible policies

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Testing <!-- OPTIONAL -->

* [X] Added tests

<!--
**Steps to verify changes:**
1.
2.
3.

**Expected result:**
-->
