### PR TITLE
Bug 2068747 - Only honor toolkit.policies.perUserDir only in automation

### DIFF
--- a/toolkit/components/enterprisepolicies/EnterprisePoliciesParent.sys.mjs
+++ b/toolkit/components/enterprisepolicies/EnterprisePoliciesParent.sys.mjs
@@ -1288,14 +1288,14 @@ class JSONPoliciesProvider extends PoliciesProvider {
 
     try {
       let configFile;
-      // A deployment choice (Bug 1583466), so only the default branch may
-      // enable it; a user value counts in automation so tests can set it.
-      let perUserPath =
-        Services.prefs
+      let perUserPath = Services.prefs.getBoolPref(PREF_PER_USER_DIR, false);
+      // On enterprise builds only the default branch may enable it,
+      // except in automation so tests can set it.
+      if (AppConstants.MOZ_ENTERPRISE && !Cu.isInAutomation) {
+        perUserPath = Services.prefs
           .getDefaultBranch("")
-          .getBoolPref(PREF_PER_USER_DIR, false) ||
-        (Cu.isInAutomation &&
-          Services.prefs.getBoolPref(PREF_PER_USER_DIR, false));
+          .getBoolPref(PREF_PER_USER_DIR, false);
+      }
       if (perUserPath) {
         configFile = Services.dirsvc.get("XREUserRunTimeDir", Ci.nsIFile);
       } else {

--- a/toolkit/components/enterprisepolicies/EnterprisePoliciesParent.sys.mjs
+++ b/toolkit/components/enterprisepolicies/EnterprisePoliciesParent.sys.mjs
@@ -1288,7 +1288,14 @@ class JSONPoliciesProvider extends PoliciesProvider {
 
     try {
       let configFile;
-      let perUserPath = Services.prefs.getBoolPref(PREF_PER_USER_DIR, false);
+      // A deployment choice (Bug 1583466), so only the default branch may
+      // enable it; a user value counts in automation so tests can set it.
+      let perUserPath =
+        Services.prefs
+          .getDefaultBranch("")
+          .getBoolPref(PREF_PER_USER_DIR, false) ||
+        (Cu.isInAutomation &&
+          Services.prefs.getBoolPref(PREF_PER_USER_DIR, false));
       if (perUserPath) {
         configFile = Services.dirsvc.get("XREUserRunTimeDir", Ci.nsIFile);
       } else {


### PR DESCRIPTION
Fix: https://bugzilla.mozilla.org/show_bug.cgi?id=2068747

## Description
Honor toolkit.policies.perUserDir only under Cu.isInAutomation.

Supersedes https://github.com/mozilla/enterprise-firefox/pull/1452.
