### PR TITLE
Bug 2071207 - Prepare updates when the console schedules a browser restart

### DIFF
--- a/testing/enterprise/manifest-browser.toml
+++ b/testing/enterprise/manifest-browser.toml
@@ -55,6 +55,8 @@ run-if = [
 
 ["test_felt_browser_relaunch_deadline_withdrawn.py"]
 
+["test_felt_browser_relaunch_update_check.py"]
+
 ["test_felt_browser_safe_mode.py"]
 
 ["test_felt_browser_shutdown_crash_exit.py"]

--- a/testing/enterprise/test_felt_browser_relaunch_update_check.py
+++ b/testing/enterprise/test_felt_browser_relaunch_update_check.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+import os
+import sys
+
+sys.path.append(os.path.dirname(__file__))
+
+from felt_relaunch_deadline import BrowserRelaunchDeadlineBase
+
+
+class BrowserRelaunchUpdateCheck(BrowserRelaunchDeadlineBase):
+    EXTRA_PREFS = {
+        "enterprise.felt_tests.should_not_close_window": True,
+    }
+
+    def test_console_deadline_checks_updates_while_browser_is_running(self):
+        self.run_felt_base()
+        self.connect_child_browser()
+        browser_pid = self._child_driver.session_capabilities["moz:processID"]
+        self._driver.set_context("chrome")
+        self._driver.execute_script(
+            """
+            const { Updates } = ChromeUtils.importESModule(
+              "resource://gre/modules/enterprise/Updates.sys.mjs"
+            );
+            window.updateChecks = 0;
+            window.originalPrepareForRestart = Updates.prepareForRestart;
+            Updates.prepareForRestart = async () => { window.updateChecks++; };
+            """
+        )
+        try:
+            self.serve_relaunch({"MinutesRemaining": 45})
+            self._wait.until(
+                lambda _: self._driver.execute_script(
+                    "return window.updateChecks == 1;"
+                ),
+                message="The console deadline did not reach FELT's update handler",
+            )
+            self.serve_relaunch({"MinutesRemaining": 44})
+            assert self._driver.execute_script("return window.updateChecks;") == 1
+            self._child_driver.set_context("chrome")
+            assert (
+                self._child_driver.execute_script("return Services.appinfo.processID;")
+                == browser_pid
+            ), "Firefox stays running during update preparation"
+        finally:
+            self.serve_relaunch(None)
+            self._driver.execute_script(
+                """
+                const { Updates } = ChromeUtils.importESModule(
+                  "resource://gre/modules/enterprise/Updates.sys.mjs"
+                );
+                Updates.prepareForRestart = window.originalPrepareForRestart;
+                """
+            )

--- a/testing/enterprise/test_felt_browser_updates_forward.py
+++ b/testing/enterprise/test_felt_browser_updates_forward.py
@@ -66,6 +66,18 @@ class FeltUpdatesForward(FeltTests):
 
         # Update is ready to run by the updater, perform a FELT restart
         self.install_update_manager_mock("applied")
+        self._driver.set_context("chrome")
+        self._driver.execute_script(
+            """
+            const { UpdateManager } = ChromeUtils.importESModule(
+              "resource://gre/modules/UpdateService.sys.mjs"
+            );
+            UpdateManager.prototype.elevationOptedIn = async () => {
+              throw new Error("Simulated elevationOptedIn failure");
+            };
+            """
+        )
+        self._driver.set_context("content")
         self.run_felt_trigger_update()
         self.run_felt_click_browser_notification()
         # This is waiting on FELT to restart

--- a/toolkit/components/enterprise/modules/RelaunchEnforcer.sys.mjs
+++ b/toolkit/components/enterprise/modules/RelaunchEnforcer.sys.mjs
@@ -18,6 +18,7 @@ ChromeUtils.defineLazyGetter(lazy, "log", () => {
 });
 
 const MS_PER_MINUTE = 60 * 1000;
+const UPDATE_CHECK_INTERVAL_MS = 5 * MS_PER_MINUTE;
 
 // Grace granted to a freshly launched session when the console names none.
 const DEFAULT_GRACE_PERIOD_MINUTES = 10;
@@ -55,7 +56,7 @@ const REPLACEABLE_IDS = [
  */
 export const RelaunchEnforcer = {
   _schedule: null,
-  _updateCheckRequested: false,
+  _lastUpdateCheck: null,
   _restartTask: null,
   _escalationTask: null,
   _countdownTask: null,
@@ -174,12 +175,21 @@ export const RelaunchEnforcer = {
       return;
     }
 
-    if (!this._updateCheckRequested) {
+    const now = Date.now();
+    if (
+      this._lastUpdateCheck === null ||
+      now - this._lastUpdateCheck >= UPDATE_CHECK_INTERVAL_MS ||
+      now < this._lastUpdateCheck
+    ) {
       try {
         this._requestUpdateCheck();
-        this._updateCheckRequested = true;
+        this._lastUpdateCheck = now;
       } catch (e) {
-        lazy.log.error("Failed to request an update check from FELT", e);
+        if (e.result === Cr.NS_ERROR_NOT_CONNECTED) {
+          lazy.log.warn("Cannot request an update check without FELT", e);
+        } else {
+          lazy.log.error("Failed to request an update check from FELT", e);
+        }
       }
     }
     this._schedule = schedule;
@@ -203,7 +213,7 @@ export const RelaunchEnforcer = {
     }
     lazy.log.debug("The console withdrew the restart deadline.");
     this._schedule = null;
-    this._updateCheckRequested = false;
+    this._lastUpdateCheck = null;
     this._disarm();
     this._stopAwaitingSessionRestore();
     this._hideNotification();
@@ -550,7 +560,7 @@ export const RelaunchEnforcer = {
       throw new Error("this method only usable in testing");
     }
     this._schedule = null;
-    this._updateCheckRequested = false;
+    this._lastUpdateCheck = null;
     this._disarm();
     this._stopAwaitingSessionRestore();
     this._hideNotification();

--- a/toolkit/components/enterprise/modules/RelaunchEnforcer.sys.mjs
+++ b/toolkit/components/enterprise/modules/RelaunchEnforcer.sys.mjs
@@ -55,6 +55,7 @@ const REPLACEABLE_IDS = [
  */
 export const RelaunchEnforcer = {
   _schedule: null,
+  _updateCheckRequested: false,
   _restartTask: null,
   _escalationTask: null,
   _countdownTask: null,
@@ -173,12 +174,24 @@ export const RelaunchEnforcer = {
       return;
     }
 
+    if (!this._updateCheckRequested) {
+      try {
+        this._requestUpdateCheck();
+        this._updateCheckRequested = true;
+      } catch (e) {
+        lazy.log.error("Failed to request an update check from FELT", e);
+      }
+    }
     this._schedule = schedule;
     this._arm();
     if (this._restarting) {
       return;
     }
     this._refreshNotification();
+  },
+
+  _requestUpdateCheck() {
+    Services.felt.requestUpdateCheck();
   },
 
   /**
@@ -190,6 +203,7 @@ export const RelaunchEnforcer = {
     }
     lazy.log.debug("The console withdrew the restart deadline.");
     this._schedule = null;
+    this._updateCheckRequested = false;
     this._disarm();
     this._stopAwaitingSessionRestore();
     this._hideNotification();
@@ -536,6 +550,7 @@ export const RelaunchEnforcer = {
       throw new Error("this method only usable in testing");
     }
     this._schedule = null;
+    this._updateCheckRequested = false;
     this._disarm();
     this._stopAwaitingSessionRestore();
     this._hideNotification();

--- a/toolkit/components/enterprise/modules/RelaunchEnforcer.sys.mjs
+++ b/toolkit/components/enterprise/modules/RelaunchEnforcer.sys.mjs
@@ -201,7 +201,9 @@ export const RelaunchEnforcer = {
   },
 
   _requestUpdateCheck() {
-    Services.felt.requestUpdateCheck();
+    if (Services.felt.isFeltBrowser()) {
+      Services.felt.requestUpdateCheck();
+    }
   },
 
   /**

--- a/toolkit/components/enterprise/modules/Updates.sys.mjs
+++ b/toolkit/components/enterprise/modules/Updates.sys.mjs
@@ -25,10 +25,20 @@ const FELT_UPDATE_APPLY_PERCENT_STAGING_END = 100;
 
 export const Updates = {
   _restartUpdateCheck: null,
+  _updateTask: Promise.resolve(),
+
+  _queueUpdateTask(task) {
+    // AppUpdater.stop() aborts all updater promises in this process.
+    const result = this._updateTask.then(task);
+    this._updateTask = result.catch(() => {});
+    return result;
+  },
 
   prepareForRestart() {
     if (!this._restartUpdateCheck) {
-      this._restartUpdateCheck = this._prepareForRestart().finally(() => {
+      this._restartUpdateCheck = this._queueUpdateTask(() =>
+        this._prepareForRestart()
+      ).finally(() => {
         this._restartUpdateCheck = null;
       });
     }
@@ -41,8 +51,6 @@ export const Updates = {
       return;
     }
 
-    // AppUpdater.stop() aborts every AppUpdater in this process. The startup
-    // check finishes before login can launch the browser that requests this.
     const updater = new lazy.AppUpdater();
     const onStatus = status => {
       lazy.log.debug(`Preparing an update before restart: ${status}`);
@@ -62,7 +70,14 @@ export const Updates = {
     }
   },
 
-  async init(doc) {
+  init(doc) {
+    return this._queueUpdateTask(() => this._init(doc));
+  },
+
+  async _init(doc) {
+    if (Services.startup.shuttingDown) {
+      return;
+    }
     // Make sure that we always refer to the correct document, so we can show
     // back the login UI in any circumstance
     this._document = doc;
@@ -110,9 +125,9 @@ export const Updates = {
       });
     }
 
-    this.forceUpdateCheck();
-
+    const check = this.forceUpdateCheck();
     this._initialized = true;
+    await check;
   },
 
   uninit() {
@@ -210,7 +225,7 @@ export const Updates = {
     Services.obs.addObserver(this, "update-error");
   },
 
-  forceUpdateCheck() {
+  async forceUpdateCheck() {
     if (this._canDoUpdateChecking !== true) {
       lazy.log.warn(
         `FeltUpdates: forceUpdateCheck(): skip because previous updates failures`
@@ -219,7 +234,7 @@ export const Updates = {
       return;
     }
 
-    this._appUpdater
+    await this._appUpdater
       .check()
       .catch(err => {
         if (this._suspended) {

--- a/toolkit/components/enterprise/modules/Updates.sys.mjs
+++ b/toolkit/components/enterprise/modules/Updates.sys.mjs
@@ -24,6 +24,42 @@ const FELT_UPDATE_APPLY_PERCENT_DOWNLOAD_END = 90;
 const FELT_UPDATE_APPLY_PERCENT_STAGING_END = 100;
 
 export const Updates = {
+  _restartUpdateCheck: null,
+
+  prepareForRestart() {
+    if (!this._restartUpdateCheck) {
+      this._restartUpdateCheck = this._prepareForRestart().finally(() => {
+        this._restartUpdateCheck = null;
+      });
+    }
+    return this._restartUpdateCheck;
+  },
+
+  async _prepareForRestart() {
+    await this.updateCheckingAllowed();
+    if (!this._canDoUpdateChecking || Services.startup.shuttingDown) {
+      return;
+    }
+
+    const updater = new lazy.AppUpdater();
+    const onStatus = status => {
+      lazy.log.debug(`Preparing an update before restart: ${status}`);
+      if (status === lazy.AppUpdater.STATUS.DOWNLOAD_AND_INSTALL) {
+        updater.allowUpdateDownload();
+      }
+    };
+    const onShutdown = () => updater.stop();
+    updater.addListener(onStatus);
+    Services.obs.addObserver(onShutdown, "quit-application");
+    try {
+      await updater.check();
+    } finally {
+      Services.obs.removeObserver(onShutdown, "quit-application");
+      updater.removeListener(onStatus);
+      updater.stop();
+    }
+  },
+
   async init(doc) {
     // Make sure that we always refer to the correct document, so we can show
     // back the login UI in any circumstance

--- a/toolkit/components/enterprise/modules/Updates.sys.mjs
+++ b/toolkit/components/enterprise/modules/Updates.sys.mjs
@@ -25,6 +25,8 @@ const FELT_UPDATE_APPLY_PERCENT_STAGING_END = 100;
 
 export const Updates = {
   _restartUpdateCheck: null,
+  _restartUpdater: null,
+  _nextRestartUpdateCheck: 0,
   _updateTask: Promise.resolve(),
 
   _queueUpdateTask(task) {
@@ -46,14 +48,27 @@ export const Updates = {
   },
 
   async _prepareForRestart() {
+    if (this._suspended || Date.now() < this._nextRestartUpdateCheck) {
+      return;
+    }
     await this.updateCheckingAllowed();
-    if (!this._canDoUpdateChecking || Services.startup.shuttingDown) {
+    if (
+      !this._canDoUpdateChecking ||
+      this._suspended ||
+      Services.startup.shuttingDown
+    ) {
       return;
     }
 
     const updater = new lazy.AppUpdater();
+    this._restartUpdater = updater;
     const onStatus = status => {
       lazy.log.debug(`Preparing an update before restart: ${status}`);
+      if (status === lazy.AppUpdater.STATUS.NO_UPDATES_FOUND) {
+        this._nextRestartUpdateCheck =
+          Date.now() +
+          Services.prefs.getIntPref("app.update.interval", 21600) * 1000;
+      }
       if (status === lazy.AppUpdater.STATUS.DOWNLOAD_AND_INSTALL) {
         updater.allowUpdateDownload();
       }
@@ -67,14 +82,11 @@ export const Updates = {
       Services.obs.removeObserver(onShutdown, "quit-application");
       updater.removeListener(onStatus);
       updater.stop();
+      this._restartUpdater = null;
     }
   },
 
-  init(doc) {
-    return this._queueUpdateTask(() => this._init(doc));
-  },
-
-  async _init(doc) {
+  async init(doc) {
     if (Services.startup.shuttingDown) {
       return;
     }
@@ -87,18 +99,23 @@ export const Updates = {
     this._suspended = false;
 
     this.maybeShowUpdateSuccess();
-    // Check this early to avoid re-downloading updates when it would fail
-    await this.updateCheckingAllowed();
-
-    // A captive portal suspended us during the await above: show the login and
-    // bail, so we don't paint the update UI over the banner or check behind it.
-    if (this._suspended) {
+    if (this._initialized) {
       this.displayLoginState();
       return;
     }
 
-    if (this._initialized) {
-      this.displayLoginState();
+    void this._queueUpdateTask(() => this._initUpdateCheck()).catch(err => {
+      lazy.log.error("FeltUpdates: initialization failed", err);
+    });
+  },
+
+  async _initUpdateCheck() {
+    if (this._suspended || this._initialized || Services.startup.shuttingDown) {
+      return;
+    }
+    // Check this early to avoid re-downloading updates when it would fail.
+    await this.updateCheckingAllowed();
+    if (this._suspended || Services.startup.shuttingDown) {
       return;
     }
 
@@ -146,6 +163,7 @@ export const Updates = {
     }
     this._suspended = true;
     this.cancelDelayedUpdateCheckUI();
+    this._restartUpdater?.stop();
     if (this._appUpdater) {
       this._appUpdater.removeListener(this._updaterCallback);
       // Abort the in-flight check so its network request doesn't linger behind
@@ -543,6 +561,9 @@ export const Updates = {
         break;
       // https://searchfox.org/enterprise-main/rev/a038f49228d707c6675ef20ce640034a64307d2e/toolkit/mozapps/update/UpdateListener.sys.mjs#366
       case "update-error":
+        if (this._suspended) {
+          break;
+        }
         switch (state) {
           case "elevation-attempt-failed":
             this.displayLoginStateWithUpdateWarning(

--- a/toolkit/components/enterprise/modules/Updates.sys.mjs
+++ b/toolkit/components/enterprise/modules/Updates.sys.mjs
@@ -41,6 +41,8 @@ export const Updates = {
       return;
     }
 
+    // AppUpdater.stop() aborts every AppUpdater in this process. The startup
+    // check finishes before login can launch the browser that requests this.
     const updater = new lazy.AppUpdater();
     const onStatus = status => {
       lazy.log.debug(`Preparing an update before restart: ${status}`);

--- a/toolkit/components/enterprise/tests/browser/browser_relaunch_enforcer.js
+++ b/toolkit/components/enterprise/tests/browser/browser_relaunch_enforcer.js
@@ -40,6 +40,11 @@ async function reset(win) {
 }
 
 add_setup(async function () {
+  const requestUpdateCheck = RelaunchEnforcer._requestUpdateCheck;
+  RelaunchEnforcer._requestUpdateCheck = () => {};
+  registerCleanupFunction(() => {
+    RelaunchEnforcer._requestUpdateCheck = requestUpdateCheck;
+  });
   registerCleanupFunction(() =>
     reset(Services.wm.getMostRecentBrowserWindow())
   );

--- a/toolkit/components/enterprise/tests/xpcshell/test_relaunch_enforcer.js
+++ b/toolkit/components/enterprise/tests/xpcshell/test_relaunch_enforcer.js
@@ -257,3 +257,11 @@ add_task(function test_requests_updates_when_the_console_sets_a_deadline() {
     sandbox.restore();
   }
 });
+
+add_task(function test_update_request_without_felt_is_a_noop() {
+  Assert.ok(
+    !Services.felt.isFeltBrowser(),
+    "This test runs without a FELT browser"
+  );
+  RelaunchEnforcer._requestUpdateCheck();
+});

--- a/toolkit/components/enterprise/tests/xpcshell/test_relaunch_enforcer.js
+++ b/toolkit/components/enterprise/tests/xpcshell/test_relaunch_enforcer.js
@@ -211,3 +211,42 @@ add_task(function test_a_deadline_before_session_restore_defers_the_restart() {
     "One withdrawal drops the wait"
   );
 });
+
+add_task(function test_requests_updates_when_the_console_sets_a_deadline() {
+  const { sinon } = ChromeUtils.importESModule(
+    "resource://testing-common/Sinon.sys.mjs"
+  );
+  const sandbox = sinon.createSandbox();
+  try {
+    sandbox.stub(RelaunchEnforcer, "_arm");
+    sandbox.stub(RelaunchEnforcer, "_refreshNotification");
+    sandbox.stub(RelaunchEnforcer, "_hideNotification");
+    const request = sandbox.stub(RelaunchEnforcer, "_requestUpdateCheck");
+    RelaunchEnforcer.onConsolePoll({ MinutesRemaining: "invalid" });
+    Assert.ok(request.notCalled, "Malformed directives do not request updates");
+    request.onFirstCall().throws(new Error("IPC not connected"));
+    RelaunchEnforcer.onConsolePoll({ MinutesRemaining: 45 });
+    RelaunchEnforcer.onConsolePoll({ MinutesRemaining: 44 });
+    Assert.equal(
+      request.callCount,
+      2,
+      "Failed IPC is retried on the next poll"
+    );
+    RelaunchEnforcer.onConsolePoll({ MinutesRemaining: 43 });
+    Assert.equal(
+      request.callCount,
+      2,
+      "Repeated deadlines do not repeat the check"
+    );
+    RelaunchEnforcer.onConsolePoll(null);
+    RelaunchEnforcer.onConsolePoll({ MinutesRemaining: 30 });
+    Assert.equal(
+      request.callCount,
+      3,
+      "A new directive requests another check"
+    );
+  } finally {
+    RelaunchEnforcer.testingOnly_reset();
+    sandbox.restore();
+  }
+});

--- a/toolkit/components/enterprise/tests/xpcshell/test_relaunch_enforcer.js
+++ b/toolkit/components/enterprise/tests/xpcshell/test_relaunch_enforcer.js
@@ -224,7 +224,11 @@ add_task(function test_requests_updates_when_the_console_sets_a_deadline() {
     const request = sandbox.stub(RelaunchEnforcer, "_requestUpdateCheck");
     RelaunchEnforcer.onConsolePoll({ MinutesRemaining: "invalid" });
     Assert.ok(request.notCalled, "Malformed directives do not request updates");
-    request.onFirstCall().throws(new Error("IPC not connected"));
+    request
+      .onFirstCall()
+      .throws(
+        Components.Exception("IPC not connected", Cr.NS_ERROR_NOT_CONNECTED)
+      );
     RelaunchEnforcer.onConsolePoll({ MinutesRemaining: 45 });
     RelaunchEnforcer.onConsolePoll({ MinutesRemaining: 44 });
     Assert.equal(

--- a/toolkit/components/enterprise/tests/xpcshell/test_relaunch_enforcer.js
+++ b/toolkit/components/enterprise/tests/xpcshell/test_relaunch_enforcer.js
@@ -238,11 +238,18 @@ add_task(function test_requests_updates_when_the_console_sets_a_deadline() {
       2,
       "Repeated deadlines do not repeat the check"
     );
+    RelaunchEnforcer._lastUpdateCheck -= 5 * MINUTE;
+    RelaunchEnforcer.onConsolePoll({ MinutesRemaining: 38 });
+    Assert.equal(
+      request.callCount,
+      3,
+      "A continuing directive retries every five minutes"
+    );
     RelaunchEnforcer.onConsolePoll(null);
     RelaunchEnforcer.onConsolePoll({ MinutesRemaining: 30 });
     Assert.equal(
       request.callCount,
-      3,
+      4,
       "A new directive requests another check"
     );
   } finally {

--- a/toolkit/components/enterprise/tests/xpcshell/test_restart_update_check.js
+++ b/toolkit/components/enterprise/tests/xpcshell/test_restart_update_check.js
@@ -1,0 +1,156 @@
+/* Any copyright is dedicated to the Public Domain.
+ * http://creativecommons.org/publicdomain/zero/1.0/ */
+
+const { Updates } = ChromeUtils.importESModule(
+  "resource://gre/modules/enterprise/Updates.sys.mjs"
+);
+const { AppUpdater } = ChromeUtils.importESModule(
+  "resource://gre/modules/AppUpdater.sys.mjs"
+);
+const { sinon } = ChromeUtils.importESModule(
+  "resource://testing-common/Sinon.sys.mjs"
+);
+const { TestUtils } = ChromeUtils.importESModule(
+  "resource://testing-common/TestUtils.sys.mjs"
+);
+
+function mockUpdater() {
+  const sandbox = sinon.createSandbox();
+  sandbox.stub(Updates, "updateCheckingAllowed").callsFake(async () => {
+    Updates._canDoUpdateChecking = true;
+  });
+  const check = sandbox.stub(AppUpdater.prototype, "check");
+  const stop = sandbox.stub(AppUpdater.prototype, "stop");
+  const addListener = sandbox.spy(AppUpdater.prototype, "addListener");
+  const removeListener = sandbox.spy(AppUpdater.prototype, "removeListener");
+  return { sandbox, check, stop, addListener, removeListener };
+}
+
+add_task(async function test_reuses_an_in_progress_check() {
+  const mock = mockUpdater();
+  try {
+    let finish;
+    mock.check.callsFake(() => new Promise(resolve => (finish = resolve)));
+    const result = Updates.prepareForRestart();
+    await TestUtils.waitForCondition(() => mock.check.calledOnce);
+    Assert.equal(
+      Updates.prepareForRestart(),
+      result,
+      "Concurrent requests share the update"
+    );
+    Assert.ok(mock.check.calledOnce, "Only one update check runs");
+    finish();
+    await result;
+    Assert.ok(mock.stop.calledOnce, "Updater listeners are disconnected");
+    Assert.equal(
+      mock.addListener.firstCall.args[0],
+      mock.removeListener.firstCall.args[0]
+    );
+    mock.check.resolves();
+    await Updates.prepareForRestart();
+    Assert.equal(
+      mock.check.callCount,
+      2,
+      "A later deadline can request a new check"
+    );
+  } finally {
+    mock.sandbox.restore();
+  }
+});
+
+add_task(async function test_failure_allows_a_later_check() {
+  const mock = mockUpdater();
+  try {
+    mock.check.rejects(new Error("Update service unavailable"));
+    await Assert.rejects(
+      Updates.prepareForRestart(),
+      /Update service unavailable/
+    );
+    Assert.equal(Updates._restartUpdateCheck, null);
+    mock.check.resolves();
+    await Updates.prepareForRestart();
+    Assert.equal(mock.check.callCount, 2);
+  } finally {
+    mock.sandbox.restore();
+  }
+});
+
+add_task(async function test_download_permission_matches_startup() {
+  const mock = mockUpdater();
+  try {
+    const allow = mock.sandbox.stub(
+      AppUpdater.prototype,
+      "allowUpdateDownload"
+    );
+    mock.check.callsFake(async () => {
+      mock.addListener.lastCall.args[0](AppUpdater.STATUS.DOWNLOAD_AND_INSTALL);
+    });
+    await Updates.prepareForRestart();
+    Assert.ok(
+      allow.calledOnce,
+      "FELT permits the update download as at startup"
+    );
+  } finally {
+    mock.sandbox.restore();
+  }
+});
+
+add_task(async function test_repeated_install_failures_skip_check() {
+  const mock = mockUpdater();
+  try {
+    Updates.updateCheckingAllowed.callsFake(async () => {
+      Updates._canDoUpdateChecking = false;
+    });
+    await Updates.prepareForRestart();
+    Assert.ok(
+      mock.check.notCalled,
+      "No update check after repeated install failures"
+    );
+  } finally {
+    mock.sandbox.restore();
+  }
+});
+
+add_task(async function test_shutdown_stops_the_check() {
+  const mock = mockUpdater();
+  try {
+    const previousObservers = Array.from(
+      Services.obs.enumerateObservers("quit-application")
+    );
+    let finish;
+    mock.check.callsFake(() => new Promise(resolve => (finish = resolve)));
+    mock.stop.callsFake(() => finish());
+    const result = Updates.prepareForRestart();
+    await TestUtils.waitForCondition(() => mock.check.calledOnce);
+    const shutdownObserver = Array.from(
+      Services.obs.enumerateObservers("quit-application")
+    ).find(observer => !previousObservers.includes(observer));
+    shutdownObserver.observe(null, "quit-application", null);
+    await result;
+    Assert.equal(
+      Updates._restartUpdateCheck,
+      null,
+      "Shutdown clears the pending check"
+    );
+    Assert.ok(mock.stop.called, "The updater is stopped during shutdown");
+  } finally {
+    mock.sandbox.restore();
+  }
+});
+
+add_task(async function test_ready_update_does_not_restart_felt() {
+  const mock = mockUpdater();
+  try {
+    const restart = mock.sandbox.stub(Updates, "automaticRestart");
+    mock.check.callsFake(async () => {
+      mock.addListener.lastCall.args[0](AppUpdater.STATUS.READY_FOR_RESTART);
+    });
+    await Updates.prepareForRestart();
+    Assert.ok(
+      restart.notCalled,
+      "Preparing the update does not restart the running session"
+    );
+  } finally {
+    mock.sandbox.restore();
+  }
+});

--- a/toolkit/components/enterprise/tests/xpcshell/test_restart_update_check.js
+++ b/toolkit/components/enterprise/tests/xpcshell/test_restart_update_check.js
@@ -154,3 +154,52 @@ add_task(async function test_ready_update_does_not_restart_felt() {
     mock.sandbox.restore();
   }
 });
+
+add_task(async function test_preparation_waits_for_startup_history_and_check() {
+  const mock = mockUpdater();
+  try {
+    mock.sandbox.stub(Updates, "maybeShowUpdateSuccess");
+    mock.sandbox.stub(Updates, "displayUpdateState");
+    let finishHistory;
+    Updates.updateCheckingAllowed
+      .onFirstCall()
+      .callsFake(() => new Promise(resolve => (finishHistory = resolve)));
+    let finishStartup;
+    mock.check
+      .onFirstCall()
+      .callsFake(() => new Promise(resolve => (finishStartup = resolve)));
+    mock.check.onSecondCall().resolves();
+
+    const startup = Updates.init({});
+    await TestUtils.waitForCondition(() => !!finishHistory);
+    const preparation = Updates.prepareForRestart();
+    await Promise.resolve();
+    Assert.ok(mock.check.notCalled, "Preparation waits for startup history");
+    Assert.ok(
+      mock.stop.notCalled,
+      "Startup is not aborted during history loading"
+    );
+
+    Updates._canDoUpdateChecking = true;
+    finishHistory();
+    await TestUtils.waitForCondition(() => !!finishStartup);
+    Assert.ok(mock.check.calledOnce, "Only the startup check is running");
+    Assert.ok(
+      mock.stop.notCalled,
+      "Preparation does not abort the startup check"
+    );
+
+    finishStartup();
+    await startup;
+    await preparation;
+    Assert.equal(
+      mock.check.callCount,
+      2,
+      "Preparation runs after startup finishes"
+    );
+    Assert.ok(mock.stop.calledOnce, "Only preparation stops its updater");
+  } finally {
+    Updates.uninit();
+    mock.sandbox.restore();
+  }
+});

--- a/toolkit/components/enterprise/tests/xpcshell/test_restart_update_check.js
+++ b/toolkit/components/enterprise/tests/xpcshell/test_restart_update_check.js
@@ -16,6 +16,8 @@ const { TestUtils } = ChromeUtils.importESModule(
 
 function mockUpdater() {
   const sandbox = sinon.createSandbox();
+  sandbox.stub(Updates, "_nextRestartUpdateCheck").value(0);
+  Updates._suspended = false;
   sandbox.stub(Updates, "updateCheckingAllowed").callsFake(async () => {
     Updates._canDoUpdateChecking = true;
   });
@@ -200,6 +202,125 @@ add_task(async function test_preparation_waits_for_startup_history_and_check() {
     Assert.ok(mock.stop.calledOnce, "Only preparation stops its updater");
   } finally {
     Updates.uninit();
+    mock.sandbox.restore();
+  }
+});
+
+add_task(async function test_reopened_window_is_bound_during_preparation() {
+  const mock = mockUpdater();
+  try {
+    mock.sandbox.stub(Updates, "_initialized").value(true);
+    const success = mock.sandbox.stub(Updates, "maybeShowUpdateSuccess");
+    const login = mock.sandbox.stub(Updates, "displayLoginState");
+    let finish;
+    mock.check.callsFake(() => new Promise(resolve => (finish = resolve)));
+    const preparation = Updates.prepareForRestart();
+    await TestUtils.waitForCondition(() => !!finish);
+    const doc = {};
+    const init = Updates.init(doc);
+    Assert.equal(
+      Updates._document,
+      doc,
+      "Reopened document is bound synchronously"
+    );
+    Assert.ok(success.calledOnce, "Update success is shown immediately");
+    Assert.ok(login.calledOnce, "Login is refreshed immediately");
+    await init;
+    Assert.ok(mock.stop.notCalled, "Rebinding does not cancel preparation");
+    finish();
+    await preparation;
+  } finally {
+    Updates._document = undefined;
+    mock.sandbox.restore();
+  }
+});
+
+add_task(async function test_portal_suspends_before_queued_startup() {
+  const mock = mockUpdater();
+  try {
+    mock.sandbox.stub(Updates, "maybeShowUpdateSuccess");
+    mock.sandbox.stub(Updates, "displayLoginState");
+    const init = Updates.init({});
+    Updates.suspend();
+    await init;
+    await Updates._updateTask;
+    Assert.ok(
+      Updates._suspended,
+      "Queued startup preserves the portal suspension"
+    );
+    Assert.ok(mock.check.notCalled, "No update check behind the portal");
+    await Updates.prepareForRestart();
+    Assert.ok(
+      mock.check.notCalled,
+      "Restart preparation also honors suspension"
+    );
+  } finally {
+    Updates.uninit();
+    mock.sandbox.restore();
+  }
+});
+
+add_task(async function test_portal_stops_restart_preparation() {
+  const mock = mockUpdater();
+  try {
+    mock.sandbox.stub(Updates, "displayLoginState");
+    let finish;
+    mock.check.callsFake(() => new Promise(resolve => (finish = resolve)));
+    mock.stop.callsFake(() => finish());
+    const preparation = Updates.prepareForRestart();
+    await TestUtils.waitForCondition(() => !!finish);
+    const updater = Updates._restartUpdater;
+    const warning = mock.sandbox.stub(
+      Updates,
+      "displayLoginStateWithUpdateWarning"
+    );
+    Updates.suspend();
+    Updates.observe(null, "update-error", "download-attempt-failed");
+    Assert.ok(
+      warning.notCalled,
+      "Update errors do not paint behind the portal"
+    );
+    Assert.ok(
+      mock.stop.calledOn(updater),
+      "The active preparation updater is stopped"
+    );
+    await preparation;
+    Assert.equal(
+      Updates._restartUpdater,
+      null,
+      "The completed updater is released"
+    );
+  } finally {
+    Updates.uninit();
+    mock.sandbox.restore();
+  }
+});
+
+add_task(async function test_no_updates_uses_the_normal_check_interval() {
+  const mock = mockUpdater();
+  try {
+    mock.check.callsFake(async () => {
+      mock.addListener.lastCall.args[0](AppUpdater.STATUS.NO_UPDATES_FOUND);
+    });
+    await Updates.prepareForRestart();
+    Updates._nextRestartUpdateCheck -= 5 * 60 * 1000;
+    await Updates.prepareForRestart();
+    Assert.ok(
+      mock.check.calledOnce,
+      "A successful empty check is not repeated after five minutes"
+    );
+    Assert.ok(
+      Updates.updateCheckingAllowed.calledOnce,
+      "The cooldown also skips update history"
+    );
+    Updates._nextRestartUpdateCheck = Date.now() - 1;
+    await Updates.prepareForRestart();
+    Assert.equal(
+      mock.check.callCount,
+      2,
+      "Checking resumes at the normal update interval"
+    );
+  } finally {
     mock.sandbox.restore();
   }
 });

--- a/toolkit/components/enterprise/tests/xpcshell/xpcshell.toml
+++ b/toolkit/components/enterprise/tests/xpcshell/xpcshell.toml
@@ -10,3 +10,5 @@ skip-if = [
 ["test_felt_storage_console_address.js"]
 
 ["test_relaunch_enforcer.js"]
+
+["test_restart_update_check.js"]

--- a/toolkit/components/felt/content/FeltProcessParent.sys.mjs
+++ b/toolkit/components/felt/content/FeltProcessParent.sys.mjs
@@ -6,6 +6,7 @@ const lazy = {};
 
 ChromeUtils.defineESModuleGetters(lazy, {
   Subprocess: "resource://gre/modules/Subprocess.sys.mjs",
+  Updates: "resource://gre/modules/enterprise/Updates.sys.mjs",
   ClientSession: "resource://gre/modules/enterprise/DevicePosture.sys.mjs",
   ConsoleClient: "resource://gre/modules/enterprise/ConsoleClient.sys.mjs",
   DevicePosture: "resource://gre/modules/enterprise/DevicePosture.sys.mjs",
@@ -124,6 +125,7 @@ function notifyFirefoxReady() {
 const kBrowserObserverTopics = [
   "felt-firefox-exiting",
   "felt-firefox-restarting",
+  "felt-firefox-check-for-updates",
   "felt-ready",
   "felt-firefox-logout",
   "felt-firefox-tokens",
@@ -179,7 +181,17 @@ export class FeltProcessParent extends JSProcessActorParent {
             break;
           }
 
+          case "felt-firefox-check-for-updates": {
+            lazy.Updates.prepareForRestart().catch(err => {
+              lazy.log.error("Failed to prepare an update before restart", err);
+            });
+            break;
+          }
+
           case "felt-firefox-restarting": {
+            if (gFeltProcessParentInstance?.restartReported) {
+              break;
+            }
             if (gFeltProcessParentInstance) {
               gFeltProcessParentInstance.restartReported = true;
               gFeltProcessParentInstance.firefox = null;
@@ -191,101 +203,72 @@ export class FeltProcessParent extends JSProcessActorParent {
               false
             );
 
-            const UM = Cc["@mozilla.org/updates/update-manager;1"].getService(
-              Ci.nsIUpdateManager
+            if (!proc) {
+              lazy.log.debug("ParentProcess: No proc to wait for!");
+              break;
+            }
+
+            // exitPromise never rejects and has no timeout. kill after a timeout, set above the
+            // toolkit.asyncshutdown.crash_timeout, to avoid hangs if the child is truly unresponsive.
+            const restartShutdownTimeout = Services.prefs.getIntPref(
+              "enterprise.browser.restart_shutdown_timeout",
+              90000
             );
-            UM.getReadyUpdate()
-              .then(readyUpdate => {
-                let pendingUpdate = false;
-                if (readyUpdate) {
-                  // Updates states when restarting will finish the update
-                  const readyStates = [
-                    "pending",
-                    "pending-service",
-                    "pending-elevate",
-                    "applied",
-                    "applied-service",
-                  ];
-                  pendingUpdate = readyStates.includes(readyUpdate.state);
-                }
-                return pendingUpdate;
-              })
-              .catch(err => {
-                lazy.log.debug(`ParentProcess: getReadyUpdate failed: ${err}`);
-              })
-              .then(pendingUpdate => {
-                lazy.log.debug(
-                  `ParentProcess: restart notification, restartDisabled=${restartDisabled}`
-                );
-                if (proc) {
-                  lazy.log.debug(
-                    `ParentProcess: Waiting for Firefox PID=${proc.pid} to exit for restart`
-                  );
-
-                  // exitPromise never rejects and has no timeout. kill after a timeout, set above the
-                  // toolkit.asyncshutdown.crash_timeout, to avoid hangs if the child is truly unresponsive.
-                  const restartShutdownTimeout = Services.prefs.getIntPref(
-                    "enterprise.browser.restart_shutdown_timeout",
-                    90000
-                  );
-                  const forceKillTimer = lazy.setTimeout(() => {
-                    if (proc.exitCode === null) {
-                      lazy.log.error(
-                        `ParentProcess: Firefox PID=${proc.pid} did not exit within ${restartShutdownTimeout}ms; killing for restart`
-                      );
-                      proc.kill();
-                    }
-                  }, restartShutdownTimeout);
-
-                  proc.exitPromise
-                    .then(() => {
-                      lazy.clearTimeout(forceKillTimer);
-                      lazy.log.debug(
-                        `ParentProcess: Firefox exited for restart, restartDisabled=${restartDisabled}`
-                      );
-
-                      if (!restartDisabled && !pendingUpdate) {
-                        lazy.log.debug(`ParentProcess: Starting new Firefox`);
-                        gFeltProcessParentInstance.startFirefox(
-                          PROCESS_START_REASON.RESTART
-                        );
-                      } else if (pendingUpdate) {
-                        lazy.log.debug(
-                          `ParentProcess: Restart requested and pending update, restarting FELT UI`
-                        );
-                        Services.cpmm.sendAsyncMessage(
-                          "FeltParent:FirefoxRestartUpdateExit",
-                          {}
-                        );
-                      } else {
-                        lazy.log.debug(
-                          `ParentProcess: Restart disabled, sending normal exit to restore FELT UI`
-                        );
-                        Services.cpmm.sendAsyncMessage(
-                          "FeltParent:FirefoxNormalExit",
-                          {}
-                        );
-                      }
-                    })
-                    .catch(err => {
-                      lazy.clearTimeout(forceKillTimer);
-                      lazy.log.error(
-                        `ParentProcess: Restart continuation failed after exit: ${err}; sending normal exit`
-                      );
-                      Services.cpmm.sendAsyncMessage(
-                        "FeltParent:FirefoxNormalExit",
-                        {}
-                      );
-                    });
-                } else {
-                  lazy.log.debug(`ParentProcess: No proc to wait for!`);
-                }
-              })
-              .catch(err => {
+            const forceKillTimer = lazy.setTimeout(() => {
+              if (proc.exitCode === null) {
                 lazy.log.error(
-                  `ParentProcess: Restart failed: ${err}; killing proc and quitting via normal exit`
+                  `ParentProcess: Firefox PID=${proc.pid} did not exit within ${restartShutdownTimeout}ms; killing for restart`
                 );
-                proc?.kill();
+                proc.kill();
+              }
+            }, restartShutdownTimeout);
+
+            proc.exitPromise
+              .then(async () => {
+                lazy.clearTimeout(forceKillTimer);
+                if (Services.startup.shuttingDown) {
+                  return;
+                }
+                const UM = Cc[
+                  "@mozilla.org/updates/update-manager;1"
+                ].getService(Ci.nsIUpdateManager);
+                const readyUpdate = await UM.getReadyUpdate().catch(err => {
+                  lazy.log.error("ParentProcess: getReadyUpdate failed", err);
+                  return null;
+                });
+                const pendingUpdate = [
+                  "pending",
+                  "pending-service",
+                  "pending-elevate",
+                  "applied",
+                  "applied-service",
+                ].includes(readyUpdate?.state);
+                if (Services.startup.shuttingDown) {
+                  return;
+                }
+
+                if (pendingUpdate) {
+                  await UM.elevationOptedIn();
+                  Services.cpmm.sendAsyncMessage(
+                    "FeltParent:FirefoxRestartUpdateExit",
+                    {}
+                  );
+                } else if (!restartDisabled) {
+                  await gFeltProcessParentInstance.startFirefox(
+                    PROCESS_START_REASON.RESTART
+                  );
+                } else {
+                  Services.cpmm.sendAsyncMessage(
+                    "FeltParent:FirefoxNormalExit",
+                    {}
+                  );
+                }
+              })
+              .catch(err => {
+                lazy.clearTimeout(forceKillTimer);
+                lazy.log.error(
+                  `ParentProcess: Restart continuation failed after exit: ${err}; sending normal exit`
+                );
                 Services.cpmm.sendAsyncMessage(
                   "FeltParent:FirefoxNormalExit",
                   {}

--- a/toolkit/components/felt/content/FeltProcessParent.sys.mjs
+++ b/toolkit/components/felt/content/FeltProcessParent.sys.mjs
@@ -189,9 +189,6 @@ export class FeltProcessParent extends JSProcessActorParent {
           }
 
           case "felt-firefox-restarting": {
-            if (gFeltProcessParentInstance?.restartReported) {
-              break;
-            }
             if (gFeltProcessParentInstance) {
               gFeltProcessParentInstance.restartReported = true;
               gFeltProcessParentInstance.firefox = null;
@@ -203,11 +200,17 @@ export class FeltProcessParent extends JSProcessActorParent {
               false
             );
 
+            lazy.log.debug(
+              `ParentProcess: restart notification, restartDisabled=${restartDisabled}`
+            );
             if (!proc) {
               lazy.log.debug("ParentProcess: No proc to wait for!");
               break;
             }
 
+            lazy.log.debug(
+              `ParentProcess: Waiting for Firefox PID=${proc.pid} to exit for restart`
+            );
             // exitPromise never rejects and has no timeout. kill after a timeout, set above the
             // toolkit.asyncshutdown.crash_timeout, to avoid hangs if the child is truly unresponsive.
             const restartShutdownTimeout = Services.prefs.getIntPref(
@@ -247,17 +250,32 @@ export class FeltProcessParent extends JSProcessActorParent {
                   return;
                 }
 
+                lazy.log.debug(
+                  `ParentProcess: Firefox exited for restart, restartDisabled=${restartDisabled}, updateState=${readyUpdate?.state}`
+                );
                 if (pendingUpdate) {
-                  await UM.elevationOptedIn();
+                  await UM.elevationOptedIn().catch(err => {
+                    lazy.log.error(
+                      "ParentProcess: elevationOptedIn failed",
+                      err
+                    );
+                  });
+                  lazy.log.debug(
+                    "ParentProcess: Restart requested and pending update, restarting FELT UI"
+                  );
                   Services.cpmm.sendAsyncMessage(
                     "FeltParent:FirefoxRestartUpdateExit",
                     {}
                   );
                 } else if (!restartDisabled) {
+                  lazy.log.debug("ParentProcess: Starting new Firefox");
                   await gFeltProcessParentInstance.startFirefox(
                     PROCESS_START_REASON.RESTART
                   );
                 } else {
+                  lazy.log.debug(
+                    "ParentProcess: Restart disabled, sending normal exit to restore FELT UI"
+                  );
                   Services.cpmm.sendAsyncMessage(
                     "FeltParent:FirefoxNormalExit",
                     {}

--- a/toolkit/components/felt/rust/nsIFelt.idl
+++ b/toolkit/components/felt/rust/nsIFelt.idl
@@ -65,9 +65,6 @@ interface nsIFelt : nsISupports {
   void refreshTokens();
 
   [must_use]
-  void requestUpdateCheck();
-
-  [must_use]
   ACString getRefreshToken();
 
   [must_use]
@@ -107,4 +104,7 @@ interface nsIFelt : nsISupports {
 
   [must_use]
   void shutdownFirefox();
+
+  [must_use]
+  void requestUpdateCheck();
 };

--- a/toolkit/components/felt/rust/nsIFelt.idl
+++ b/toolkit/components/felt/rust/nsIFelt.idl
@@ -65,6 +65,9 @@ interface nsIFelt : nsISupports {
   void refreshTokens();
 
   [must_use]
+  void requestUpdateCheck();
+
+  [must_use]
   ACString getRefreshToken();
 
   [must_use]

--- a/toolkit/components/felt/rust/src/client.rs
+++ b/toolkit/components/felt/rust/src/client.rs
@@ -87,6 +87,16 @@ impl FeltIpcClient {
         }
     }
 
+    pub fn request_update_check(&self) -> nsresult {
+        match &self.tx {
+            Some(tx) => match tx.send(FeltMessage::CheckForUpdates) {
+                Ok(()) => NS_OK,
+                Err(_) => NS_ERROR_FAILURE,
+            },
+            None => NS_ERROR_FAILURE,
+        }
+    }
+
     pub fn notify_refresh_tokens(&self) {
         trace!("FeltIpcClient::notify_refresh_tokens()");
         let msg = FeltMessage::RefreshTokens;
@@ -475,6 +485,10 @@ impl FeltClientThread {
         trace!("FeltClientThread::notify_signout()");
         let client = self.ipc_client.borrow();
         client.notify_signout();
+    }
+
+    pub fn request_update_check(&self) -> nsresult {
+        self.ipc_client.borrow().request_update_check()
     }
 
     pub fn notify_refresh_tokens(&self) {

--- a/toolkit/components/felt/rust/src/client.rs
+++ b/toolkit/components/felt/rust/src/client.rs
@@ -2,7 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
-use nserror::{nsresult, NS_ERROR_FAILURE, NS_OK};
+use nserror::{
+    nsresult, NS_ERROR_CONNECTION_REFUSED, NS_ERROR_FAILURE, NS_ERROR_NOT_CONNECTED, NS_OK,
+};
 use nsstring::nsString;
 use std::cell::RefCell;
 use std::ffi::{c_char, CStr, CString};
@@ -88,12 +90,16 @@ impl FeltIpcClient {
     }
 
     pub fn request_update_check(&self) -> nsresult {
+        trace!("FeltIpcClient::request_update_check()");
         match &self.tx {
             Some(tx) => match tx.send(FeltMessage::CheckForUpdates) {
                 Ok(()) => NS_OK,
-                Err(_) => NS_ERROR_FAILURE,
+                Err(err) => {
+                    trace!("FeltIpcClient::request_update_check() TX ERROR: {}", err);
+                    NS_ERROR_CONNECTION_REFUSED
+                }
             },
-            None => NS_ERROR_FAILURE,
+            None => NS_ERROR_NOT_CONNECTED,
         }
     }
 
@@ -488,6 +494,7 @@ impl FeltClientThread {
     }
 
     pub fn request_update_check(&self) -> nsresult {
+        trace!("FeltClientThread::request_update_check()");
         self.ipc_client.borrow().request_update_check()
     }
 

--- a/toolkit/components/felt/rust/src/components.rs
+++ b/toolkit/components/felt/rust/src/components.rs
@@ -267,6 +267,7 @@ impl FeltXPCOM {
     }
 
     fn RequestUpdateCheck(&self) -> nserror::nsresult {
+        trace!("FeltXPCOM::RequestUpdateCheck()");
         let guard = crate::FELT_CLIENT.lock().expect("Could not get lock");
         match &*guard {
             Some(client) => client.request_update_check(),

--- a/toolkit/components/felt/rust/src/components.rs
+++ b/toolkit/components/felt/rust/src/components.rs
@@ -266,6 +266,14 @@ impl FeltXPCOM {
         self.send(FeltMessage::PrimarySecret(hex)).to_result()
     }
 
+    fn RequestUpdateCheck(&self) -> nserror::nsresult {
+        let guard = crate::FELT_CLIENT.lock().expect("Could not get lock");
+        match &*guard {
+            Some(client) => client.request_update_check(),
+            None => NS_ERROR_NOT_CONNECTED,
+        }
+    }
+
     fn RefreshTokens(&self) -> nserror::nsresult {
         trace!("FeltXPCOM::RefreshTokens");
         let guard = crate::FELT_CLIENT.lock().expect("Could not get lock");
@@ -458,6 +466,9 @@ impl FeltXPCOM {
                                     "expires_at": expires_at,
                                 }).to_string();
                                 crate::utils::notify_observers_with_payload("felt-firefox-tokens".to_string(), Some(payload));
+                            },
+                            Ok(FeltMessage::CheckForUpdates) => {
+                                crate::utils::notify_observers("felt-firefox-check-for-updates".to_string());
                             },
                             Ok(FeltMessage::RefreshTokens) => {
                                 trace!("FeltServerThread::felt_server::ipc_loop(): Browser is requesting token refresh");

--- a/toolkit/components/felt/rust/src/message.rs
+++ b/toolkit/components/felt/rust/src/message.rs
@@ -72,6 +72,7 @@ pub enum FeltMessage {
     Exiting,
     UpdateReady,
     Shutdown,
+    CheckForUpdates,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -80,4 +81,4 @@ pub enum FocusHint {
     Timestamp(u32),
 }
 
-pub const FELT_IPC_VERSION: u32 = 12;
+pub const FELT_IPC_VERSION: u32 = 13;


### PR DESCRIPTION
Fixes [Bug 2071207](https://bugzilla.mozilla.org/show_bug.cgi?id=2071207): a console-requested restart could relaunch Firefox before FELT had prepared its update. Firefox now requests preparation when the console supplies a restart deadline, while the user continues browsing.

### Behavior

- **Restart:** Any browser restart applies a ready update by restarting FELT. Unfinished downloads never delay the restart, so an immediate deadline can still precede update readiness.
- **Retry:** A console deadline requests an update check immediately, so a restart scheduled to apply a freshly published update finds it. While the deadline stands, Firefox re-requests a check after five minutes, then doubles the spacing up to `app.update.interval` (six hours by default). Once an update is downloading or staged, a re-check is local and does not contact the update server. A withdrawn and re-issued deadline starts over with an immediate check. Startup and captive-portal recovery checks are unaffected.
- **Notification:** Staging an update while browsing triggers the existing “Restart to update” badge on staging-enabled builds.
- **Lifecycle:** Update work is serialized; reopening FELT refreshes its UI immediately. Captive portals suspend preparation. Elevation-bookkeeping errors cannot prevent an update restart.

### Validation

- Native/resource builds and lint pass.
- Four enterprise xpcshell files and the browser enforcer test pass (30 browser assertions).
- Integration coverage passes for update-check IPC, update restarts with elevation failure, and captive portals.
- [CI for the current revision](https://treeherder.mozilla.org/jobs?repo=enterprise-firefox-pr&revision=f7959efbb480) is running.

