### PR TITLE
Bug 2065838 - Skip mochitests browser chrome tests not applicable in enterprise

### DIFF
--- a/browser/base/content/test/sync/browser.toml
+++ b/browser/base/content/test/sync/browser.toml
@@ -34,7 +34,6 @@ support-files = ["browser_fxa_web_channel.html"]
 skip-if = ["enterprise"] # Enterprise Accounts replaces Firefox Accounts; there is no fxa sign-in or signed-out flow.
 
 ["browser_sendtab_toolbarbutton.js"]
-skip-if = ["enterprise"] # Enterprise Accounts replaces Firefox Accounts; there is no fxa sign-in or signed-out flow.
 
 ["browser_signed_out_avatar_variants.js"]
 skip-if = ["enterprise"] # Enterprise Accounts replaces Firefox Accounts; there is no fxa sign-in or signed-out flow.

--- a/browser/base/content/test/sync/browser.toml
+++ b/browser/base/content/test/sync/browser.toml
@@ -2,10 +2,13 @@
 support-files = ["head.js"]
 
 ["browser_appmenu_nova_fxa_label_signin.js"]
+skip-if = ["enterprise"] # Enterprise Accounts replaces Firefox Accounts; there is no fxa sign-in or signed-out flow.
 
 ["browser_appmenu_signin_cta_variants.js"]
+skip-if = ["enterprise"] # Enterprise Accounts replaces Firefox Accounts; there is no fxa sign-in or signed-out flow.
 
 ["browser_avatar_menu_signin_cta_variants.js"]
