### PR TITLE
Bug 2070625 - Use launcher process when spawning browser from felt

### DIFF
--- a/testing/enterprise/manifest-browser.toml
+++ b/testing/enterprise/manifest-browser.toml
@@ -31,6 +31,15 @@ disabled = "Bug 1996558: scaffolding for the browsing-child encryption-mismatch 
 
 ["test_felt_browser_fxa.py"]
 
+["test_felt_browser_launcher_process.py"]
+run-if = [
+  "os == 'win'",
+]
+skip-if = [
+  "asan",
+  "os == 'win' && arch == 'aarch64'",
+]
+
 ["test_felt_browser_new_window_from_cli.py"]
 
 ["test_felt_browser_rapid_new_tabs_from_cli.py"]

--- a/testing/enterprise/test_felt_browser_launcher_process.py
+++ b/testing/enterprise/test_felt_browser_launcher_process.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import os
+import sys
+
+sys.path.append(os.path.dirname(__file__))
+
+from felt_tests import FeltTests
+
+
+class BrowserLauncherProcess(FeltTests):
+    def test_browser_started_via_launcher(self):
+        """Felt must start the browser through the launcher process, which
+        patches security enhancements into the browser process. The dynamic
+        blocklist is only available if the browser was started through the
+        launcher process, so we can check for that to verify it."""
+        self.run_felt_base()
+        self.connect_child_browser()
+
+        with self._child_driver.using_context(self._child_driver.CONTEXT_CHROME):
+            available = self._child_driver.execute_script(
+                """
+                return Cc["@mozilla.org/about-thirdparty;1"].getService(
+                  Ci.nsIAboutThirdParty
+                ).isDynamicBlocklistAvailable;
+                """
+            )
+
+        self._logger.info(f"isDynamicBlocklistAvailable: {available}")
+
+        assert available, (
+            "Expected the browser to be started by a launcher process, but it "
+            "has no shared section (isDynamicBlocklistAvailable is false)"
+        )

--- a/testing/enterprise/test_felt_restart_works.py
+++ b/testing/enterprise/test_felt_restart_works.py
@@ -65,12 +65,20 @@ class AppRestartWorks(FeltTests):
         felt_ui_pid = self._driver.session_capabilities["moz:processID"]
         target_exe = psutil.Process(felt_ui_pid).exe()
         felt_browser_pids = set(self._get_felt_browser_pids(target_exe))
-        unexpected = felt_browser_pids - {new_browser_pid}
-        assert not unexpected, (
-            f"Extra FELT browser process(es) after restart (double relaunch?): {unexpected}"
-        )
+
         assert new_browser_pid in felt_browser_pids, (
             f"Relaunched browser PID {new_browser_pid} is not running"
+        )
+
+        launcher_pid = self._check_for_launcher(new_browser_pid, felt_browser_pids)
+
+        expected_pids = {new_browser_pid}
+        if launcher_pid is not None:
+            expected_pids.add(launcher_pid)
+
+        unexpected = felt_browser_pids - expected_pids
+        assert not unexpected, (
+            f"Extra FELT browser process(es) after restart (double relaunch?): {unexpected}"
         )
 
         self._logger.info(f"Closing new browser with PID {new_browser_pid}")
@@ -90,3 +98,35 @@ class AppRestartWorks(FeltTests):
             except (psutil.NoSuchProcess, psutil.ZombieProcess, psutil.AccessDenied):
                 continue
         return pids
+
+    def _check_for_launcher(self, browser_pid, felt_browser_pids):
+        """On Windows Firefox, asserts that browser_pid was started by a
+        launcher process, and returns that launcher's PID.
+        Otherwise returns None.
+        """
+        app_name = self._driver.session_capabilities.get("browserName")
+        if sys.platform != "win32" or app_name != "firefox":
+            return None
+
+        launcher_pid = self._get_launcher_pid(browser_pid)
+        assert launcher_pid in felt_browser_pids, (
+            f"Expected a launcher process parent for browser PID {browser_pid}, "
+            f"got {launcher_pid}; running FELT browser processes: "
+            f"{felt_browser_pids}"
+        )
+        return launcher_pid
+
+    def _get_launcher_pid(self, browser_pid):
+        """Returns the browser's parent process PID if it is a launcher
+        process (i.e., the command line contains "--launcher" and "-felt").
+        Returns None when the browser has no launcher.
+        """
+        try:
+            parent = psutil.Process(browser_pid).parent()
+            if parent:
+                cmdline = parent.cmdline()
+                if "--launcher" in cmdline and "-felt" in cmdline:
+                    return parent.pid
+        except (psutil.NoSuchProcess, psutil.ZombieProcess, psutil.AccessDenied):
+            pass
+        return None

--- a/toolkit/components/felt/content/FeltProcessParent.sys.mjs
+++ b/toolkit/components/felt/content/FeltProcessParent.sys.mjs
@@ -874,8 +874,20 @@ export class FeltProcessParent extends JSProcessActorParent {
       profileArgs = ["-P", foundProfile.name];
     }
 
+    // Use the launcher process so the browser gets the DLL blocklist and other
+    // security enhancements patched in while suspended.
+    // --wait-for-browser keeps the launcher alive to relay the browser's exit code
+    // --no-deelevate keeps the browser at felt's integrity level so that the ipc
+    // socket is accessible to both the browser and felt. (Felt running elevated
+    // is probably bad, but unlikely due to felt's own launcher process)
+    let launcherArgs = [];
+    if (Services.appinfo.OS == "WINNT" && lazy.isBuildAppBrowser()) {
+      launcherArgs = ["--launcher", "--wait-for-browser", "--no-deelevate"];
+    }
+
     lazy.log.debug(`Using profileArgs: ${profileArgs}`);
     const firefoxRunArgs = [
+      ...launcherArgs,
       "--foreground",
       ...profileArgs,
       "-felt",


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2070625

On Windows, Firefox's initial process is a Launcher process that launches the browser process in a suspended state so that it can patch the DLL loading mechanism to block modules and to set up pre-launch CIG guards, etc. Normally this happens because the initial process detects that its parent process is not Firefox, so it becomes a Launcher. However, since we launch the browser from Felt, the auto-detection does not work. Similarly by launching using `Subprocess`, we don't go through the typical setup with which Firefox propagates the protections to subprocesses.

Instead we can pass the "--launcher" flag to specify a launcher process and get the protections.

Note: Normally, the initial launcher process exits leaving the spawned browser running. However, with how Felt spawns the process there are problems with this approach:
1. By default, Subprocess will kill its process tree when its process exits
2. Felt depends on the exit code from the browser process, which is not captured if the launcher process exits

The extra launcher process has minimal overhead (~8MB from a debug build on my system) so we will just keep it alive.

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Blocks: #1442 

---

### Testing <!-- OPTIONAL -->

* [x] Added tests
* [x] Manual testing performed
  * I've done testing of the specific third-party module blocking and some restart scenarios, but we'll need QA to be on the alert for any issues that could show up.

<!--
**Steps to verify changes:**
1.
4.
5.

**Expected result:**
-->
