### PR TITLE
Bug 2070529 - Update skipping enterprise incompatible tests

### DIFF
--- a/browser/components/enterprisepolicies/tests/browser/browser.toml
+++ b/browser/components/enterprisepolicies/tests/browser/browser.toml
@@ -51,6 +51,7 @@ run-if = [
 
 ["browser_policy_bookmarks.js"]
 support-files = "favicon.svg"
+skip-if = ["enterprise"] # Applies Bookmarks, unsupported in enterprise builds
 
 ["browser_policy_cookie_settings.js"]
 https_first_disabled = true
@@ -85,6 +86,7 @@ support-files = [
 ]
 
 ["browser_policy_disable_privatebrowsing.js"]
+skip-if = ["enterprise"] # Applies DisablePrivateBrowsing, unsupported in enterprise builds
 
 ["browser_policy_disable_profile_import.js"]
 

--- a/browser/components/enterprisepolicies/tests/xpcshell/xpcshell.toml
+++ b/browser/components/enterprisepolicies/tests/xpcshell/xpcshell.toml
@@ -20,10 +20,8 @@ support-files = [
 run-if = ["enterprise"]
 
 ["test_appupdatepin.js"]
-skip-if = ["enterprise"] # Applies AppUpdateURL, unsupported on enterprise (x-compatibility)
 
 ["test_appupdateurl.js"]
-skip-if = ["enterprise"] # Applies AppUpdateURL, unsupported on enterprise (x-compatibility)
 
 ["test_bug1658259.js"]
 


### PR DESCRIPTION
<!-- Nice PR, thanks for the work!

## Checklist for the author (in addition to filling out the template)
- [ ] Ensure the linked Bugzilla item is up to date
- [ ] Provide sufficient implementation details in commit messages when necessary

This helps reviewers quickly understand your changes. -->

### Description <!-- REQUIRED -->

Bugzilla: Bug-2070529

[D325324](https://phabricator.services.mozilla.com/D325324) disables the policies `Bookmarks` and `DisablePrivateBrowsing`  and re-enabled the policy `AppUpdateURL` in enterprise builds. Hence we need to skip the tests for incompatible policies and reenable the now compatible one.

<!-- Please include a short summary of the changes. More detailed implementation information belongs in commit messages. -->

---

### Dependencies / Related Issues <!-- OPTIONAL -->

* Depends on: [D325324](https://phabricator.services.mozilla.com/D325324)