+skip-if = ["enterprise"] # Enterprise Accounts replaces Firefox Accounts; there is no fxa sign-in or signed-out flow.
 
 ["browser_contextmenu_sendpage.js"]
 skip-if = [
@@ -17,20 +20,27 @@ skip-if = [
 ["browser_contextmenu_sendtab.js"]
 
 ["browser_fxa_badge.js"]
+skip-if = ["enterprise"] # Enterprise Accounts replaces Firefox Accounts; there is no fxa sign-in or signed-out flow.
 
 ["browser_fxa_cta_links.js"]
+skip-if = ["enterprise"] # Enterprise Accounts replaces Firefox Accounts; there is no fxa sign-in or signed-out flow.
 
 ["browser_fxa_web_channel.js"]
+skip-if = ["enterprise"] # Enterprise Accounts replaces Firefox Accounts; there is no fxa sign-in or signed-out flow.
 https_first_disabled = true
 support-files = ["browser_fxa_web_channel.html"]
 
 ["browser_sendtab_telemetry.js"]
+skip-if = ["enterprise"] # Enterprise Accounts replaces Firefox Accounts; there is no fxa sign-in or signed-out flow.
 
 ["browser_sendtab_toolbarbutton.js"]
+skip-if = ["enterprise"] # Enterprise Accounts replaces Firefox Accounts; there is no fxa sign-in or signed-out flow.
 
 ["browser_signed_out_avatar_variants.js"]
+skip-if = ["enterprise"] # Enterprise Accounts replaces Firefox Accounts; there is no fxa sign-in or signed-out flow.
 
 ["browser_sync.js"]
+skip-if = ["enterprise"] # Enterprise Accounts replaces Firefox Accounts; there is no fxa sign-in or signed-out flow.
 support-files = ["!/browser/components/profiles/tests/browser/head.js"]
 
 ["browser_synced_tabs_view.js"]

--- a/browser/components/asrouter/tests/browser/browser.toml
+++ b/browser/components/asrouter/tests/browser/browser.toml
@@ -38,6 +38,7 @@ skip-if = [
 https_first_disabled = true
 
 ["browser_asrouter_menu_messages.js"]
+skip-if = ["enterprise"] # Enterprise builds do not support the FxA menu.
 
 ["browser_asrouter_milestone_message_cfr.js"]
 
@@ -62,6 +63,7 @@ run-if = [
 ["browser_asrouter_toolbarbadge.js"]
 tags = "remote-settings"
 skip-if = [
+  "enterprise", # Enterprise Accounts replaces Firefox Accounts; the FxA toolbar button this test badges is hidden.
   "a11y_checks", # Bug 1854515 and 1858041 to investigate intermittent a11y_checks results (fails on Autoland, passes on Try)
 ]
 

--- a/browser/components/extensions/test/browser/browser_unified_extensions_empty_panel.js
+++ b/browser/components/extensions/test/browser/browser_unified_extensions_empty_panel.js
@@ -377,34 +377,41 @@ add_task(
   }
 );
 
-add_task(async function test_button_click_in_pbm_without_any_extensions() {
-  const win = await BrowserTestUtils.openNewBrowserWindow({ private: true });
+add_task(
+  {
+    // Enterprise builds disable the discovery pane
+    // (extensions.getAddons.showPane=false)
+    skip_if: () => AppConstants.MOZ_ENTERPRISE,
+  },
+  async function test_button_click_in_pbm_without_any_extensions() {
+    const win = await BrowserTestUtils.openNewBrowserWindow({ private: true });
 
-  // This clicks on gUnifiedExtensions.button and waits for panel to show.
-  await openExtensionsPanel(win);
+    // This clicks on gUnifiedExtensions.button and waits for panel to show.
+    await openExtensionsPanel(win);
 
-  assertIsEmptyPanelOnboardingExtensions(win);
-  const discoverButton = getDiscoverButton(win);
+    assertIsEmptyPanelOnboardingExtensions(win);
+    const discoverButton = getDiscoverButton(win);
 
-  // Button click opens about:addons (reuses about:privatebrowsing tab).
-  // Primary click should open about:addons.
-  const tabLoadedPromise = BrowserTestUtils.browserStopped(
-    win.gBrowser.selectedBrowser,
-    "about:addons"
-  );
+    // Button click opens about:addons (reuses about:privatebrowsing tab).
+    // Primary click should open about:addons.
+    const tabLoadedPromise = BrowserTestUtils.browserStopped(
+      win.gBrowser.selectedBrowser,
+      "about:addons"
+    );
 
-  discoverButton.click();
+    discoverButton.click();
 
-  await tabLoadedPromise;
-  is(
-    win.gBrowser.currentURI.spec,
-    "about:addons",
-    "expected about:addons to be open"
-  );
+    await tabLoadedPromise;
+    is(
+      win.gBrowser.currentURI.spec,
+      "about:addons",
+      "expected about:addons to be open"
+    );
 
-  // This also closes the new tab.
-  await BrowserTestUtils.closeWindow(win);
-});
+    // This also closes the new tab.
+    await BrowserTestUtils.closeWindow(win);
+  }
+);
 
 // Tests behavior when the user has extensions installed, but without private
 // browsing access. Extensions without private browsing access are not shown,
@@ -592,50 +599,61 @@ add_task(async function test_empty_state_with_disabled_addon() {
 // This test shows that non-extension add-ons are ignored in evaluating whether
 // the empty panel should be shown, even if there is another reason that could
 // potentially match for extension types (e.g. add-on being disabled).
-add_task(async function test_no_empty_state_with_disabled_non_extension() {
-  const disabledDictAddon = await promiseInstallWebExtension({
-    manifest: {
-      name: "This is a dictionary (definitely not type 'extension') (disabled)",
-      dictionaries: {},
-      browser_specific_settings: { gecko: { id: "@dict-disabled" } },
-    },
-  });
-  const dictAddon = await promiseInstallWebExtension({
-    manifest: {
-      name: "This is a dictionary (definitely not type 'extension') (enabled)",
-      dictionaries: {},
-      browser_specific_settings: { gecko: { id: "@dict-not-disabled" } },
-    },
-  });
-  await disabledDictAddon.disable();
-  is(disabledDictAddon.isActive, false, "One of the dict add-ons was disabled");
+add_task(
+  {
+    // Enterprise builds disable the discovery pane
+    // (extensions.getAddons.showPane=false)
+    skip_if: () => AppConstants.MOZ_ENTERPRISE,
+  },
+  async function test_no_empty_state_with_disabled_non_extension() {
+    const disabledDictAddon = await promiseInstallWebExtension({
+      manifest: {
+        name: "This is a dictionary (definitely not type 'extension') (disabled)",
+        dictionaries: {},
+        browser_specific_settings: { gecko: { id: "@dict-disabled" } },
+      },
+    });
+    const dictAddon = await promiseInstallWebExtension({
+      manifest: {
+        name: "This is a dictionary (definitely not type 'extension') (enabled)",
+        dictionaries: {},
+        browser_specific_settings: { gecko: { id: "@dict-not-disabled" } },
+      },
+    });
+    await disabledDictAddon.disable();
+    is(
+      disabledDictAddon.isActive,
+      false,
+      "One of the dict add-ons was disabled"
+    );
 
-  await BrowserTestUtils.withNewTab(
-    { gBrowser, url: "about:robots" },
-    async () => {
-      // This clicks on gUnifiedExtensions.button and waits for panel to show.
-      await openExtensionsPanel(window);
+    await BrowserTestUtils.withNewTab(
+      { gBrowser, url: "about:robots" },
+      async () => {
+        // This clicks on gUnifiedExtensions.button and waits for panel to show.
+        await openExtensionsPanel(window);
 
-      assertIsEmptyPanelOnboardingExtensions(window);
-      const discoverButton = getDiscoverButton(window);
+        assertIsEmptyPanelOnboardingExtensions(window);
+        const discoverButton = getDiscoverButton(window);
 
-      const tabPromise = BrowserTestUtils.waitForNewTab(
-        gBrowser,
-        "about:addons",
-        true
-      );
+        const tabPromise = BrowserTestUtils.waitForNewTab(
+          gBrowser,
+          "about:addons",
+          true
+        );
 
-      discoverButton.click();
+        discoverButton.click();
 
-      const tab = await tabPromise;
-      ok(true, "about:addons opened instead of panel about disabled add-ons");
-      BrowserTestUtils.removeTab(tab);
-    }
-  );
+        const tab = await tabPromise;
+        ok(true, "about:addons opened instead of panel about disabled add-ons");
+        BrowserTestUtils.removeTab(tab);
+      }
+    );
 
-  await disabledDictAddon.uninstall();
-  await dictAddon.uninstall();
-});
+    await disabledDictAddon.uninstall();
+    await dictAddon.uninstall();
+  }
+);
 
 // Verifies that if the only add-on is disabled by blocklisting, that we still
 // see a panel and that the blocklist message is visible.

--- a/browser/components/ipprotection/tests/browser/browser.toml
+++ b/browser/components/ipprotection/tests/browser/browser.toml
@@ -134,5 +134,11 @@ skip-if = [
 ["browser_ipprotection_utils.js"]
 
 ["browser_ipprotection_viewer_site_exclusion.js"]
+skip-if = [
+  "enterprise", # Enterprise uses IPPEnterpriseAuthProvider and does not show the standard panel or toolbar button.
+]
 
 ["browser_ipprotection_window_close.js"]
+skip-if = [
+  "enterprise", # Enterprise uses IPPEnterpriseAuthProvider and does not show the standard panel or toolbar button.
+]

--- a/browser/components/preferences/tests/privacy/browser_privacy_ipprotection.js
+++ b/browser/components/preferences/tests/privacy/browser_privacy_ipprotection.js
@@ -274,146 +274,136 @@ add_task(async function test_exclusions_add_button() {
 
 // Test that the exclusion_added counter is incremented
 // when exclusions are added via the permissions dialog.
-// Bug XXX - IPPExceptionsManager, which records the exclusion_added telemetry,
-// is only initialized in non-enterprise builds (see IPProtectionHelpers.sys.mjs),
-// so the counter is never incremented in enterprise builds.
-add_task(
-  { skip_if: () => AppConstants.MOZ_ENTERPRISE },
-  async function test_exclusions_telemetry() {
-    const PERM_NAME = "ipp-vpn";
-    await setupVpnPrefs({
-      feature: "beta",
-      siteExceptions: true,
-      entitlementCache: '{"some":"data"}',
-    });
+add_task(async function test_exclusions_telemetry() {
+  const PERM_NAME = "ipp-vpn";
+  await setupVpnPrefs({
+    feature: "beta",
+    siteExceptions: true,
+    entitlementCache: '{"some":"data"}',
+  });
 
-    await BrowserTestUtils.withNewTab(
-      { gBrowser, url: "about:preferences#privacy" },
-      async function (browser) {
-        let settingGroup = testSettingsGroupVisible(browser);
-        let siteExceptionsGroup = settingGroup?.querySelector(
-          "#ipProtectionExceptions"
-        );
-        let exceptionAllListButton = siteExceptionsGroup?.querySelector(
-          "#ipProtectionExceptionAllListButton"
-        );
+  await BrowserTestUtils.withNewTab(
+    { gBrowser, url: "about:preferences#privacy" },
+    async function (browser) {
+      let settingGroup = testSettingsGroupVisible(browser);
+      let siteExceptionsGroup = settingGroup?.querySelector(
+        "#ipProtectionExceptions"
+      );
+      let exceptionAllListButton = siteExceptionsGroup?.querySelector(
+        "#ipProtectionExceptionAllListButton"
+      );
 
-        // Clear ipp-vpn and old telemetry
-        Services.perms.removeByType(PERM_NAME);
-        Services.fog.testResetFOG();
-        await Services.fog.testFlushAllChildren();
+      // Clear ipp-vpn and old telemetry
+      Services.perms.removeByType(PERM_NAME);
+      Services.fog.testResetFOG();
+      await Services.fog.testFlushAllChildren();
 
-        // Add an existing exclusion that we'll remove later
-        const site1 = "https://existing.example.com";
-        let principal1 =
-          Services.scriptSecurityManager.createContentPrincipalFromOrigin(
-            site1
-          );
-        Services.perms.addFromPrincipal(
-          principal1,
-          PERM_NAME,
-          Services.perms.DENY_ACTION
-        );
+      // Add an existing exclusion that we'll remove later
+      const site1 = "https://existing.example.com";
+      let principal1 =
+        Services.scriptSecurityManager.createContentPrincipalFromOrigin(site1);
+      Services.perms.addFromPrincipal(
+        principal1,
+        PERM_NAME,
+        Services.perms.DENY_ACTION
+      );
 
-        // Reset telemetry after setting up the existing exclusion
-        Services.fog.testResetFOG();
-        await Services.fog.testFlushAllChildren();
+      // Reset telemetry after setting up the existing exclusion
+      Services.fog.testResetFOG();
+      await Services.fog.testFlushAllChildren();
 
-        // Load the permissions dialog
-        let promiseSubDialogLoaded = promiseLoadSubDialog(
-          "chrome://browser/content/preferences/dialogs/permissions.xhtml"
-        );
+      // Load the permissions dialog
+      let promiseSubDialogLoaded = promiseLoadSubDialog(
+        "chrome://browser/content/preferences/dialogs/permissions.xhtml"
+      );
 
-        exceptionAllListButton.click();
+      exceptionAllListButton.click();
 
-        const win = await promiseSubDialogLoaded;
+      const win = await promiseSubDialogLoaded;
 
-        let permissionsBox = win.document.getElementById("permissionsBox");
+      let permissionsBox = win.document.getElementById("permissionsBox");
 
-        // Wait for existing exclusion to appear
-        await BrowserTestUtils.waitForMutationCondition(
-          permissionsBox,
-          { subtree: true, childList: true },
-          () => permissionsBox.children.length === 1
-        );
+      // Wait for existing exclusion to appear
+      await BrowserTestUtils.waitForMutationCondition(
+        permissionsBox,
+        { subtree: true, childList: true },
+        () => permissionsBox.children.length === 1
+      );
 
-        // Add two new exclusions
-        let siteListUpdatedPromise = BrowserTestUtils.waitForMutationCondition(
-          permissionsBox,
-          { subtree: true, childList: true },
-          () => {
-            return permissionsBox.children.length === 3;
-          }
-        );
+      // Add two new exclusions
+      let siteListUpdatedPromise = BrowserTestUtils.waitForMutationCondition(
+        permissionsBox,
+        { subtree: true, childList: true },
+        () => {
+          return permissionsBox.children.length === 3;
+        }
+      );
 
-        let urlField = win.document.getElementById("url");
-        let addButton = win.document.getElementById("btnAdd");
+      let urlField = win.document.getElementById("url");
+      let addButton = win.document.getElementById("btnAdd");
 
-        const site2 = "https://example.com";
-        urlField.focus();
-        EventUtils.sendString(site2, win);
-        await addButton.updateComplete;
-        addButton.click();
+      const site2 = "https://example.com";
+      urlField.focus();
+      EventUtils.sendString(site2, win);
+      await addButton.updateComplete;
+      addButton.click();
 
-        const site3 = "https://another.example.com";
-        urlField.focus();
-        EventUtils.sendString(site3, win);
-        await addButton.updateComplete;
-        addButton.click();
+      const site3 = "https://another.example.com";
+      urlField.focus();
+      EventUtils.sendString(site3, win);
+      await addButton.updateComplete;
+      addButton.click();
 
-        await siteListUpdatedPromise;
+      await siteListUpdatedPromise;
 
-        // Remove the existing exclusion
-        siteListUpdatedPromise = BrowserTestUtils.waitForMutationCondition(
-          permissionsBox,
-          { subtree: true, childList: true },
-          () => {
-            return permissionsBox.children.length === 2;
-          }
-        );
+      // Remove the existing exclusion
+      siteListUpdatedPromise = BrowserTestUtils.waitForMutationCondition(
+        permissionsBox,
+        { subtree: true, childList: true },
+        () => {
+          return permissionsBox.children.length === 2;
+        }
+      );
 
-        let removeButton = win.document.getElementById("removePermission");
-        let existingItem = Array.from(permissionsBox.children).find(
-          item => item.getAttribute("origin") === site1
-        );
-        Assert.ok(existingItem, "Should find the existing entry");
+      let removeButton = win.document.getElementById("removePermission");
+      let existingItem = Array.from(permissionsBox.children).find(
+        item => item.getAttribute("origin") === site1
+      );
+      Assert.ok(existingItem, "Should find the existing entry");
 
-        existingItem.click();
-        await removeButton.updateComplete;
-        removeButton.click();
+      existingItem.click();
+      await removeButton.updateComplete;
+      removeButton.click();
 
-        await siteListUpdatedPromise;
+      await siteListUpdatedPromise;
 
-        // Apply the changes and check telemetry
-        let saveButton = win.document
-          .querySelector("dialog")
-          .getButton("accept");
-        saveButton.click();
+      // Apply the changes and check telemetry
+      let saveButton = win.document.querySelector("dialog").getButton("accept");
+      saveButton.click();
 
-        // First verify the permissions were actually saved
-        let exclusions = Services.perms.getAllByTypes([PERM_NAME]);
-        Assert.equal(
-          exclusions.length,
-          2,
-          "Should have 2 new exclusions saved and remaining, ignoring the removed existing exclusion"
-        );
+      // First verify the permissions were actually saved
+      let exclusions = Services.perms.getAllByTypes([PERM_NAME]);
+      Assert.equal(
+        exclusions.length,
+        2,
+        "Should have 2 new exclusions saved and remaining, ignoring the removed existing exclusion"
+      );
 
-        await Services.fog.testFlushAllChildren();
+      await Services.fog.testFlushAllChildren();
 
-        Assert.equal(
-          Glean.ipprotection.exclusionAdded.testGetValue(),
-          2,
-          "exclusion_added counter should be 2, ignoring the removed existing exclusion"
-        );
+      Assert.equal(
+        Glean.ipprotection.exclusionAdded.testGetValue(),
+        2,
+        "exclusion_added counter should be 2, ignoring the removed existing exclusion"
+      );
 
-        // Clean up
-        Services.perms.removeByType(PERM_NAME);
-        Services.prefs.clearUserPref(ONBOARDING_MESSAGE_MASK_PREF);
-        Services.fog.testResetFOG();
-      }
-    );
-  }
-);
+      // Clean up
+      Services.perms.removeByType(PERM_NAME);
+      Services.prefs.clearUserPref(ONBOARDING_MESSAGE_MASK_PREF);
+      Services.fog.testResetFOG();
+    }
+  );
+});
 
 // Test that we show the correct number of site exclusions
 add_task(async function test_exclusions_count() {

--- a/browser/components/preferences/tests/privacy/browser_privacy_ipprotection.js
+++ b/browser/components/preferences/tests/privacy/browser_privacy_ipprotection.js
@@ -273,137 +273,147 @@ add_task(async function test_exclusions_add_button() {
 });
 
 // Test that the exclusion_added counter is incremented
-// when exclusions are added via the permissions dialog
-add_task(async function test_exclusions_telemetry() {
-  const PERM_NAME = "ipp-vpn";
-  await setupVpnPrefs({
-    feature: "beta",
-    siteExceptions: true,
-    entitlementCache: '{"some":"data"}',
-  });
+// when exclusions are added via the permissions dialog.
+// Bug XXX - IPPExceptionsManager, which records the exclusion_added telemetry,
+// is only initialized in non-enterprise builds (see IPProtectionHelpers.sys.mjs),
+// so the counter is never incremented in enterprise builds.
+add_task(
+  { skip_if: () => AppConstants.MOZ_ENTERPRISE },
+  async function test_exclusions_telemetry() {
+    const PERM_NAME = "ipp-vpn";
+    await setupVpnPrefs({
+      feature: "beta",
+      siteExceptions: true,
+      entitlementCache: '{"some":"data"}',
+    });
 
-  await BrowserTestUtils.withNewTab(
-    { gBrowser, url: "about:preferences#privacy" },
-    async function (browser) {
-      let settingGroup = testSettingsGroupVisible(browser);
-      let siteExceptionsGroup = settingGroup?.querySelector(
-        "#ipProtectionExceptions"
-      );
-      let exceptionAllListButton = siteExceptionsGroup?.querySelector(
-        "#ipProtectionExceptionAllListButton"
-      );
+    await BrowserTestUtils.withNewTab(
+      { gBrowser, url: "about:preferences#privacy" },
+      async function (browser) {
+        let settingGroup = testSettingsGroupVisible(browser);
+        let siteExceptionsGroup = settingGroup?.querySelector(
+          "#ipProtectionExceptions"
+        );
+        let exceptionAllListButton = siteExceptionsGroup?.querySelector(
+          "#ipProtectionExceptionAllListButton"
+        );
 
-      // Clear ipp-vpn and old telemetry
-      Services.perms.removeByType(PERM_NAME);
-      Services.fog.testResetFOG();
-      await Services.fog.testFlushAllChildren();
+        // Clear ipp-vpn and old telemetry
+        Services.perms.removeByType(PERM_NAME);
+        Services.fog.testResetFOG();
+        await Services.fog.testFlushAllChildren();
 
-      // Add an existing exclusion that we'll remove later
-      const site1 = "https://existing.example.com";
-      let principal1 =
-        Services.scriptSecurityManager.createContentPrincipalFromOrigin(site1);
-      Services.perms.addFromPrincipal(
-        principal1,
-        PERM_NAME,
-        Services.perms.DENY_ACTION
-      );
+        // Add an existing exclusion that we'll remove later
+        const site1 = "https://existing.example.com";
+        let principal1 =
+          Services.scriptSecurityManager.createContentPrincipalFromOrigin(
+            site1
+          );
+        Services.perms.addFromPrincipal(
+          principal1,
+          PERM_NAME,
+          Services.perms.DENY_ACTION
+        );
 
-      // Reset telemetry after setting up the existing exclusion
-      Services.fog.testResetFOG();
-      await Services.fog.testFlushAllChildren();
+        // Reset telemetry after setting up the existing exclusion
+        Services.fog.testResetFOG();
+        await Services.fog.testFlushAllChildren();
 
-      // Load the permissions dialog
-      let promiseSubDialogLoaded = promiseLoadSubDialog(
-        "chrome://browser/content/preferences/dialogs/permissions.xhtml"
-      );
+        // Load the permissions dialog
+        let promiseSubDialogLoaded = promiseLoadSubDialog(
+          "chrome://browser/content/preferences/dialogs/permissions.xhtml"
+        );
 
-      exceptionAllListButton.click();
+        exceptionAllListButton.click();
 
-      const win = await promiseSubDialogLoaded;
+        const win = await promiseSubDialogLoaded;
 
-      let permissionsBox = win.document.getElementById("permissionsBox");
+        let permissionsBox = win.document.getElementById("permissionsBox");
 
-      // Wait for existing exclusion to appear
-      await BrowserTestUtils.waitForMutationCondition(
-        permissionsBox,
-        { subtree: true, childList: true },
-        () => permissionsBox.children.length === 1
-      );
+        // Wait for existing exclusion to appear
+        await BrowserTestUtils.waitForMutationCondition(
+          permissionsBox,
+          { subtree: true, childList: true },
+          () => permissionsBox.children.length === 1
+        );
 
-      // Add two new exclusions
-      let siteListUpdatedPromise = BrowserTestUtils.waitForMutationCondition(
-        permissionsBox,
-        { subtree: true, childList: true },
-        () => {
-          return permissionsBox.children.length === 3;
-        }
-      );
+        // Add two new exclusions
+        let siteListUpdatedPromise = BrowserTestUtils.waitForMutationCondition(
+          permissionsBox,
+          { subtree: true, childList: true },
+          () => {
+            return permissionsBox.children.length === 3;
+          }
+        );
 
-      let urlField = win.document.getElementById("url");
-      let addButton = win.document.getElementById("btnAdd");
+        let urlField = win.document.getElementById("url");
+        let addButton = win.document.getElementById("btnAdd");
 
-      const site2 = "https://example.com";
-      urlField.focus();
-      EventUtils.sendString(site2, win);
-      await addButton.updateComplete;
-      addButton.click();
+        const site2 = "https://example.com";
+        urlField.focus();
+        EventUtils.sendString(site2, win);
+        await addButton.updateComplete;
+        addButton.click();
 
-      const site3 = "https://another.example.com";
-      urlField.focus();
-      EventUtils.sendString(site3, win);
-      await addButton.updateComplete;
-      addButton.click();
+        const site3 = "https://another.example.com";
+        urlField.focus();
+        EventUtils.sendString(site3, win);
+        await addButton.updateComplete;
+        addButton.click();
 
-      await siteListUpdatedPromise;
+        await siteListUpdatedPromise;
 
-      // Remove the existing exclusion
-      siteListUpdatedPromise = BrowserTestUtils.waitForMutationCondition(
-        permissionsBox,
-        { subtree: true, childList: true },
-        () => {
-          return permissionsBox.children.length === 2;
-        }
-      );
+        // Remove the existing exclusion
+        siteListUpdatedPromise = BrowserTestUtils.waitForMutationCondition(
+          permissionsBox,
+          { subtree: true, childList: true },
+          () => {
+            return permissionsBox.children.length === 2;
+          }
+        );
 
-      let removeButton = win.document.getElementById("removePermission");
-      let existingItem = Array.from(permissionsBox.children).find(
-        item => item.getAttribute("origin") === site1
-      );
-      Assert.ok(existingItem, "Should find the existing entry");
+        let removeButton = win.document.getElementById("removePermission");
+        let existingItem = Array.from(permissionsBox.children).find(
+          item => item.getAttribute("origin") === site1
+        );
+        Assert.ok(existingItem, "Should find the existing entry");
 
-      existingItem.click();
-      await removeButton.updateComplete;
-      removeButton.click();
+        existingItem.click();
+        await removeButton.updateComplete;
+        removeButton.click();
 
-      await siteListUpdatedPromise;
+        await siteListUpdatedPromise;
 
-      // Apply the changes and check telemetry
-      let saveButton = win.document.querySelector("dialog").getButton("accept");
-      saveButton.click();
+        // Apply the changes and check telemetry
+        let saveButton = win.document
+          .querySelector("dialog")
+          .getButton("accept");
+        saveButton.click();
 
-      // First verify the permissions were actually saved
-      let exclusions = Services.perms.getAllByTypes([PERM_NAME]);
-      Assert.equal(
-        exclusions.length,
-        2,
-        "Should have 2 new exclusions saved and remaining, ignoring the removed existing exclusion"
-      );
+        // First verify the permissions were actually saved
+        let exclusions = Services.perms.getAllByTypes([PERM_NAME]);
+        Assert.equal(
+          exclusions.length,
+          2,
+          "Should have 2 new exclusions saved and remaining, ignoring the removed existing exclusion"
+        );
 
-      await Services.fog.testFlushAllChildren();
+        await Services.fog.testFlushAllChildren();
 
-      Assert.equal(
-        Glean.ipprotection.exclusionAdded.testGetValue(),
-        2,
-        "exclusion_added counter should be 2, ignoring the removed existing exclusion"
-      );
+        Assert.equal(
+          Glean.ipprotection.exclusionAdded.testGetValue(),
+          2,
+          "exclusion_added counter should be 2, ignoring the removed existing exclusion"
+        );
 
-      // Clean up
-      Services.perms.removeByType(PERM_NAME);
-      Services.prefs.clearUserPref(ONBOARDING_MESSAGE_MASK_PREF);
-      Services.fog.testResetFOG();
-    }
-  );
-});
+        // Clean up
+        Services.perms.removeByType(PERM_NAME);
+        Services.prefs.clearUserPref(ONBOARDING_MESSAGE_MASK_PREF);
+        Services.fog.testResetFOG();
+      }
+    );
+  }
+);
 
 // Test that we show the correct number of site exclusions
 add_task(async function test_exclusions_count() {

--- a/browser/components/preferences/tests/searchResults/browser_search_overlapping_ranges.js
+++ b/browser/components/preferences/tests/searchResults/browser_search_overlapping_ranges.js
@@ -113,86 +113,91 @@ function searchableGroupCount(doc, paneName) {
 // finishes. The following "backup" search then takes the subQuery fast path and
 // skips the hidden group. No group matches, so the pane-level fallback shows
 // every group. The searchCompleted gate makes the search run in full instead.
-add_task(async function overlapping_subquery_does_not_show_whole_pane() {
-  const PANE = DEFAULT_PANE;
+add_task(
+  // The Backup settings group is hidden in enterprise builds
+  // (SQLite at-rest encryption disables backup).
+  { skip_if: () => AppConstants.MOZ_ENTERPRISE },
+  async function overlapping_subquery_does_not_show_whole_pane() {
+    const PANE = DEFAULT_PANE;
 
-  // A fresh, non-overlapping search shows a proper subset of the pane's groups.
-  let doc = await openSearchWithQuery("backup");
-  let freshVisible = visibleGroupIds(doc, PANE);
-  let totalGroups = searchableGroupCount(doc, PANE);
-  Assert.greater(
-    freshVisible.length,
-    0,
-    "Fresh 'backup' search shows at least one group in " + PANE
-  );
-  Assert.less(
-    freshVisible.length,
-    totalGroups,
-    "Fresh 'backup' search does not show the whole " + PANE
-  );
-  BrowserTestUtils.removeTab(gBrowser.selectedTab);
+    // A fresh, non-overlapping search shows a proper subset of the pane's groups.
+    let doc = await openSearchWithQuery("backup");
+    let freshVisible = visibleGroupIds(doc, PANE);
+    let totalGroups = searchableGroupCount(doc, PANE);
+    Assert.greater(
+      freshVisible.length,
+      0,
+      "Fresh 'backup' search shows at least one group in " + PANE
+    );
+    Assert.less(
+      freshVisible.length,
+      totalGroups,
+      "Fresh 'backup' search does not show the whole " + PANE
+    );
+    BrowserTestUtils.removeTab(gBrowser.selectedTab);
 
-  // Type the typo so the Backup group is hidden. Deleting the "p" leaves "backuo",
-  // which still matches nothing, so the group stays hidden.
-  doc = await openSearchWithQuery("backuop");
-  let win = gBrowser.contentWindow;
-  let searchInput = doc.getElementById("searchInput");
+    // Type the typo so the Backup group is hidden. Deleting the "p" leaves "backuo",
+    // which still matches nothing, so the group stays hidden.
+    doc = await openSearchWithQuery("backuop");
+    let win = gBrowser.contentWindow;
+    let searchInput = doc.getElementById("searchInput");
 
-  searchInput.focus();
-  let backuoCompleted = BrowserTestUtils.waitForEvent(
-    win,
-    "PreferencesSearchCompleted",
-    e => e.detail == "backuo"
-  );
-  EventUtils.synthesizeKey("KEY_Backspace");
-  await backuoCompleted;
-
-  // Block the next search ("backu") at its gotoPref await so it never finishes,
-  // leaving this.query "backu" and searchCompleted false.
-  let releaseStale;
-  let staleBlocked = new Promise(r => (releaseStale = r));
-  let staleReachedGotoPref;
-  let staleEnteredGotoPref = new Promise(r => (staleReachedGotoPref = r));
-  let origGotoPref = win.gotoPref;
-  let armed = true;
-  win.gotoPref = async function (...args) {
-    if (armed && args[0] === "paneSearchResults") {
-      armed = false;
-      staleReachedGotoPref();
-      await staleBlocked;
-    }
-    return origGotoPref(...args);
-  };
-
-  try {
-    // Delete the "o" so the "backu" search blocks at gotoPref.
-    EventUtils.synthesizeKey("KEY_Backspace");
-    await staleEnteredGotoPref;
-
-    // Add the "p" so the "backup" search runs to completion while "backu" is
-    // still blocked.
-    let targetCompleted = BrowserTestUtils.waitForEvent(
+    searchInput.focus();
+    let backuoCompleted = BrowserTestUtils.waitForEvent(
       win,
       "PreferencesSearchCompleted",
-      e => e.detail == "backup"
+      e => e.detail == "backuo"
     );
-    EventUtils.sendString("p");
-    await targetCompleted;
+    EventUtils.synthesizeKey("KEY_Backspace");
+    await backuoCompleted;
 
-    Assert.deepEqual(
-      visibleGroupIds(gBrowser.contentDocument, PANE),
-      freshVisible,
-      "Overlapping subQuery search must match a fresh search, not show the whole " +
-        PANE
-    );
-  } finally {
-    win.gotoPref = origGotoPref;
-    releaseStale();
+    // Block the next search ("backu") at its gotoPref await so it never finishes,
+    // leaving this.query "backu" and searchCompleted false.
+    let releaseStale;
+    let staleBlocked = new Promise(r => (releaseStale = r));
+    let staleReachedGotoPref;
+    let staleEnteredGotoPref = new Promise(r => (staleReachedGotoPref = r));
+    let origGotoPref = win.gotoPref;
+    let armed = true;
+    win.gotoPref = async function (...args) {
+      if (armed && args[0] === "paneSearchResults") {
+        armed = false;
+        staleReachedGotoPref();
+        await staleBlocked;
+      }
+      return origGotoPref(...args);
+    };
+
+    try {
+      // Delete the "o" so the "backu" search blocks at gotoPref.
+      EventUtils.synthesizeKey("KEY_Backspace");
+      await staleEnteredGotoPref;
+
+      // Add the "p" so the "backup" search runs to completion while "backu" is
+      // still blocked.
+      let targetCompleted = BrowserTestUtils.waitForEvent(
+        win,
+        "PreferencesSearchCompleted",
+        e => e.detail == "backup"
+      );
+      EventUtils.sendString("p");
+      await targetCompleted;
+
+      Assert.deepEqual(
+        visibleGroupIds(gBrowser.contentDocument, PANE),
+        freshVisible,
+        "Overlapping subQuery search must match a fresh search, not show the whole " +
+          PANE
+      );
+    } finally {
+      win.gotoPref = origGotoPref;
+      releaseStale();
+    }
+
+    await waitForRangeCountStable(win);
+    BrowserTestUtils.removeTab(gBrowser.selectedTab);
   }
-
-  await waitForRangeCountStable(win);
-  BrowserTestUtils.removeTab(gBrowser.selectedTab);
-});
+);
 
 // Bug 2045266: same overlap as above, driven through searchInput keystrokes
 // instead of searchFunction. A single sendString dispatches all its keystrokes

--- a/browser/components/profiles/tests/browser/browser-legacy.toml
+++ b/browser/components/profiles/tests/browser/browser-legacy.toml
@@ -47,6 +47,7 @@ skip-if = [
 ["browser_empty_name_beforeunload_test.js"]
 
 ["browser_fxa_menu_profiles.js"]
+skip-if = ["enterprise"] # Enterprise builds do not support the FxA menu.
 
 ["browser_icon_avatar_test.js"]
 

--- a/browser/components/profiles/tests/browser/browser.toml
+++ b/browser/components/profiles/tests/browser/browser.toml
@@ -45,6 +45,7 @@ run-if = [
 skip-if = ["enterprise"] # Enterprise builds do not support the FxA menu.
 
 ["browser_fxa_menu_profiles_telemetry.js"]
+skip-if = ["enterprise"] # Enterprise builds do not support the FxA menu.
 
 ["browser_icon_avatar_test.js"]
 

--- a/browser/components/profiles/tests/browser/browser.toml
+++ b/browser/components/profiles/tests/browser/browser.toml
@@ -42,6 +42,7 @@ run-if = [
 ["browser_empty_name_beforeunload_test.js"]
 
 ["browser_fxa_menu_profiles.js"]
+skip-if = ["enterprise"] # Enterprise builds do not support the FxA menu.
 
 ["browser_fxa_menu_profiles_telemetry.js"]
 

--- a/browser/components/referrals/tests/browser/browser.toml
+++ b/browser/components/referrals/tests/browser/browser.toml
@@ -1,5 +1,6 @@
 [DEFAULT]
 
 ["browser_referralsAccountMenu.js"]
+skip-if = ["enterprise"] # Enterprise builds do not support the FxA menu.
 
 ["browser_referralsAppMenu.js"]

--- a/browser/components/uitour/test/browser.toml
+++ b/browser/components/uitour/test/browser.toml
@@ -77,6 +77,7 @@ skip-if = [
 
 ["browser_fxa.js"]
 tags = "os_integration"
+skip-if = ["enterprise"] # UITour FxA integration is not applicable in enterprise builds
 
 ["browser_fxa_config.js"]
 


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2065838

Skips tests from the mochitest browser chrome that are not applicable in enterprise builds, i.e. the majority of non-applicable tests that are skipped are rely on unsupported Firefox Accounts UI elements.
